### PR TITLE
update project properties to fix build and release - 7.0.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.12.1
+    gravitee: gravitee-io/gravitee@4.16.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.2.5</version>
+        <version>22.5.1</version>
     </parent>
 
     <groupId>io.gravitee.node</groupId>


### PR DESCRIPTION
**Description**

Bump orb and parent to fix build and release process.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.0.12-update-project-properties-to-fix-build-and-release-7-0-x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/7.0.12-update-project-properties-to-fix-build-and-release-7-0-x-SNAPSHOT/gravitee-node-7.0.12-update-project-properties-to-fix-build-and-release-7-0-x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
