### PR TITLE
feat: add `apim-cluster`, `apim-native-kafka-console` feature to license

### DIFF
--- a/gravitee-node-license/src/main/resources/license-model.yml
+++ b/gravitee-node-license/src/main/resources/license-model.yml
@@ -102,6 +102,8 @@ packs:
             - oem-customization
     native-kafka:
         features:
+            - apim-cluster
+            - apim-native-kafka-console
             - apim-native-kafka-reactor
             - apim-native-kafka-policy-acl
             - apim-native-kafka-policy-quota


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-9623

**Description**

add `apim-cluster`, `apim-native-kafka-console` feature to license

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.11.0-APIM-9623-kafka-cluster-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/7.11.0-APIM-9623-kafka-cluster-SNAPSHOT/gravitee-node-7.11.0-APIM-9623-kafka-cluster-SNAPSHOT.zip)
  <!-- Version placeholder end -->
