### PR TITLE
feat: improve Prometheus endpoint stability and add test coverage (#533)

### DIFF
--- a/gravitee-node-management/src/main/java/io/gravitee/node/management/http/metrics/prometheus/PrometheusEndpoint.java
+++ b/gravitee-node-management/src/main/java/io/gravitee/node/management/http/metrics/prometheus/PrometheusEndpoint.java
@@ -1,12 +1,13 @@
 /**
  * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -71,21 +72,35 @@ public class PrometheusEndpoint implements ManagementEndpoint {
 
     @Override
     public void handle(RoutingContext routingContext) {
+        if (prometheusRegistry == null) {
+            routingContext.response().setStatusCode(501).end("Prometheus metrics are not enabled");
+            return;
+        }
         HttpServerResponse response = routingContext.response();
 
         response.putHeader(CONTENT_TYPE, CONTENT_TYPE_004);
         response.setChunked(true);
 
-        try (BufferedWriter writer = new BufferedWriter(new SafeBufferedWriter(response))) {
+        try (
+            SafeBufferedWriter safeBufferedWriter = new SafeBufferedWriter(response);
+            BufferedWriter writer = new BufferedWriter(safeBufferedWriter)
+        ) {
             prometheusRegistry.scrape(writer);
             writer.flush();
-            if (!response.ended()) {
-                response.end();
-            }
         } catch (IOException ioe) {
+            // On write-queue drain timeout, abort the TCP connection so the client
+            // gets a clean error instead of hanging. close() fires the closeHandler
+            // in ConcurrencyLimitHandler which releases the semaphore permit.
             LOGGER.error("Unexpected error while scraping the Prometheus endpoint", ioe);
-            if (!response.ended()) {
+            if (!response.ended() && !response.closed()) {
                 response.close();
+            }
+        } finally {
+            // Ensure the response is always terminated. The closed() guard prevents
+            // calling end() on an already-aborted connection (which would throw in
+            // some Vert.x versions).
+            if (!response.ended() && !response.closed()) {
+                response.end();
             }
         }
     }

--- a/gravitee-node-management/src/main/java/io/gravitee/node/management/http/utils/ConcurrencyLimitHandler.java
+++ b/gravitee-node-management/src/main/java/io/gravitee/node/management/http/utils/ConcurrencyLimitHandler.java
@@ -7,6 +7,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,12 +42,28 @@ public class ConcurrencyLimitHandler implements Handler<RoutingContext> {
 
         HttpServerResponse response = context.response();
 
-        // Release semaphore when request ends or fails
-        response.bodyEndHandler(v -> semaphore.release());
+        // In Vert.x, bodyEndHandler, exceptionHandler, and closeHandler can all fire for the
+        // same request (e.g. IOException in SafeBufferedWriter triggers exceptionHandler, then
+        // PrometheusEndpoint calls response.close() which triggers closeHandler). Without a
+        // guard, each fires semaphore.release() and permits accumulate beyond the configured
+        // limit — permanently breaking the concurrency gate. The AtomicBoolean ensures we
+        // release exactly once regardless of how many handlers fire.
+        AtomicBoolean released = new AtomicBoolean(false);
+        Runnable release = () -> {
+            if (released.compareAndSet(false, true)) {
+                semaphore.release();
+            }
+        };
+
+        response.bodyEndHandler(v -> release.run());
         response.exceptionHandler(e -> {
-            LOGGER.error("Error thrown  ", e);
-            semaphore.release();
+            LOGGER.error("Error on connection", e);
+            release.run();
         });
+        // closeHandler is critical: when SafeBufferedWriter times out, PrometheusEndpoint
+        // calls response.close() which does NOT trigger bodyEndHandler or exceptionHandler.
+        // Without this handler the semaphore permit is never returned.
+        response.closeHandler(v -> release.run());
 
         context.next();
     }

--- a/gravitee-node-management/src/test/java/io/gravitee/node/management/http/metrics/prometheus/PrometheusEndpointIntegrationTest.java
+++ b/gravitee-node-management/src/test/java/io/gravitee/node/management/http/metrics/prometheus/PrometheusEndpointIntegrationTest.java
@@ -1,0 +1,226 @@
+package io.gravitee.node.management.http.metrics.prometheus;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.gravitee.node.management.http.utils.ConcurrencyLimitHandler;
+import io.gravitee.node.management.http.utils.OffloadHandler;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServer;
+import io.vertx.ext.web.Router;
+import io.vertx.micrometer.MicrometerMetricsOptions;
+import io.vertx.micrometer.VertxPrometheusOptions;
+import io.vertx.micrometer.backends.BackendRegistries;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+class PrometheusEndpointIntegrationTest {
+
+    private PrometheusMeterRegistry prometheusMeterRegistry;
+    private Vertx vertx;
+    private HttpServer server;
+    private HttpClient client;
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        prometheusMeterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        CompositeMeterRegistry compositeMeterRegistry = new CompositeMeterRegistry();
+        compositeMeterRegistry.add(prometheusMeterRegistry);
+
+        MicrometerMetricsOptions metricsOptions = new MicrometerMetricsOptions()
+            .setEnabled(true)
+            .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true))
+            .setMicrometerRegistry(compositeMeterRegistry);
+
+        vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(metricsOptions));
+        client = vertx.createHttpClient();
+
+        Counter.builder("test_counter").register(prometheusMeterRegistry).increment();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (server != null) {
+            await(server.close());
+        }
+        if (client != null) {
+            client.close();
+        }
+        if (vertx != null) {
+            await(vertx.close());
+        }
+    }
+
+    @Test
+    void should_expose_prometheus_metrics_end_to_end() throws Exception {
+        startServer(false);
+
+        String body = scrapeAndGetBody();
+        assertNotNull(body, "Body is null");
+        assertFalse(body.isEmpty(), "No data received from prometheus endpoint");
+        assertTrue(body.contains("test_counter_total"), body);
+    }
+
+    @Test
+    void should_not_expose_prometheus_metrics_when_disabled() throws Exception {
+        Router router = Router.router(vertx);
+        server = vertx.createHttpServer().requestHandler(router);
+        port = listen(server);
+
+        CompletableFuture<Integer> statusFuture = new CompletableFuture<>();
+        client
+            .request(HttpMethod.GET, port, "localhost", "/metrics/prometheus")
+            .compose(io.vertx.core.http.HttpClientRequest::send)
+            .onComplete(ar -> {
+                if (ar.succeeded()) {
+                    statusFuture.complete(ar.result().statusCode());
+                } else {
+                    statusFuture.completeExceptionally(ar.cause());
+                }
+            });
+
+        assertEquals(404, await(Future.fromCompletionStage(statusFuture)));
+    }
+
+    @Test
+    void should_handle_repeated_scrapes_without_degradation() throws Exception {
+        startServer(false);
+
+        for (int i = 0; i < 20; i++) {
+            int status = scrapeAndGetStatus();
+            assertEquals(200, status, "Request " + i + " failed with status " + status);
+        }
+    }
+
+    @Test
+    void should_handle_repeated_scrapes_with_concurrency_limit() throws Exception {
+        startServer(true);
+
+        for (int i = 0; i < 20; i++) {
+            int status = scrapeAndGetStatus();
+            assertEquals(200, status, "Request " + i + " was rejected — concurrency slots may be leaking");
+        }
+    }
+
+    @Test
+    void should_scrape_with_concurrency_limit_and_return_metrics() throws Exception {
+        startServer(true);
+
+        String body = scrapeAndGetBody();
+        assertNotNull(body);
+        assertFalse(body.isEmpty());
+        assertTrue(body.contains("test_counter_total"), body);
+    }
+
+    // --- Helpers ---
+
+    private void startServer(boolean withConcurrencyLimit) throws Exception {
+        Router router = Router.router(vertx);
+        router
+            .route()
+            .failureHandler(ctx -> {
+                Throwable t = ctx.failure();
+                if (t != null) {
+                    t.printStackTrace();
+                }
+                if (!ctx.response().ended()) {
+                    ctx.response().setStatusCode(500).end();
+                }
+            });
+
+        // The mock only needs to be active during construction since the
+        // constructor resolves the registry once and stores it in a field.
+        PrometheusEndpoint endpoint;
+        try (MockedStatic<BackendRegistries> mocked = Mockito.mockStatic(BackendRegistries.class)) {
+            CompositeMeterRegistry composite = new CompositeMeterRegistry();
+            composite.add(prometheusMeterRegistry);
+            mocked.when(BackendRegistries::getDefaultNow).thenReturn(composite);
+            endpoint = new PrometheusEndpoint();
+        }
+
+        var route = router.route(HttpMethod.GET, endpoint.path());
+        if (withConcurrencyLimit) {
+            route.handler(new ConcurrencyLimitHandler(3));
+        }
+        route.handler(
+            OffloadHandler.ofCtx((ctx, promise) -> {
+                endpoint.handle(ctx);
+                promise.complete();
+            })
+        );
+
+        server = vertx.createHttpServer().requestHandler(router);
+        server.exceptionHandler(Throwable::printStackTrace);
+        port = listen(server);
+    }
+
+    private int scrapeAndGetStatus() throws Exception {
+        CompletableFuture<Integer> statusFuture = new CompletableFuture<>();
+        client
+            .request(HttpMethod.GET, port, "localhost", "/metrics/prometheus")
+            .compose(req -> req.send())
+            .compose(response -> response.body().map(buffer -> response.statusCode()))
+            .onComplete(ar -> {
+                if (ar.succeeded()) {
+                    statusFuture.complete(ar.result());
+                } else {
+                    statusFuture.completeExceptionally(ar.cause());
+                }
+            });
+        return statusFuture.get(10, TimeUnit.SECONDS);
+    }
+
+    private String scrapeAndGetBody() throws Exception {
+        CompletableFuture<String> bodyFuture = new CompletableFuture<>();
+        StringBuilder bodyBuilder = new StringBuilder();
+
+        io.vertx.core.http.HttpClientRequest request = await(client.request(HttpMethod.GET, port, "localhost", "/metrics/prometheus"));
+        request
+            .send()
+            .onComplete(ar -> {
+                if (ar.succeeded()) {
+                    io.vertx.core.http.HttpClientResponse response = ar.result();
+                    if (response.statusCode() != 200) {
+                        bodyFuture.completeExceptionally(new RuntimeException("Status code " + response.statusCode()));
+                        return;
+                    }
+                    response.handler(chunk -> bodyBuilder.append(chunk.toString()));
+                    response.endHandler(v -> bodyFuture.complete(bodyBuilder.toString()));
+                    response.exceptionHandler(bodyFuture::completeExceptionally);
+                } else {
+                    bodyFuture.completeExceptionally(ar.cause());
+                }
+            });
+
+        return await(Future.fromCompletionStage(bodyFuture));
+    }
+
+    private static int listen(HttpServer server) throws Exception {
+        return await(server.listen(0)).actualPort();
+    }
+
+    private static <T> T await(io.vertx.core.Future<T> future) throws Exception {
+        CompletableFuture<T> cf = new CompletableFuture<>();
+        future.onComplete(ar -> {
+            if (ar.succeeded()) {
+                cf.complete(ar.result());
+            } else {
+                cf.completeExceptionally(ar.cause());
+            }
+        });
+        return cf.get(10, TimeUnit.SECONDS);
+    }
+}

--- a/gravitee-node-management/src/test/java/io/gravitee/node/management/http/metrics/prometheus/PrometheusEndpointTest.java
+++ b/gravitee-node-management/src/test/java/io/gravitee/node/management/http/metrics/prometheus/PrometheusEndpointTest.java
@@ -1,0 +1,130 @@
+package io.gravitee.node.management.http.metrics.prometheus;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.micrometer.backends.BackendRegistries;
+import java.io.IOException;
+import java.io.Writer;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+class PrometheusEndpointTest {
+
+    @Test
+    void should_end_response_after_successful_scrape() {
+        PrometheusMeterRegistry mockRegistry = mock(PrometheusMeterRegistry.class);
+        PrometheusEndpoint endpoint = createEndpointWith(mockRegistry);
+
+        HttpServerResponse mockResponse = createMockResponse();
+        RoutingContext mockContext = createMockContext(mockResponse);
+        when(mockResponse.ended()).thenReturn(false);
+        when(mockResponse.closed()).thenReturn(false);
+
+        endpoint.handle(mockContext);
+
+        verify(mockResponse).end();
+        verify(mockResponse, never()).close();
+    }
+
+    @Test
+    void should_close_response_on_scrape_IOException() throws Exception {
+        PrometheusMeterRegistry mockRegistry = mock(PrometheusMeterRegistry.class);
+        doThrow(new IOException("Timeout while waiting for write queue to drain")).when(mockRegistry).scrape(any(Writer.class));
+        PrometheusEndpoint endpoint = createEndpointWith(mockRegistry);
+
+        HttpServerResponse mockResponse = createMockResponse();
+        RoutingContext mockContext = createMockContext(mockResponse);
+        when(mockResponse.ended()).thenReturn(false);
+        when(mockResponse.closed()).thenReturn(false);
+        doAnswer(inv -> {
+                when(mockResponse.closed()).thenReturn(true);
+                return null;
+            })
+            .when(mockResponse)
+            .close();
+
+        endpoint.handle(mockContext);
+
+        verify(mockResponse).close();
+        verify(mockResponse, never()).end();
+    }
+
+    @Test
+    void should_not_call_close_or_end_if_response_already_ended() throws Exception {
+        PrometheusMeterRegistry mockRegistry = mock(PrometheusMeterRegistry.class);
+        doThrow(new IOException("write error")).when(mockRegistry).scrape(any(Writer.class));
+        PrometheusEndpoint endpoint = createEndpointWith(mockRegistry);
+
+        HttpServerResponse mockResponse = createMockResponse();
+        RoutingContext mockContext = createMockContext(mockResponse);
+        when(mockResponse.ended()).thenReturn(true);
+
+        endpoint.handle(mockContext);
+
+        verify(mockResponse, never()).close();
+        verify(mockResponse, never()).end();
+    }
+
+    @Test
+    void should_set_chunked_and_content_type() {
+        PrometheusMeterRegistry mockRegistry = mock(PrometheusMeterRegistry.class);
+        PrometheusEndpoint endpoint = createEndpointWith(mockRegistry);
+
+        HttpServerResponse mockResponse = createMockResponse();
+        RoutingContext mockContext = createMockContext(mockResponse);
+        when(mockResponse.ended()).thenReturn(false);
+        when(mockResponse.closed()).thenReturn(false);
+
+        endpoint.handle(mockContext);
+
+        verify(mockResponse).setChunked(true);
+        verify(mockResponse).putHeader(any(CharSequence.class), any(CharSequence.class));
+    }
+
+    @Test
+    void should_return_501_when_registry_is_null() {
+        PrometheusEndpoint endpoint = createEndpointWith(null);
+
+        HttpServerResponse mockResponse = createMockResponse();
+        when(mockResponse.setStatusCode(anyInt())).thenReturn(mockResponse);
+        RoutingContext mockContext = createMockContext(mockResponse);
+
+        endpoint.handle(mockContext);
+
+        verify(mockResponse).setStatusCode(501);
+        verify(mockResponse).end("Prometheus metrics are not enabled");
+    }
+
+    // --- Helpers ---
+
+    private PrometheusEndpoint createEndpointWith(PrometheusMeterRegistry registry) {
+        try (MockedStatic<BackendRegistries> mocked = Mockito.mockStatic(BackendRegistries.class)) {
+            CompositeMeterRegistry composite = null;
+            if (registry != null) {
+                composite = new CompositeMeterRegistry();
+                composite.add(registry);
+            }
+            mocked.when(BackendRegistries::getDefaultNow).thenReturn(composite);
+            return new PrometheusEndpoint();
+        }
+    }
+
+    private HttpServerResponse createMockResponse() {
+        HttpServerResponse resp = mock(HttpServerResponse.class);
+        when(resp.putHeader(any(CharSequence.class), any(CharSequence.class))).thenReturn(resp);
+        when(resp.setChunked(anyBoolean())).thenReturn(resp);
+        return resp;
+    }
+
+    private RoutingContext createMockContext(HttpServerResponse response) {
+        RoutingContext ctx = mock(RoutingContext.class);
+        when(ctx.response()).thenReturn(response);
+        return ctx;
+    }
+}

--- a/gravitee-node-management/src/test/java/io/gravitee/node/management/http/utils/ConcurrencyLimitHandlerTest.java
+++ b/gravitee-node-management/src/test/java/io/gravitee/node/management/http/utils/ConcurrencyLimitHandlerTest.java
@@ -2,38 +2,32 @@ package io.gravitee.node.management.http.utils;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
+import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class ConcurrencyLimitHandlerTest {
 
     private RoutingContext mockContext;
     private HttpServerResponse mockResponse;
-    private HttpServerRequest mockRequest;
 
     @BeforeEach
     void setup() {
-        mockContext = mock(RoutingContext.class);
-        mockRequest = mock(HttpServerRequest.class);
-        mockResponse = mock(HttpServerResponse.class);
-        when(mockContext.request()).thenReturn(mockRequest);
-        when(mockRequest.path()).thenReturn("/test");
-        when(mockContext.response()).thenReturn(mockResponse);
-        when(mockResponse.setStatusCode(anyInt())).thenReturn(mockResponse);
-        when(mockResponse.putHeader(any(CharSequence.class), any(CharSequence.class))).thenReturn(mockResponse);
-        when(mockResponse.endHandler(any())).thenReturn(mockResponse);
+        mockContext = createMockContext();
     }
 
     @Test
     void should_reject_request_when_limit_reached() {
         ConcurrencyLimitHandler handler = new ConcurrencyLimitHandler(0);
-        when(mockResponse.putHeader(anyString(), anyString())).thenReturn(mockResponse);
         handler.handle(mockContext);
+
         verify(mockResponse).setStatusCode(429);
         verify(mockResponse).end("Too Many Requests - limit of 0 for path /test");
         verify(mockContext, never()).next();
@@ -43,8 +37,230 @@ class ConcurrencyLimitHandlerTest {
     void should_allow_request_when_slot_available() {
         ConcurrencyLimitHandler handler = new ConcurrencyLimitHandler(1);
         handler.handle(mockContext);
+
         verify(mockContext).next();
         verify(mockResponse).bodyEndHandler(any());
         verify(mockResponse, never()).setStatusCode(429);
+    }
+
+    @Test
+    void should_register_all_three_handlers() {
+        ConcurrencyLimitHandler handler = new ConcurrencyLimitHandler(1);
+        handler.handle(mockContext);
+
+        verify(mockResponse).bodyEndHandler(any());
+        verify(mockResponse).exceptionHandler(any());
+        verify(mockResponse).closeHandler(any());
+    }
+
+    // --- Slot recovery: prove the semaphore is actually freed after each release path ---
+
+    @Test
+    void should_accept_new_request_after_successful_completion() {
+        ConcurrencyLimitHandler handler = new ConcurrencyLimitHandler(1);
+        handler.handle(mockContext);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Handler<Void>> bodyEndCaptor = ArgumentCaptor.forClass(Handler.class);
+        verify(mockResponse).bodyEndHandler(bodyEndCaptor.capture());
+
+        bodyEndCaptor.getValue().handle(null);
+
+        RoutingContext secondCtx = createMockContext();
+        handler.handle(secondCtx);
+        verify(secondCtx).next();
+    }
+
+    @Test
+    void should_accept_new_request_after_exception() {
+        ConcurrencyLimitHandler handler = new ConcurrencyLimitHandler(1);
+        handler.handle(mockContext);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Handler<Throwable>> exceptionCaptor = ArgumentCaptor.forClass(Handler.class);
+        verify(mockResponse).exceptionHandler(exceptionCaptor.capture());
+
+        exceptionCaptor.getValue().handle(new RuntimeException("connection reset"));
+
+        RoutingContext secondCtx = createMockContext();
+        handler.handle(secondCtx);
+        verify(secondCtx).next();
+    }
+
+    @Test
+    void should_accept_new_request_after_connection_close() {
+        ConcurrencyLimitHandler handler = new ConcurrencyLimitHandler(1);
+        handler.handle(mockContext);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Handler<Void>> closeCaptor = ArgumentCaptor.forClass(Handler.class);
+        verify(mockResponse).closeHandler(closeCaptor.capture());
+
+        closeCaptor.getValue().handle(null);
+
+        RoutingContext secondCtx = createMockContext();
+        handler.handle(secondCtx);
+        verify(secondCtx).next();
+    }
+
+    // --- Double/triple-fire guard: AtomicBoolean prevents over-release ---
+
+    @Test
+    void should_release_only_once_when_both_exception_and_close_fire() {
+        ConcurrencyLimitHandler handler = new ConcurrencyLimitHandler(1);
+        handler.handle(mockContext);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Handler<Throwable>> exceptionCaptor = ArgumentCaptor.forClass(Handler.class);
+        verify(mockResponse).exceptionHandler(exceptionCaptor.capture());
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Handler<Void>> closeCaptor = ArgumentCaptor.forClass(Handler.class);
+        verify(mockResponse).closeHandler(closeCaptor.capture());
+
+        exceptionCaptor.getValue().handle(new RuntimeException("error"));
+        closeCaptor.getValue().handle(null);
+
+        RoutingContext secondCtx = createMockContext();
+        handler.handle(secondCtx);
+        verify(secondCtx).next();
+
+        RoutingContext thirdCtx = createMockContext();
+        handler.handle(thirdCtx);
+        verify(thirdCtx.response()).setStatusCode(429);
+    }
+
+    @Test
+    void should_release_only_once_when_all_three_handlers_fire() {
+        ConcurrencyLimitHandler handler = new ConcurrencyLimitHandler(1);
+        handler.handle(mockContext);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Handler<Void>> bodyEndCaptor = ArgumentCaptor.forClass(Handler.class);
+        verify(mockResponse).bodyEndHandler(bodyEndCaptor.capture());
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Handler<Throwable>> exceptionCaptor = ArgumentCaptor.forClass(Handler.class);
+        verify(mockResponse).exceptionHandler(exceptionCaptor.capture());
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Handler<Void>> closeCaptor = ArgumentCaptor.forClass(Handler.class);
+        verify(mockResponse).closeHandler(closeCaptor.capture());
+
+        bodyEndCaptor.getValue().handle(null);
+        exceptionCaptor.getValue().handle(new RuntimeException("late error"));
+        closeCaptor.getValue().handle(null);
+
+        RoutingContext secondCtx = createMockContext();
+        handler.handle(secondCtx);
+        verify(secondCtx).next();
+
+        RoutingContext thirdCtx = createMockContext();
+        handler.handle(thirdCtx);
+        verify(thirdCtx.response()).setStatusCode(429);
+    }
+
+    // --- Concurrent request limit ---
+
+    @Test
+    void should_allow_up_to_limit_concurrent_requests() {
+        int limit = 3;
+        ConcurrencyLimitHandler handler = new ConcurrencyLimitHandler(limit);
+
+        RoutingContext[] contexts = new RoutingContext[limit];
+        for (int i = 0; i < limit; i++) {
+            contexts[i] = createMockContext();
+            handler.handle(contexts[i]);
+            verify(contexts[i]).next();
+        }
+
+        RoutingContext rejected = createMockContext();
+        handler.handle(rejected);
+        verify(rejected.response()).setStatusCode(429);
+        verify(rejected, never()).next();
+    }
+
+    @Test
+    void should_accept_new_request_after_one_slot_is_freed() {
+        int limit = 3;
+        ConcurrencyLimitHandler handler = new ConcurrencyLimitHandler(limit);
+
+        RoutingContext[] contexts = new RoutingContext[limit];
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Handler<Void>>[] bodyEndCaptors = new ArgumentCaptor[limit];
+
+        for (int i = 0; i < limit; i++) {
+            contexts[i] = createMockContext();
+            handler.handle(contexts[i]);
+            bodyEndCaptors[i] = ArgumentCaptor.forClass(Handler.class);
+            verify(contexts[i].response()).bodyEndHandler(bodyEndCaptors[i].capture());
+        }
+
+        RoutingContext rejected = createMockContext();
+        handler.handle(rejected);
+        verify(rejected.response()).setStatusCode(429);
+
+        bodyEndCaptors[0].getValue().handle(null);
+
+        RoutingContext accepted = createMockContext();
+        handler.handle(accepted);
+        verify(accepted).next();
+    }
+
+    // --- Bug reproduction: the exact scenario from the issue ---
+
+    @Test
+    void should_not_permanently_reject_after_repeated_close_without_body_end() {
+        ConcurrencyLimitHandler handler = new ConcurrencyLimitHandler(3);
+
+        for (int i = 0; i < 3; i++) {
+            RoutingContext ctx = createMockContext();
+            handler.handle(ctx);
+            verify(ctx).next();
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<Handler<Void>> closeCaptor = ArgumentCaptor.forClass(Handler.class);
+            verify(ctx.response()).closeHandler(closeCaptor.capture());
+
+            closeCaptor.getValue().handle(null);
+        }
+
+        RoutingContext nextCtx = createMockContext();
+        handler.handle(nextCtx);
+        verify(nextCtx).next();
+        verify(nextCtx.response(), never()).setStatusCode(429);
+    }
+
+    @Test
+    void should_reject_with_correct_status_and_body() {
+        ConcurrencyLimitHandler handler = new ConcurrencyLimitHandler(1);
+        handler.handle(mockContext);
+
+        RoutingContext rejected = createMockContext();
+        handler.handle(rejected);
+
+        verify(rejected.response()).setStatusCode(429);
+        verify(rejected.response()).end("Too Many Requests - limit of 1 for path /test");
+    }
+
+    // --- Helper ---
+
+    private RoutingContext createMockContext() {
+        RoutingContext ctx = mock(RoutingContext.class);
+        HttpServerRequest req = mock(HttpServerRequest.class);
+        HttpServerResponse resp = mock(HttpServerResponse.class);
+        when(ctx.request()).thenReturn(req);
+        when(req.path()).thenReturn("/test");
+        when(ctx.response()).thenReturn(resp);
+        when(resp.setStatusCode(anyInt())).thenReturn(resp);
+        when(resp.putHeader(any(CharSequence.class), any(CharSequence.class))).thenReturn(resp);
+        when(resp.putHeader(anyString(), anyString())).thenReturn(resp);
+        when(resp.endHandler(any())).thenReturn(resp);
+
+        if (this.mockContext == null) {
+            this.mockResponse = resp;
+            this.mockContext = ctx;
+        }
+        return ctx;
     }
 }


### PR DESCRIPTION
- Ensure graceful handling when Prometheus registry is unavailable.
- Prevent double semaphore releases in ConcurrencyLimitHandler.
- Add unit and integration tests for Prometheus endpoint and concurrency handler.

**Issue**

https://github.com/gravitee-io/issues/issues/APIM-12316

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.26.3-APIM-12316-Prometheus-scrapping-error-7-26-x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/7.26.3-APIM-12316-Prometheus-scrapping-error-7-26-x-SNAPSHOT/gravitee-node-7.26.3-APIM-12316-Prometheus-scrapping-error-7-26-x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
