### PR TITLE
fix: improve concurrency handling and add integration tests for Prome…

### DIFF
--- a/gravitee-node-management/src/main/java/io/gravitee/node/management/http/metrics/prometheus/PrometheusEndpoint.java
+++ b/gravitee-node-management/src/main/java/io/gravitee/node/management/http/metrics/prometheus/PrometheusEndpoint.java
@@ -75,6 +75,10 @@ public class PrometheusEndpoint implements ManagementEndpoint {
     @Override
     public void handle(RoutingContext routingContext) {
         HttpServerResponse response = routingContext.response();
+        if (prometheusRegistry == null) {
+            response.setStatusCode(501).end("Prometheus metrics are not enabled");
+            return;
+        }
 
         response.putHeader(CONTENT_TYPE, CONTENT_TYPE_004);
         response.setChunked(true);
@@ -90,11 +94,11 @@ public class PrometheusEndpoint implements ManagementEndpoint {
             .onComplete(ar -> {
                 if (ar.failed()) {
                     log.error("Unexpected error while scraping the Prometheus endpoint", ar.cause());
-                    if (!response.ended()) {
+                    if (!response.ended() && !response.closed()) {
                         routingContext.request().connection().close();
                     }
                 } else {
-                    if (!response.ended()) {
+                    if (!response.ended() && !response.closed()) {
                         response.end();
                     }
                 }

--- a/gravitee-node-management/src/main/java/io/gravitee/node/management/http/utils/ConcurrencyLimitHandler.java
+++ b/gravitee-node-management/src/main/java/io/gravitee/node/management/http/utils/ConcurrencyLimitHandler.java
@@ -7,6 +7,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.CustomLog;
 
 @CustomLog
@@ -40,12 +41,21 @@ public class ConcurrencyLimitHandler implements Handler<RoutingContext> {
 
         HttpServerResponse response = context.response();
 
-        // Release semaphore when request ends or fails
-        response.bodyEndHandler(v -> semaphore.release());
+        // bodyEndHandler, exceptionHandler, and closeHandler can all fire for one request.
+        // Release the permit exactly once regardless of which lifecycle path finishes it.
+        AtomicBoolean released = new AtomicBoolean(false);
+        Runnable release = () -> {
+            if (released.compareAndSet(false, true)) {
+                semaphore.release();
+            }
+        };
+
+        response.bodyEndHandler(v -> release.run());
         response.exceptionHandler(e -> {
-            log.error("Error thrown  ", e);
-            semaphore.release();
+            log.error("Error on connection", e);
+            release.run();
         });
+        response.closeHandler(v -> release.run());
 
         context.next();
     }

--- a/gravitee-node-management/src/main/java/io/gravitee/node/management/http/vertx/verticle/ManagementVerticle.java
+++ b/gravitee-node-management/src/main/java/io/gravitee/node/management/http/vertx/verticle/ManagementVerticle.java
@@ -25,7 +25,6 @@ import io.gravitee.node.management.http.node.heap.HeapDumpEndpoint;
 import io.gravitee.node.management.http.node.log.LoggingEndpoint;
 import io.gravitee.node.management.http.node.thread.ThreadDumpEndpoint;
 import io.gravitee.node.management.http.utils.ConcurrencyLimitHandler;
-import io.gravitee.node.management.http.utils.OffloadHandler;
 import io.gravitee.node.management.http.vertx.configuration.HttpServerConfiguration;
 import io.vertx.core.*;
 import io.vertx.core.http.HttpMethod;
@@ -246,7 +245,7 @@ public class ManagementVerticle extends AbstractVerticle {
                     nodeRouter
                         .route(convert(endpoint.method()), endpoint.path())
                         .handler(new ConcurrencyLimitHandler(configuredConcurrentLimit))
-                        .handler(OffloadHandler.ofCtx(endpoint::handle));
+                        .handler(endpoint::handle);
                 } else {
                     if (method.equals(io.gravitee.common.http.HttpMethod.POST)) {
                         nodeRouter.route(convert(method), endpoint.path()).handler(BodyHandler.create()).handler(endpoint::handle);

--- a/gravitee-node-management/src/test/java/io/gravitee/node/management/http/metrics/prometheus/PrometheusEndpointIntegrationTest.java
+++ b/gravitee-node-management/src/test/java/io/gravitee/node/management/http/metrics/prometheus/PrometheusEndpointIntegrationTest.java
@@ -1,0 +1,177 @@
+package io.gravitee.node.management.http.metrics.prometheus;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.gravitee.node.management.http.utils.ConcurrencyLimitHandler;
+import io.micrometer.prometheusmetrics.PrometheusConfig;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServer;
+import io.vertx.ext.web.Router;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PrometheusEndpointIntegrationTest {
+
+    private PrometheusMeterRegistry prometheusMeterRegistry;
+    private Vertx vertx;
+    private HttpServer server;
+    private HttpClient client;
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        prometheusMeterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        prometheusMeterRegistry.counter("test_counter", "env", "test").increment();
+
+        vertx = Vertx.vertx();
+        client = vertx.createHttpClient();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (server != null) {
+            await(server.close());
+        }
+        if (client != null) {
+            client.close();
+        }
+        if (vertx != null) {
+            await(vertx.close());
+        }
+    }
+
+    @Test
+    void should_expose_prometheus_metrics_end_to_end() throws Exception {
+        startServer(false);
+
+        String body = scrapeAndGetBody();
+        assertNotNull(body, "Body is null");
+        assertFalse(body.isEmpty(), "No data received from prometheus endpoint");
+        assertTrue(body.contains("test_counter"), body);
+    }
+
+    @Test
+    void should_return_501_when_registry_is_unavailable() throws Exception {
+        startServer(new PrometheusEndpoint((PrometheusMeterRegistry) null), false);
+
+        int status = scrapeAndGetStatus();
+        assertEquals(501, status);
+    }
+
+    @Test
+    void should_handle_repeated_scrapes_without_degradation() throws Exception {
+        startServer(false);
+
+        for (int i = 0; i < 20; i++) {
+            int status = scrapeAndGetStatus();
+            assertEquals(200, status, "Request " + i + " failed with status " + status);
+        }
+    }
+
+    @Test
+    void should_handle_repeated_scrapes_with_concurrency_limit() throws Exception {
+        startServer(true);
+
+        for (int i = 0; i < 20; i++) {
+            int status = scrapeAndGetStatus();
+            assertEquals(200, status, "Request " + i + " was rejected - concurrency slots may be leaking");
+        }
+    }
+
+    @Test
+    void should_scrape_with_concurrency_limit_and_return_metrics() throws Exception {
+        startServer(true);
+
+        String body = scrapeAndGetBody();
+        assertNotNull(body);
+        assertFalse(body.isEmpty());
+        assertTrue(body.contains("test_counter"), body);
+    }
+
+    private void startServer(boolean withConcurrencyLimit) throws Exception {
+        startServer(new PrometheusEndpoint(prometheusMeterRegistry), withConcurrencyLimit);
+    }
+
+    private void startServer(PrometheusEndpoint endpoint, boolean withConcurrencyLimit) throws Exception {
+        Router router = Router.router(vertx);
+        router
+            .route()
+            .failureHandler(ctx -> {
+                if (!ctx.response().ended()) {
+                    ctx.response().setStatusCode(500).end();
+                }
+            });
+
+        var route = router.route(HttpMethod.GET, endpoint.path());
+        if (withConcurrencyLimit) {
+            route.handler(new ConcurrencyLimitHandler(3));
+        }
+        route.handler(endpoint::handle);
+
+        server = vertx.createHttpServer().requestHandler(router);
+        port = listen(server);
+    }
+
+    private int scrapeAndGetStatus() throws Exception {
+        CompletableFuture<Integer> statusFuture = new CompletableFuture<>();
+        client
+            .request(HttpMethod.GET, port, "localhost", "/metrics/prometheus")
+            .compose(req -> req.send())
+            .compose(response -> response.body().map(buffer -> response.statusCode()))
+            .onComplete(ar -> {
+                if (ar.succeeded()) {
+                    statusFuture.complete(ar.result());
+                } else {
+                    statusFuture.completeExceptionally(ar.cause());
+                }
+            });
+        return statusFuture.get(10, TimeUnit.SECONDS);
+    }
+
+    private String scrapeAndGetBody() throws Exception {
+        CompletableFuture<String> bodyFuture = new CompletableFuture<>();
+        StringBuilder bodyBuilder = new StringBuilder();
+
+        await(client.request(HttpMethod.GET, port, "localhost", "/metrics/prometheus"))
+            .send()
+            .onComplete(ar -> {
+                if (ar.succeeded()) {
+                    var response = ar.result();
+                    if (response.statusCode() != 200) {
+                        bodyFuture.completeExceptionally(new RuntimeException("Status code " + response.statusCode()));
+                        return;
+                    }
+                    response.handler(chunk -> bodyBuilder.append(chunk.toString()));
+                    response.endHandler(v -> bodyFuture.complete(bodyBuilder.toString()));
+                    response.exceptionHandler(bodyFuture::completeExceptionally);
+                } else {
+                    bodyFuture.completeExceptionally(ar.cause());
+                }
+            });
+
+        return await(Future.fromCompletionStage(bodyFuture));
+    }
+
+    private static int listen(HttpServer server) throws Exception {
+        return await(server.listen(0)).actualPort();
+    }
+
+    private static <T> T await(io.vertx.core.Future<T> future) throws Exception {
+        CompletableFuture<T> cf = new CompletableFuture<>();
+        future.onComplete(ar -> {
+            if (ar.succeeded()) {
+                cf.complete(ar.result());
+            } else {
+                cf.completeExceptionally(ar.cause());
+            }
+        });
+        return cf.get(10, TimeUnit.SECONDS);
+    }
+}

--- a/gravitee-node-management/src/test/java/io/gravitee/node/management/http/metrics/prometheus/PrometheusEndpointTest.java
+++ b/gravitee-node-management/src/test/java/io/gravitee/node/management/http/metrics/prometheus/PrometheusEndpointTest.java
@@ -29,7 +29,6 @@ import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.concurrent.Callable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -90,12 +89,25 @@ class PrometheusEndpointTest {
     @Test
     void should_set_correct_content_type_and_chunked_mode() {
         setupHandleMocks();
-        when(vertx.executeBlocking(any(Callable.class))).thenReturn(Future.succeededFuture());
+        when(vertx.executeBlocking(org.mockito.ArgumentMatchers.<Callable<Void>>any())).thenReturn(Future.succeededFuture());
 
         cut.handle(routingContext);
 
         verify(httpServerResponse).putHeader(CONTENT_TYPE, PrometheusEndpoint.CONTENT_TYPE_004);
         verify(httpServerResponse).setChunked(true);
+    }
+
+    @Test
+    void should_return_501_when_registry_is_null() {
+        cut = new PrometheusEndpoint((PrometheusMeterRegistry) null);
+        when(routingContext.response()).thenReturn(httpServerResponse);
+        when(httpServerResponse.setStatusCode(501)).thenReturn(httpServerResponse);
+
+        cut.handle(routingContext);
+
+        verify(httpServerResponse).setStatusCode(501);
+        verify(httpServerResponse).end("Prometheus metrics are not enabled");
+        verifyNoInteractions(vertx);
     }
 
     @Test
@@ -105,7 +117,7 @@ class PrometheusEndpointTest {
         @SuppressWarnings("unchecked")
         ArgumentCaptor<Callable<Void>> callableCaptor = ArgumentCaptor.forClass(Callable.class);
 
-        when(vertx.executeBlocking(callableCaptor.capture()))
+        when(vertx.<Void>executeBlocking(callableCaptor.capture()))
             .thenAnswer(invocation -> {
                 // Execute the callable synchronously for testing
                 try {
@@ -132,7 +144,7 @@ class PrometheusEndpointTest {
         @SuppressWarnings("unchecked")
         ArgumentCaptor<Callable<Void>> callableCaptor = ArgumentCaptor.forClass(Callable.class);
 
-        when(vertx.executeBlocking(callableCaptor.capture()))
+        when(vertx.<Void>executeBlocking(callableCaptor.capture()))
             .thenAnswer(invocation -> {
                 try {
                     callableCaptor.getValue().call();
@@ -152,7 +164,8 @@ class PrometheusEndpointTest {
     @Test
     void should_close_connection_on_scrape_failure() {
         setupHandleMocks();
-        when(vertx.executeBlocking(any(Callable.class))).thenReturn(Future.failedFuture(new IOException("Scrape failed")));
+        when(vertx.executeBlocking(org.mockito.ArgumentMatchers.<Callable<Void>>any()))
+            .thenReturn(Future.failedFuture(new IOException("Scrape failed")));
         when(httpServerResponse.ended()).thenReturn(false);
         when(routingContext.request()).thenReturn(httpServerRequest);
         when(httpServerRequest.connection()).thenReturn(httpConnection);
@@ -166,7 +179,8 @@ class PrometheusEndpointTest {
     @Test
     void should_not_close_connection_if_response_already_ended_on_failure() {
         setupHandleMocks();
-        when(vertx.executeBlocking(any(Callable.class))).thenReturn(Future.failedFuture(new IOException("Scrape failed")));
+        when(vertx.executeBlocking(org.mockito.ArgumentMatchers.<Callable<Void>>any()))
+            .thenReturn(Future.failedFuture(new IOException("Scrape failed")));
         when(httpServerResponse.ended()).thenReturn(true);
 
         cut.handle(routingContext);
@@ -182,7 +196,7 @@ class PrometheusEndpointTest {
         ArgumentCaptor<Callable<Void>> callableCaptor = ArgumentCaptor.forClass(Callable.class);
         ArgumentCaptor<io.vertx.core.buffer.Buffer> bufferCaptor = ArgumentCaptor.forClass(io.vertx.core.buffer.Buffer.class);
 
-        when(vertx.executeBlocking(callableCaptor.capture()))
+        when(vertx.<Void>executeBlocking(callableCaptor.capture()))
             .thenAnswer(invocation -> {
                 try {
                     callableCaptor.getValue().call();

--- a/gravitee-node-management/src/test/java/io/gravitee/node/management/http/utils/ConcurrencyLimitHandlerTest.java
+++ b/gravitee-node-management/src/test/java/io/gravitee/node/management/http/utils/ConcurrencyLimitHandlerTest.java
@@ -2,49 +2,105 @@ package io.gravitee.node.management.http.utils;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
+import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class ConcurrencyLimitHandlerTest {
 
     private RoutingContext mockContext;
-    private HttpServerResponse mockResponse;
-    private HttpServerRequest mockRequest;
 
     @BeforeEach
     void setup() {
-        mockContext = mock(RoutingContext.class);
-        mockRequest = mock(HttpServerRequest.class);
-        mockResponse = mock(HttpServerResponse.class);
-        when(mockContext.request()).thenReturn(mockRequest);
-        when(mockRequest.path()).thenReturn("/test");
-        when(mockContext.response()).thenReturn(mockResponse);
-        when(mockResponse.setStatusCode(anyInt())).thenReturn(mockResponse);
-        when(mockResponse.putHeader(any(CharSequence.class), any(CharSequence.class))).thenReturn(mockResponse);
-        when(mockResponse.endHandler(any())).thenReturn(mockResponse);
+        mockContext = createMockContext();
     }
 
     @Test
     void should_reject_request_when_limit_reached() {
         ConcurrencyLimitHandler handler = new ConcurrencyLimitHandler(0);
-        when(mockResponse.putHeader(anyString(), anyString())).thenReturn(mockResponse);
         handler.handle(mockContext);
-        verify(mockResponse).setStatusCode(429);
-        verify(mockResponse).end("Too Many Requests - limit of 0 for path /test");
+
+        verify(mockContext.response()).setStatusCode(429);
+        verify(mockContext.response()).end("Too Many Requests - limit of 0 for path /test");
         verify(mockContext, never()).next();
     }
 
     @Test
     void should_allow_request_when_slot_available() {
         ConcurrencyLimitHandler handler = new ConcurrencyLimitHandler(1);
+
         handler.handle(mockContext);
+
         verify(mockContext).next();
-        verify(mockResponse).bodyEndHandler(any());
-        verify(mockResponse, never()).setStatusCode(429);
+        verify(mockContext.response()).bodyEndHandler(any());
+        verify(mockContext.response()).closeHandler(any());
+        verify(mockContext.response(), never()).setStatusCode(429);
+    }
+
+    @Test
+    void should_release_only_once_when_exception_and_close_fire() {
+        ConcurrencyLimitHandler handler = new ConcurrencyLimitHandler(1);
+        handler.handle(mockContext);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Handler<Throwable>> exceptionCaptor = ArgumentCaptor.forClass(Handler.class);
+        verify(mockContext.response()).exceptionHandler(exceptionCaptor.capture());
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Handler<Void>> closeCaptor = ArgumentCaptor.forClass(Handler.class);
+        verify(mockContext.response()).closeHandler(closeCaptor.capture());
+
+        exceptionCaptor.getValue().handle(new RuntimeException("failure"));
+        closeCaptor.getValue().handle(null);
+
+        RoutingContext nextContext = createMockContext();
+        handler.handle(nextContext);
+        verify(nextContext).next();
+
+        RoutingContext rejectedContext = createMockContext();
+        handler.handle(rejectedContext);
+        verify(rejectedContext.response()).setStatusCode(429);
+    }
+
+    @Test
+    void should_accept_request_after_close_handler_releases_slot() {
+        ConcurrencyLimitHandler handler = new ConcurrencyLimitHandler(1);
+        handler.handle(mockContext);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Handler<Void>> closeCaptor = ArgumentCaptor.forClass(Handler.class);
+        verify(mockContext.response()).closeHandler(closeCaptor.capture());
+
+        closeCaptor.getValue().handle(null);
+
+        RoutingContext nextContext = createMockContext();
+        handler.handle(nextContext);
+        verify(nextContext).next();
+    }
+
+    private RoutingContext createMockContext() {
+        RoutingContext context = mock(RoutingContext.class);
+        HttpServerRequest request = mock(HttpServerRequest.class);
+        HttpServerResponse response = mock(HttpServerResponse.class);
+
+        when(context.request()).thenReturn(request);
+        when(request.path()).thenReturn("/test");
+        when(context.response()).thenReturn(response);
+        when(response.setStatusCode(anyInt())).thenReturn(response);
+        when(response.putHeader(any(CharSequence.class), any(CharSequence.class))).thenReturn(response);
+        when(response.putHeader(anyString(), anyString())).thenReturn(response);
+        when(response.endHandler(any())).thenReturn(response);
+
+        return context;
     }
 }


### PR DESCRIPTION
…theus endpoint

**Issue**

https://github.com/gravitee-io/issues/issues/12316

**Description**

`PrometheusEndpoint` now returns 501 when no Prometheus registry is available and uses `ended()/closed()` guards before closing or ending the response, while still keeping the alpha `ResponseOutputStream` path intact in `PrometheusEndpoint.java`.
`ConcurrencyLimitHandler` now releases permits exactly once across bodyEndHandler, exceptionHandler, and closeHandler in `ConcurrencyLimitHandler.java`.
Also removed the extra route-level offload for Prometheus in `ManagementVerticle.java`, so alpha now has a single offload boundary inside the endpoint.

On the test side, extended `PrometheusEndpointTest.java`, expanded `ConcurrencyLimitHandlerTest.java`, and added a new alpha-specific `PrometheusEndpointIntegrationTest.java` covering repeated scrapes, concurrency-limit stability, and null-registry behavior.

Summary 

- Improve Prometheus endpoint stability on the alpha branch after the Vert.x 5 / Micrometer migration
- return 501 when Prometheus metrics are unavailable instead of failing later in the scrape path
- fix concurrency permit handling so request slots are always released exactly once, including connection close scenarios
- remove the extra route-level offload for Prometheus and keep a single offload boundary inside the endpoint
- add focused unit and integration coverage for repeated scrapes, concurrency-limit behavior, and missing-registry handling

Why

- The Vert.x 5 / Micrometer migration changed the Prometheus scrape implementation to use an OutputStream-based path. This PR keeps that alpha-specific implementation, but aligns it with the stability fixes already validated on other branches.

Without these follow-up changes:

- Prometheus requests could still leak concurrency permits when the connection closed unexpectedly
- missing Prometheus registry initialization could fail later in the async scrape path instead of returning a clear 501
- Prometheus scraping was being offloaded twice, making the execution flow harder to reason about

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `9.0.0-APIM-12316-Prometheus-scrapping-error-alpha-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/9.0.0-APIM-12316-Prometheus-scrapping-error-alpha-SNAPSHOT/gravitee-node-9.0.0-APIM-12316-Prometheus-scrapping-error-alpha-SNAPSHOT.zip)
  <!-- Version placeholder end -->
