### PR TITLE
fix(vertx): disable named pools metrics domain by default

### DIFF
--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/VertxFactory.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/VertxFactory.java
@@ -152,6 +152,7 @@ public class VertxFactory implements FactoryBean<Vertx> {
                 new HashSet<>(
                     Arrays.asList(
                         MetricsDomain.DATAGRAM_SOCKET.toCategory(),
+                        MetricsDomain.NAMED_POOLS.toCategory(),
                         MetricsDomain.VERTICLES.toCategory(),
                         MetricsDomain.EVENT_BUS.toCategory()
                     )


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

