### PR TITLE
fix(deps): bump protobuf-java to 3.25.5 [7.9.x]

### DIFF
--- a/gravitee-node-opentelemetry/pom.xml
+++ b/gravitee-node-opentelemetry/pom.xml
@@ -47,6 +47,11 @@
             <artifactId>vertx-grpc-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>${protobuf-java.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>mutiny</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
         <snakeyaml.version>2.0</snakeyaml.version>
         <hazelcast.version>5.5.0</hazelcast.version>
         <gravitee-alert-api.version>1.9.1</gravitee-alert-api.version>
+        <protobuf-java.version>3.25.5</protobuf-java.version>
         <opentelemetry.version>1.39.0</opentelemetry.version>
         <opentelemetry-instrumentation.version>1.33.4-alpha</opentelemetry-instrumentation.version>
         <opentelemetry-semconv.version>1.23.1-alpha</opentelemetry-semconv.version>


### PR DESCRIPTION
**Description**

fixes [CVE-2024-7254](https://github.com/advisories/GHSA-735f-pc8j-v9w8)

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.9.3-bump-protobuf-java-7-9-x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/7.9.3-bump-protobuf-java-7-9-x-SNAPSHOT/gravitee-node-7.9.3-bump-protobuf-java-7-9-x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
