### PR TITLE
feat: replace Prometheus MeterRegistry by a CompositeRegistry

### DIFF
--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/metrics/Metrics.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/metrics/Metrics.java
@@ -32,8 +32,8 @@ public class Metrics {
     private Metrics() {}
 
     /**
-     * Get the default micrometer registry. May return null if it hasn't been registered yet or if it has been stopped.
-     * @return the micrometer registry or null if metrics is not enabled. You can enable metrics by setting
+     * Get the default micrometer registry.
+     * @return the micrometer registry. You can enable metrics by setting
      * services.metrics.enabled=true  inside gravitee.yaml or environmental variable gravitee_services_metrics_enabled=true
      */
     public static MeterRegistry getDefaultRegistry() {
@@ -47,10 +47,14 @@ public class Metrics {
 
     /**
      * Get the micrometer registry of the given name. May return null if it hasn't been registered yet or if it has been stopped.
+     * <p/>
+     * <b>WARN</b>: this method should not be used, default registry should always be used.
+     *
      * @param registryName  – the name associated with this registry in Micrometer options
      * @return the micrometer registry or null if metrics is not enabled. You can enable metrics by setting
      * services.metrics.enabled=true  inside gravitee.yaml or environmental variable gravitee_services_metrics_enabled=true
      */
+    @Deprecated
     public static MeterRegistry getRegistry(String registryName) {
         MeterRegistry registry = BackendRegistries.getNow(registryName);
         if (registry == null) {

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/metrics/ExcludeTagsFilter.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/metrics/ExcludeTagsFilter.java
@@ -15,33 +15,18 @@
  */
 package io.gravitee.node.vertx.metrics;
 
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.StreamSupport.stream;
-
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.reactivex.rxjava3.annotations.NonNull;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class ExcludeTagsFilter implements MeterFilter {
-
-    private final String category;
-
-    private final List<String> excludedLabels;
-
-    public ExcludeTagsFilter(String category, List<String> excludedLabels) {
-        this.category = category;
-        this.excludedLabels = excludedLabels;
-    }
-
+public record ExcludeTagsFilter(String category, List<String> excludedLabels) implements MeterFilter {
     @NonNull
     @Override
     public Meter.Id map(@NonNull Meter.Id id) {
@@ -60,13 +45,5 @@ public class ExcludeTagsFilter implements MeterFilter {
             return processedTags > tags.size() ? id.replaceTags(tags) : id;
         }
         return id;
-    }
-
-    public String getCategory() {
-        return category;
-    }
-
-    public List<String> getExcludedLabels() {
-        return excludedLabels;
     }
 }


### PR DESCRIPTION
- meter binders can be configured
- metric domains can be configured

**Issue**

https://gravitee.atlassian.net/browse/ARCHI-534

**Description**

This PR aims to provide a way to use a different registry if needed by changing the default Prometheus registry with a Composite registry.
It also adds some new capability to configure the meter binders and the metric domains.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.14.0-feat-add-composite-registry-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/7.14.0-feat-add-composite-registry-SNAPSHOT/gravitee-node-7.14.0-feat-add-composite-registry-SNAPSHOT.zip)
  <!-- Version placeholder end -->
