### PR TITLE
fix: add 'With' methods to HttpServerConfiguration

### DIFF
--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/configuration/HttpServerConfiguration.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/configuration/HttpServerConfiguration.java
@@ -21,6 +21,9 @@ import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.tracing.TracingPolicy;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.With;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.env.Environment;
@@ -31,6 +34,8 @@ import org.springframework.util.StringUtils;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@With
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class HttpServerConfiguration {
 
     private static final Logger logger = LoggerFactory.getLogger(HttpServerConfiguration.class);

--- a/pom.xml
+++ b/pom.xml
@@ -244,6 +244,13 @@
             <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <properties>
@@ -264,6 +271,7 @@
         <bouncycastle.version>1.70</bouncycastle.version>
         <guava.version>31.1-jre</guava.version>
         <license3j.version>3.2.0</license3j.version>
+        <lombok.version>1.18.24</lombok.version>
     </properties>
     <build>
         <plugins>


### PR DESCRIPTION
Issue

https://gravitee.atlassian.net/browse/APIM-1381

Description

HttpServerConfiguration builder implementation was only relying on Environment so set default values.
Add lombok's @With to be able to set fields after builds with an immutable object.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.6-apim-1381-debugmode-secured-3-20-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/2.0.6-apim-1381-debugmode-secured-3-20-SNAPSHOT/gravitee-node-2.0.6-apim-1381-debugmode-secured-3-20-SNAPSHOT.zip)
  <!-- Version placeholder end -->
