### PR TITLE
fix: micrometer registry is now a CompositeRegistry

### DIFF
--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/healthcheck/NodeHealthCheckService.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/healthcheck/NodeHealthCheckService.java
@@ -92,9 +92,7 @@ public class NodeHealthCheckService extends AbstractService {
 
             MeterRegistry micrometerRegistry = BackendRegistries.getDefaultNow();
 
-            if (micrometerRegistry instanceof PrometheusMeterRegistry) {
-                new NodeHealthCheckMicrometerHandler(probeRegistry).bindTo(micrometerRegistry);
-            }
+            new NodeHealthCheckMicrometerHandler(probeRegistry).bindTo(micrometerRegistry);
 
             ((ScheduledExecutorService) executorService).scheduleWithFixedDelay(
                     nodeHealthCheckThread,

--- a/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/healthcheck/NodeHealthCheckServiceTest.java
+++ b/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/healthcheck/NodeHealthCheckServiceTest.java
@@ -8,6 +8,7 @@ import io.gravitee.node.management.http.endpoint.ManagementEndpointManager;
 import io.gravitee.node.monitoring.DefaultProbeEvaluator;
 import io.gravitee.node.monitoring.spring.HealthConfiguration;
 import io.gravitee.plugin.alert.AlertEventProducer;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.vertx.core.Vertx;
 import io.vertx.micrometer.backends.BackendRegistries;
@@ -57,7 +58,7 @@ class NodeHealthCheckServiceTest {
         );
 
         try (MockedStatic<BackendRegistries> backendRegistries = Mockito.mockStatic(BackendRegistries.class)) {
-            backendRegistries.when(BackendRegistries::getDefaultNow).thenReturn(mock(PrometheusMeterRegistry.class));
+            backendRegistries.when(BackendRegistries::getDefaultNow).thenReturn(mock(CompositeMeterRegistry.class));
 
             cut.doStart();
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-12531

**Description**

NodeHealthCheckMicrometerHandler should always be added to the registry
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.26.1-apim-12531-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/7.26.1-apim-12531-SNAPSHOT/gravitee-node-7.26.1-apim-12531-SNAPSHOT.zip)
  <!-- Version placeholder end -->
