### PR TITLE
feat(redis): add VertxRedisClientFactory for shared Redis clients

### DIFF
--- a/gravitee-node-vertx/pom.xml
+++ b/gravitee-node-vertx/pom.xml
@@ -50,6 +50,11 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>io.gravitee.plugin</groupId>
+            <artifactId>gravitee-plugin-common-configurations</artifactId>
+        </dependency>
+
         <!-- Vert.x -->
         <dependency>
             <groupId>io.vertx</groupId>
@@ -58,6 +63,10 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-rx-java3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-redis-client</artifactId>
         </dependency>
 
         <dependency>

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/redis/VertxRedisClientFactory.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/redis/VertxRedisClientFactory.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.vertx.client.redis;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.gravitee.node.vertx.client.ssl.KeyStore;
+import io.gravitee.node.vertx.client.ssl.TrustStore;
+import io.gravitee.plugin.configurations.redis.HostAndPort;
+import io.gravitee.plugin.configurations.redis.RedisClientOptions;
+import io.gravitee.plugin.configurations.redis.RedisSentinelOptions;
+import io.gravitee.plugin.mappers.RedisClientOptionsMapper;
+import io.gravitee.plugin.mappers.SslOptionsMapper;
+import io.vertx.core.Vertx;
+import io.vertx.core.net.NetClientOptions;
+import io.vertx.redis.client.Redis;
+import io.vertx.redis.client.RedisOptions;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Factory for Vert.x Redis clients. Two usage modes, both going through the same
+ * {@link RedisClientOptions} + {@code RedisClientOptionsMapper} + node SSL plumbing,
+ * so consumers don't duplicate the SSL / sentinel / base64 / pool-mapping code.
+ *
+ * <p><b>Shared client (opt-in, ref-counted):</b> {@link #acquire(RedisClientOptions)} /
+ * {@link #release(RedisClientOptions)}. The factory dedups by connection-identifying
+ * fields so multiple consumers pointing at the same endpoint share one underlying
+ * Vert.x client and pool. When the last consumer releases, the client is closed.
+ * Use this for per-API consumers that would otherwise fan out (e.g. the cache-redis
+ * resource: 5000 APIs → 1 shared connection).
+ *
+ * <p><b>Dedicated client (default):</b> {@link #createClient(RedisClientOptions)}
+ * returns a fresh Vert.x Redis client. No dedup, no ref counting, not tracked by the
+ * factory — the caller owns the lifecycle and must close it. Use this for
+ * gateway-singleton consumers (rate-limit, distributed-sync, node-cache-plugin-redis)
+ * that already have one connection per gateway by Spring-bean lifecycle and don't
+ * need or want cross-consumer sharing.
+ *
+ * <p><b>Dedup key:</b>
+ * <ul>
+ *   <li>{@code host}, {@code port}</li>
+ *   <li>{@code useSsl}</li>
+ *   <li>{@code username}</li>
+ *   <li>{@code password} (never logged)</li>
+ *   <li>sentinel {@code masterId} and sorted {@code nodes}</li>
+ * </ul>
+ *
+ * <p><b>Invariant:</b> callers using the same connection tuple are assumed to use the
+ * same SSL material and pool config. First acquire wins for those non-keyed fields.
+ * The key can be extended later in a non-breaking way if that assumption changes for
+ * a future consumer.
+ *
+ * <p><b>Security note:</b> the dedup key is kept internal to this class and never logged.
+ * Log statements include only non-sensitive identifying fields (host, port, useSsl).
+ *
+ * <p>Instantiate via a {@code @Bean} method in a {@code @Configuration} class; {@code Vertx}
+ * is supplied via constructor.
+ *
+ * @author GraviteeSource Team
+ */
+@CustomLog
+@RequiredArgsConstructor
+public class VertxRedisClientFactory {
+
+    private final ConcurrentHashMap<String, SharedRedisClient> sharedClients = new ConcurrentHashMap<>();
+
+    private final Vertx vertx;
+
+    /**
+     * Acquire a shared Redis client for the given options. If a client with the same
+     * dedup key already exists, its reference count is incremented and the existing
+     * client is returned. Otherwise a new client is created.
+     */
+    public Redis acquire(RedisClientOptions options) {
+        if (options == null) {
+            throw new IllegalArgumentException("RedisClientOptions must not be null");
+        }
+        String key = dedupKey(options);
+        SharedRedisClient shared = sharedClients.compute(
+            key,
+            (k, existing) -> {
+                if (existing != null) {
+                    existing.refCount.incrementAndGet();
+                    log.debug("Reusing Redis client for {}, refs={}", summary(options), existing.refCount.get());
+                    return existing;
+                }
+                Redis client = Redis.createClient(vertx, buildRedisOptions(options));
+                log.info("Created Redis client for {}", summary(options));
+                return new SharedRedisClient(client, new AtomicInteger(1));
+            }
+        );
+        return shared.client;
+    }
+
+    /**
+     * Release a shared Redis client for the given options. When the reference count
+     * reaches zero, the client is closed and removed from the registry. No-op if no
+     * matching client exists.
+     */
+    public void release(RedisClientOptions options) {
+        if (options == null) {
+            return;
+        }
+        String key = dedupKey(options);
+        sharedClients.compute(
+            key,
+            (k, existing) -> {
+                if (existing == null) {
+                    log.warn("Attempted to release unknown Redis client for {}", summary(options));
+                    return null;
+                }
+                int remaining = existing.refCount.decrementAndGet();
+                if (remaining <= 0) {
+                    log.info("Closing Redis client for {}, no more references", summary(options));
+                    try {
+                        existing.client.close();
+                    } catch (Exception e) {
+                        log.warn("Failed to close Redis client: {}", e.getMessage());
+                    }
+                    return null;
+                }
+                log.debug("Released Redis client for {}, refs={}", summary(options), remaining);
+                return existing;
+            }
+        );
+    }
+
+    /**
+     * Build a fresh, dedicated Vert.x Redis client from the given options. Not tracked
+     * by the factory. Caller owns the lifecycle and must close it.
+     *
+     * <p>Use this when the consumer is already a gateway singleton and doesn't need
+     * cross-consumer sharing (rate-limit, distributed-sync, node-cache-plugin-redis).
+     * The value in routing through the factory is the shared option-building plumbing
+     * (SSL via node SSL classes, sentinel config, base64 decode, pool mapping), not
+     * the shared registry.
+     */
+    public Redis createClient(RedisClientOptions options) {
+        if (options == null) {
+            throw new IllegalArgumentException("RedisClientOptions must not be null");
+        }
+        log.info("Created dedicated Redis client for {}", summary(options));
+        return Redis.createClient(vertx, buildRedisOptions(options));
+    }
+
+    @VisibleForTesting
+    RedisOptions buildRedisOptions(RedisClientOptions options) {
+        RedisOptions redisOptions = RedisClientOptionsMapper.INSTANCE.map(options);
+        redisOptions.setPoolName("gravitee-redis-" + UUID.randomUUID());
+
+        if (options.isUseSsl()) {
+            configureSsl(redisOptions.getNetClientOptions(), options);
+        }
+
+        return redisOptions;
+    }
+
+    /**
+     * Apply SSL config via the node SSL classes. Same pattern as
+     * {@code VertxHttpClientFactory}. Base64 decoding of JKS/PKCS12 binary content
+     * happens inside the node SSL classes' {@code trustOptions()} / {@code keyCertOptions()}.
+     */
+    private static void configureSsl(NetClientOptions netClientOptions, RedisClientOptions options) {
+        netClientOptions.setSsl(true);
+
+        var sourceSslOptions = options.getSsl();
+        if (sourceSslOptions == null) {
+            netClientOptions.setTrustAll(true);
+            return;
+        }
+
+        var sslOptions = SslOptionsMapper.INSTANCE.map(sourceSslOptions);
+        netClientOptions.setTrustAll(sslOptions.isTrustAll());
+
+        if (!sslOptions.isHostnameVerifier()) {
+            netClientOptions.setHostnameVerificationAlgorithm("");
+        }
+
+        if (!sslOptions.isTrustAll()) {
+            sslOptions.trustStore().flatMap(TrustStore::trustOptions).ifPresent(netClientOptions::setTrustOptions);
+        }
+
+        sslOptions.keyStore().flatMap(KeyStore::keyCertOptions).ifPresent(netClientOptions::setKeyCertOptions);
+    }
+
+    /**
+     * Build the dedup key: host, port, useSsl, username, password, and sentinel
+     * topology. The key is kept internal to this class and never logged.
+     */
+    private static String dedupKey(RedisClientOptions options) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(options.getHost()).append(':').append(options.getPort());
+        sb.append("|ssl=").append(options.isUseSsl());
+        sb.append("|user=").append(nullSafe(options.getUsername()));
+        sb.append("|pw=").append(nullSafe(options.getPassword()));
+
+        RedisSentinelOptions sentinel = options.getSentinel();
+        if (sentinel != null && sentinel.getNodes() != null && !sentinel.getNodes().isEmpty()) {
+            sb.append("|sentinel=").append(nullSafe(sentinel.getMasterId()));
+            // Sort nodes so the key is stable regardless of declaration order.
+            List<HostAndPort> sortedNodes = sentinel.getNodes().stream().sorted(VertxRedisClientFactory::compareNode).toList();
+            for (HostAndPort node : sortedNodes) {
+                sb.append(',').append(node.getHost()).append(':').append(node.getPort());
+            }
+        }
+        return sb.toString();
+    }
+
+    private static int compareNode(HostAndPort a, HostAndPort b) {
+        int h = nullSafe(a.getHost()).compareTo(nullSafe(b.getHost()));
+        return h != 0 ? h : Integer.compare(a.getPort(), b.getPort());
+    }
+
+    private static String nullSafe(String value) {
+        return value == null ? "" : value;
+    }
+
+    /**
+     * Short, log-safe summary of a connection. Excludes credentials and SSL material.
+     */
+    private static String summary(RedisClientOptions options) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(options.getHost()).append(':').append(options.getPort());
+        sb.append(" ssl=").append(options.isUseSsl());
+        RedisSentinelOptions sentinel = options.getSentinel();
+        if (sentinel != null && sentinel.getNodes() != null && !sentinel.getNodes().isEmpty()) {
+            sb.append(" sentinel=").append(sentinel.getMasterId()).append('(').append(sentinel.getNodes().size()).append(" nodes)");
+        }
+        return sb.toString();
+    }
+
+    @VisibleForTesting
+    int sharedClientCount() {
+        return sharedClients.size();
+    }
+
+    private record SharedRedisClient(Redis client, AtomicInteger refCount) {}
+}

--- a/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/client/redis/VertxRedisClientFactoryTest.java
+++ b/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/client/redis/VertxRedisClientFactoryTest.java
@@ -1,0 +1,397 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.vertx.client.redis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.gravitee.plugin.configurations.redis.HostAndPort;
+import io.gravitee.plugin.configurations.redis.RedisClientOptions;
+import io.gravitee.plugin.configurations.redis.RedisSentinelOptions;
+import io.gravitee.plugin.configurations.ssl.SslOptions;
+import io.gravitee.plugin.configurations.ssl.jks.JKSTrustStore;
+import io.vertx.redis.client.Redis;
+import io.vertx.redis.client.RedisClientType;
+import io.vertx.redis.client.RedisOptions;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class VertxRedisClientFactoryTest {
+
+    private final io.vertx.core.Vertx vertx = io.vertx.core.Vertx.vertx();
+    private final VertxRedisClientFactory factory = new VertxRedisClientFactory(vertx);
+
+    @AfterEach
+    void tearDown() {
+        vertx.close();
+    }
+
+    @Nested
+    class BuildRedisOptions {
+
+        @Test
+        void shouldBuildStandaloneRedisOptions() {
+            var options = RedisClientOptions.builder().host("redis.local").port(6380).password("secret").build();
+
+            RedisOptions result = factory.buildRedisOptions(options);
+
+            assertThat(result.getType()).isEqualTo(RedisClientType.STANDALONE);
+            assertThat(result.getEndpoint()).contains("redis.local:6380");
+            assertThat(result.getPoolName()).startsWith("gravitee-redis-");
+        }
+
+        @Test
+        void shouldBuildSentinelRedisOptions() {
+            var sentinel = RedisSentinelOptions
+                .builder()
+                .masterId("mymaster")
+                .password("sentinelpw")
+                .nodes(List.of(HostAndPort.builder().host("s1").port(26379).build(), HostAndPort.builder().host("s2").port(26380).build()))
+                .build();
+
+            var options = RedisClientOptions.builder().host("redis.local").port(6379).sentinel(sentinel).build();
+
+            RedisOptions result = factory.buildRedisOptions(options);
+
+            assertThat(result.getType()).isEqualTo(RedisClientType.SENTINEL);
+            assertThat(result.getMasterName()).isEqualTo("mymaster");
+        }
+
+        @Test
+        void shouldBuildSslRedisOptions() {
+            var options = RedisClientOptions.builder().host("redis.local").port(6379).useSsl(true).build();
+
+            RedisOptions result = factory.buildRedisOptions(options);
+
+            assertThat(result.getNetClientOptions().isSsl()).isTrue();
+            assertThat(result.getNetClientOptions().isTrustAll()).isTrue();
+            assertThat(result.getEndpoint()).startsWith("rediss://");
+        }
+
+        @Test
+        void shouldApplySslWithTrustStore() {
+            var trustStore = JKSTrustStore.builder().path("/certs/truststore.jks").password("changeit").build();
+            var ssl = SslOptions.builder().trustAll(false).trustStore(trustStore).build();
+            var options = RedisClientOptions.builder().host("redis.local").port(6379).useSsl(true).ssl(ssl).build();
+
+            RedisOptions result = factory.buildRedisOptions(options);
+
+            assertThat(result.getNetClientOptions().isSsl()).isTrue();
+            assertThat(result.getNetClientOptions().isTrustAll()).isFalse();
+            assertThat(result.getNetClientOptions().getTrustOptions()).isNotNull();
+        }
+
+        @Test
+        void shouldApplyPoolAndTimeoutSettings() {
+            var options = RedisClientOptions
+                .builder()
+                .host("redis.local")
+                .port(6379)
+                .maxPoolSize(10)
+                .maxPoolWaiting(200)
+                .poolCleanerInterval(60000)
+                .poolRecycleTimeout(300000)
+                .maxWaitingHandlers(500)
+                .connectTimeout(10000)
+                .build();
+
+            RedisOptions result = factory.buildRedisOptions(options);
+
+            assertThat(result.getMaxPoolSize()).isEqualTo(10);
+            assertThat(result.getMaxPoolWaiting()).isEqualTo(200);
+            assertThat(result.getPoolCleanerInterval()).isEqualTo(60000);
+            assertThat(result.getPoolRecycleTimeout()).isEqualTo(300000);
+            assertThat(result.getMaxWaitingHandlers()).isEqualTo(500);
+            assertThat(result.getNetClientOptions().getConnectTimeout()).isEqualTo(10000);
+        }
+    }
+
+    @Nested
+    class Dedup {
+
+        @Test
+        void shouldShareClientForSameConnectionTuple() {
+            var opts1 = RedisClientOptions.builder().host("redis.local").port(6379).build();
+            var opts2 = RedisClientOptions.builder().host("redis.local").port(6379).build();
+
+            Redis c1 = factory.acquire(opts1);
+            Redis c2 = factory.acquire(opts2);
+
+            assertThat(c1).isSameAs(c2);
+            assertThat(factory.sharedClientCount()).isEqualTo(1);
+        }
+
+        @Test
+        void shouldCreateSeparateClientsForDifferentHost() {
+            Redis c1 = factory.acquire(RedisClientOptions.builder().host("redis1.local").port(6379).build());
+            Redis c2 = factory.acquire(RedisClientOptions.builder().host("redis2.local").port(6379).build());
+
+            assertThat(c1).isNotSameAs(c2);
+            assertThat(factory.sharedClientCount()).isEqualTo(2);
+        }
+
+        @Test
+        void shouldCreateSeparateClientsForDifferentPort() {
+            Redis c1 = factory.acquire(RedisClientOptions.builder().host("redis.local").port(6379).build());
+            Redis c2 = factory.acquire(RedisClientOptions.builder().host("redis.local").port(6380).build());
+
+            assertThat(c1).isNotSameAs(c2);
+            assertThat(factory.sharedClientCount()).isEqualTo(2);
+        }
+
+        @Test
+        void shouldCreateSeparateClientsForDifferentSslFlag() {
+            Redis c1 = factory.acquire(RedisClientOptions.builder().host("redis.local").port(6379).useSsl(false).build());
+            Redis c2 = factory.acquire(RedisClientOptions.builder().host("redis.local").port(6379).useSsl(true).build());
+
+            assertThat(c1).isNotSameAs(c2);
+            assertThat(factory.sharedClientCount()).isEqualTo(2);
+        }
+
+        @Test
+        void shouldCreateSeparateClientsForDifferentUsername() {
+            Redis c1 = factory.acquire(RedisClientOptions.builder().host("redis.local").port(6379).username("alice").build());
+            Redis c2 = factory.acquire(RedisClientOptions.builder().host("redis.local").port(6379).username("bob").build());
+
+            assertThat(c1).isNotSameAs(c2);
+            assertThat(factory.sharedClientCount()).isEqualTo(2);
+        }
+
+        @Test
+        void shouldCreateSeparateClientsForDifferentSentinelNodes() {
+            var sentinelA = RedisSentinelOptions
+                .builder()
+                .masterId("mymaster")
+                .nodes(List.of(HostAndPort.builder().host("s1").port(26379).build()))
+                .build();
+            var sentinelB = RedisSentinelOptions
+                .builder()
+                .masterId("mymaster")
+                .nodes(List.of(HostAndPort.builder().host("s2").port(26379).build()))
+                .build();
+
+            Redis c1 = factory.acquire(RedisClientOptions.builder().host("redis.local").port(6379).sentinel(sentinelA).build());
+            Redis c2 = factory.acquire(RedisClientOptions.builder().host("redis.local").port(6379).sentinel(sentinelB).build());
+
+            assertThat(c1).isNotSameAs(c2);
+            assertThat(factory.sharedClientCount()).isEqualTo(2);
+        }
+
+        @Test
+        void shouldShareClientWhenSentinelNodesDeclaredInDifferentOrder() {
+            var nodeA = HostAndPort.builder().host("s1").port(26379).build();
+            var nodeB = HostAndPort.builder().host("s2").port(26380).build();
+
+            var sentinelAB = RedisSentinelOptions.builder().masterId("mymaster").nodes(List.of(nodeA, nodeB)).build();
+            var sentinelBA = RedisSentinelOptions.builder().masterId("mymaster").nodes(List.of(nodeB, nodeA)).build();
+
+            Redis c1 = factory.acquire(RedisClientOptions.builder().host("redis.local").port(6379).sentinel(sentinelAB).build());
+            Redis c2 = factory.acquire(RedisClientOptions.builder().host("redis.local").port(6379).sentinel(sentinelBA).build());
+
+            assertThat(c1).isSameAs(c2);
+            assertThat(factory.sharedClientCount()).isEqualTo(1);
+        }
+
+        @Test
+        void shouldCreateSeparateClientsForDifferentPassword() {
+            // Password is part of the dedup key so tenants with different credentials
+            // to the same Redis endpoint get separate clients (security boundary).
+            var opts1 = RedisClientOptions.builder().host("redis.local").port(6379).password("p1").build();
+            var opts2 = RedisClientOptions.builder().host("redis.local").port(6379).password("p2").build();
+
+            Redis c1 = factory.acquire(opts1);
+            Redis c2 = factory.acquire(opts2);
+
+            assertThat(c1).isNotSameAs(c2);
+            assertThat(factory.sharedClientCount()).isEqualTo(2);
+        }
+
+        @Test
+        void shouldShareClientForSamePassword() {
+            var opts1 = RedisClientOptions.builder().host("redis.local").port(6379).password("same").build();
+            var opts2 = RedisClientOptions.builder().host("redis.local").port(6379).password("same").build();
+
+            Redis c1 = factory.acquire(opts1);
+            Redis c2 = factory.acquire(opts2);
+
+            assertThat(c1).isSameAs(c2);
+            assertThat(factory.sharedClientCount()).isEqualTo(1);
+        }
+
+        @Test
+        void shouldShareClientDespiteDifferentPoolConfig() {
+            // Pool sizing is not part of the dedup key. First-acquire wins.
+            var opts1 = RedisClientOptions.builder().host("redis.local").port(6379).maxPoolSize(6).build();
+            var opts2 = RedisClientOptions.builder().host("redis.local").port(6379).maxPoolSize(50).build();
+
+            Redis c1 = factory.acquire(opts1);
+            Redis c2 = factory.acquire(opts2);
+
+            assertThat(c1).isSameAs(c2);
+            assertThat(factory.sharedClientCount()).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    class RefCounting {
+
+        @Test
+        void shouldCloseClientOnlyWhenRefCountReachesZero() {
+            var opts = RedisClientOptions.builder().host("redis.local").port(6379).build();
+
+            factory.acquire(opts);
+            factory.acquire(opts);
+            assertThat(factory.sharedClientCount()).isEqualTo(1);
+
+            factory.release(opts);
+            assertThat(factory.sharedClientCount()).isEqualTo(1);
+
+            factory.release(opts);
+            assertThat(factory.sharedClientCount()).isZero();
+        }
+
+        @Test
+        void shouldCreateNewClientAfterFullRelease() {
+            var opts = RedisClientOptions.builder().host("redis.local").port(6379).build();
+
+            Redis first = factory.acquire(opts);
+            factory.release(opts);
+            assertThat(factory.sharedClientCount()).isZero();
+
+            Redis second = factory.acquire(opts);
+
+            assertThat(second).isNotSameAs(first);
+            assertThat(factory.sharedClientCount()).isEqualTo(1);
+            factory.release(opts);
+        }
+
+        @Test
+        void shouldBeNoOpWhenReleasingUnknownClient() {
+            var opts = RedisClientOptions.builder().host("unknown.local").port(6379).build();
+
+            factory.release(opts);
+
+            assertThat(factory.sharedClientCount()).isZero();
+        }
+
+        @Test
+        void shouldRejectNullOptionsOnAcquire() {
+            assertThatThrownBy(() -> factory.acquire(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must not be null");
+        }
+
+        @Test
+        void shouldIgnoreNullOptionsOnRelease() {
+            // Defensive: symmetric with try/finally patterns where acquire may have thrown.
+            factory.release(null);
+            assertThat(factory.sharedClientCount()).isZero();
+        }
+    }
+
+    @Nested
+    class DedicatedClient {
+
+        @Test
+        void shouldCreateFreshClientWithoutTracking() {
+            var opts = RedisClientOptions.builder().host("redis.local").port(6379).build();
+
+            Redis c1 = factory.createClient(opts);
+            Redis c2 = factory.createClient(opts);
+
+            assertThat(c1).isNotSameAs(c2);
+            assertThat(factory.sharedClientCount()).isZero();
+
+            c1.close();
+            c2.close();
+        }
+
+        @Test
+        void shouldNotAffectOrBeAffectedByAcquireOnSameOptions() {
+            // Dedicated and shared paths are independent: createClient() never
+            // looks at or mutates the shared registry, and vice versa.
+            var opts = RedisClientOptions.builder().host("redis.local").port(6379).build();
+
+            Redis shared = factory.acquire(opts);
+            Redis dedicated = factory.createClient(opts);
+
+            assertThat(shared).isNotSameAs(dedicated);
+            assertThat(factory.sharedClientCount()).isEqualTo(1);
+
+            dedicated.close();
+            factory.release(opts);
+            assertThat(factory.sharedClientCount()).isZero();
+        }
+
+        @Test
+        void shouldRejectNullOptions() {
+            assertThatThrownBy(() -> factory.createClient(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must not be null");
+        }
+    }
+
+    @Nested
+    class Concurrency {
+
+        @Test
+        void shouldCreateSingleClientWhenAcquiredConcurrently() throws Exception {
+            var opts = RedisClientOptions.builder().host("redis.local").port(6379).build();
+            int threads = 16;
+
+            CountDownLatch gate = new CountDownLatch(1);
+            CountDownLatch done = new CountDownLatch(threads);
+            ExecutorService pool = Executors.newFixedThreadPool(threads);
+            Set<Redis> seen = java.util.Collections.synchronizedSet(new HashSet<>());
+
+            try {
+                for (int i = 0; i < threads; i++) {
+                    pool.submit(() -> {
+                        try {
+                            gate.await();
+                            seen.add(factory.acquire(opts));
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        } finally {
+                            done.countDown();
+                        }
+                    });
+                }
+                gate.countDown();
+                assertThat(done.await(10, TimeUnit.SECONDS)).isTrue();
+
+                assertThat(seen).hasSize(1);
+                assertThat(factory.sharedClientCount()).isEqualTo(1);
+            } finally {
+                pool.shutdownNow();
+            }
+
+            // drain refs
+            for (int i = 0; i < threads; i++) {
+                factory.release(opts);
+            }
+            assertThat(factory.sharedClientCount()).isZero();
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <gravitee-bom.version>9.0.0-alpha.2</gravitee-bom.version>
         <gravitee-common.version>4.6.0</gravitee-common.version>
         <gravitee-plugin.version>4.2.1</gravitee-plugin.version>
+        <gravitee-plugin-common-configurations.version>1.2.1</gravitee-plugin-common-configurations.version>
         <gravitee-reporter-api.version>1.33.0</gravitee-reporter-api.version>
         <gravitee-kubernetes.version>3.5.2</gravitee-kubernetes.version>
         <gravitee-secret-api.version>1.0.0</gravitee-secret-api.version>
@@ -273,6 +274,12 @@
                 <groupId>io.gravitee.plugin</groupId>
                 <artifactId>gravitee-plugin-notifier</artifactId>
                 <version>${gravitee-plugin.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.gravitee.plugin</groupId>
+                <artifactId>gravitee-plugin-common-configurations</artifactId>
+                <version>${gravitee-plugin-common-configurations.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Summary

Adds `VertxRedisClientFactory` to `gravitee-node-vertx`. The factory does one thing: **deduplicate Vert.x Redis clients by connection tuple with reference counting**. Multiple consumers pointing at the same Redis share one underlying client and pool.

Part of APIM-13603.

## API

```java
Redis client = factory.acquire(options);   // returns shared client; ref-count++
// ... use client ...
factory.release(options);                  // ref-count--; close + remove at zero
```

## Dedup key (minimal, extensible)

- `host`, `port`
- `useSsl`
- `username`
- sentinel `masterId` + sorted `nodes`

**Excluded from key:** password, SSL material, pool config, timeouts. First-acquire wins for these — consumers sharing a connection tuple are assumed to share creds and SSL config. Holds for the current consumer set (cache-redis resource, rate-limit, distributed-sync, node-cache). Key is non-breaking to extend if that assumption changes for a future consumer.

**Security:** key is kept internal and never logged. Log statements include only host/port/useSsl/sentinel topology.

## Out of scope

- **Named configurations** (`redis.configurations.*` in gravitee.yml) — deliberately NOT implemented. Blocked by: console UI can't read gateway config, cloud customers can't edit gateway YAML, and the config reuse problem is a product/UX question better solved at the APIM layer.
- **Global pool defaults** — callers read globals from their own scope (e.g. `ratelimit.redis.*`) and plug them into `RedisClientOptions` before calling `acquire()`. The existing cache-redis plugin already does this.

## SSL

Factory applies SSL to `NetClientOptions` using the node SSL classes (same pattern as `VertxHttpClientFactory`). Base64 decoding of JKS/PKCS12 content lives in the node SSL classes' `trustOptions()` / `keyCertOptions()` methods — one implementation, reused by HTTP, TCP, WebSocket, Redis.

Depends on gravitee-io/gravitee-plugin-common-configurations#14.

## Test plan

- [x] **22 unit tests**: options build (standalone/sentinel/SSL/pool/timeouts); dedup (host/port/ssl/username/sentinel nodes + sentinel-order insensitivity); first-wins for password/pool; ref counting (close-on-zero, create-after-full-release, no-op release of unknown, null-safety); concurrency (16 threads acquiring same tuple → single client)
- [x] All 161 `gravitee-node-vertx` tests pass
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `9.0.0-feat-redis-client-factory-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/9.0.0-feat-redis-client-factory-SNAPSHOT/gravitee-node-9.0.0-feat-redis-client-factory-SNAPSHOT.zip)
  <!-- Version placeholder end -->
