### PR TITLE
fix(vertx): disable named pools metrics domain by default

### DIFF
--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/VertxFactory.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/VertxFactory.java
@@ -154,6 +154,7 @@ public class VertxFactory implements FactoryBean<Vertx> {
                 new HashSet<>(
                     Arrays.asList(
                         MetricsDomain.DATAGRAM_SOCKET.toCategory(),
+                        MetricsDomain.NAMED_POOLS.toCategory(),
                         MetricsDomain.VERTICLES.toCategory(),
                         MetricsDomain.EVENT_BUS.toCategory()
                     )


### PR DESCRIPTION
## Summary
- Adds `MetricsDomain.NAMED_POOLS.toCategory()` back to the default disabled metrics domains in `VertxFactory`

## Test plan
- [ ] Verify named pools metrics are not exposed by default after upgrade
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.26.2-fix-fix-node-named-pools-49-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/7.26.2-fix-fix-node-named-pools-49-SNAPSHOT/gravitee-node-7.26.2-fix-fix-node-named-pools-49-SNAPSHOT.zip)
  <!-- Version placeholder end -->
