### PR TITLE
feat: add span-attribute redaction support

### DIFF
--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/TracerFactory.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/TracerFactory.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.node.api.opentelemetry;
 
+import io.gravitee.node.api.opentelemetry.redaction.RedactionConfig;
 import java.util.List;
 import java.util.Map;
 
@@ -45,4 +46,27 @@ public interface TracerFactory {
         final List<InstrumenterTracerFactory> instrumenterTracerFactories,
         final Map<String, String> additionalResourceAttributes
     );
+
+    default Tracer createTracer(
+        final String id,
+        final String serviceName,
+        final String serviceNamespace,
+        final String version,
+        final List<InstrumenterTracerFactory> instrumenterTracerFactories,
+        final RedactionConfig redactionConfig
+    ) {
+        return createTracer(id, serviceName, serviceNamespace, version, instrumenterTracerFactories, null, redactionConfig);
+    }
+
+    default Tracer createTracer(
+        final String id,
+        final String serviceName,
+        final String serviceNamespace,
+        final String version,
+        final List<InstrumenterTracerFactory> instrumenterTracerFactories,
+        final Map<String, String> additionalResourceAttributes,
+        final RedactionConfig redactionConfig
+    ) {
+        return createTracer(id, serviceName, serviceNamespace, version, instrumenterTracerFactories, additionalResourceAttributes);
+    }
 }

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/redaction/FullMaskingStrategy.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/redaction/FullMaskingStrategy.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.api.opentelemetry.redaction;
+
+public record FullMaskingStrategy(String replacement) implements MaskingStrategy {
+    public FullMaskingStrategy {
+        if (replacement == null || replacement.isEmpty()) {
+            replacement = "[REDACTED]";
+        }
+    }
+}

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/redaction/MaskingStrategy.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/redaction/MaskingStrategy.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.api.opentelemetry.redaction;
+
+public sealed interface MaskingStrategy permits FullMaskingStrategy, PartialMaskingStrategy {
+    MaskingStrategy DEFAULT = new FullMaskingStrategy("[REDACTED]");
+
+    static MaskingStrategy fullMask(String replacement) {
+        return new FullMaskingStrategy(replacement);
+    }
+
+    static MaskingStrategy partialMask(int prefixLength, int suffixLength) {
+        return new PartialMaskingStrategy(prefixLength, suffixLength, "*");
+    }
+
+    static MaskingStrategy partialMask(int prefixLength, int suffixLength, String maskChar) {
+        return new PartialMaskingStrategy(prefixLength, suffixLength, maskChar);
+    }
+}

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/redaction/PartialMaskingStrategy.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/redaction/PartialMaskingStrategy.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.api.opentelemetry.redaction;
+
+public record PartialMaskingStrategy(int prefixLength, int suffixLength, String maskChar) implements MaskingStrategy {
+    public PartialMaskingStrategy {
+        if (maskChar == null || maskChar.isEmpty()) {
+            maskChar = "*";
+        }
+        if (maskChar.length() > 1) {
+            throw new IllegalArgumentException("PARTIAL mask character must be exactly one character, got: \"" + maskChar + "\"");
+        }
+        if (prefixLength < 0) throw new IllegalArgumentException("prefixLength must be >= 0, got: " + prefixLength);
+        if (suffixLength < 0) throw new IllegalArgumentException("suffixLength must be >= 0, got: " + suffixLength);
+    }
+}

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/redaction/RedactionConfig.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/redaction/RedactionConfig.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.api.opentelemetry.redaction;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public record RedactionConfig(List<RedactionRule> rules, String defaultReplacement) {
+    public static final RedactionConfig EMPTY = new RedactionConfig(List.of());
+
+    public RedactionConfig {
+        rules = (rules == null) ? List.of() : List.copyOf(rules);
+        defaultReplacement =
+            (defaultReplacement == null || defaultReplacement.isBlank()) ? RedactionRule.DEFAULT_REPLACEMENT : defaultReplacement;
+    }
+
+    public RedactionConfig(List<RedactionRule> rules) {
+        this(rules, RedactionRule.DEFAULT_REPLACEMENT);
+    }
+
+    public boolean hasRules() {
+        return !rules.isEmpty();
+    }
+
+    public RedactionConfig mergeWith(RedactionConfig config) {
+        if (config == null || !config.hasRules()) return this;
+        if (!this.hasRules()) return config;
+        List<RedactionRule> combined = new ArrayList<>(this.rules());
+        combined.addAll(config.rules());
+        return new RedactionConfig(combined, this.defaultReplacement());
+    }
+}

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/redaction/RedactionRule.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/redaction/RedactionRule.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.api.opentelemetry.redaction;
+
+import java.util.Objects;
+
+public record RedactionRule(String attributeNamePattern, MaskingStrategy maskingStrategy, String valuePattern) {
+    public static final String DEFAULT_REPLACEMENT = "[REDACTED]";
+
+    public RedactionRule {
+        Objects.requireNonNull(attributeNamePattern, "attributeNamePattern must not be null");
+        maskingStrategy = (maskingStrategy == null) ? MaskingStrategy.DEFAULT : maskingStrategy;
+    }
+
+    public RedactionRule(String attributeNamePattern) {
+        this(attributeNamePattern, MaskingStrategy.DEFAULT, null);
+    }
+
+    public RedactionRule(String attributeNamePattern, String replacement) {
+        this(attributeNamePattern, MaskingStrategy.fullMask(replacement), null);
+    }
+
+    public RedactionRule(String attributeNamePattern, MaskingStrategy maskingStrategy) {
+        this(attributeNamePattern, maskingStrategy, null);
+    }
+}

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/OpenTelemetryFactory.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/OpenTelemetryFactory.java
@@ -18,8 +18,10 @@ package io.gravitee.node.opentelemetry;
 import io.gravitee.node.api.opentelemetry.InstrumenterTracerFactory;
 import io.gravitee.node.api.opentelemetry.Tracer;
 import io.gravitee.node.api.opentelemetry.TracerFactory;
+import io.gravitee.node.api.opentelemetry.redaction.RedactionConfig;
 import io.gravitee.node.opentelemetry.configuration.OpenTelemetryConfiguration;
 import io.gravitee.node.opentelemetry.exporter.SpanExporterFactory;
+import io.gravitee.node.opentelemetry.exporter.redact.RedactSpanExporter;
 import io.gravitee.node.opentelemetry.tracer.OpenTelemetryTracer;
 import io.gravitee.node.opentelemetry.tracer.noop.NoOpTracer;
 import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
@@ -33,6 +35,7 @@ import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.resources.ResourceBuilder;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.semconv.ResourceAttributes;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -66,7 +69,15 @@ public class OpenTelemetryFactory implements TracerFactory {
         final String serviceVersion,
         final List<InstrumenterTracerFactory> instrumenterTracerFactories
     ) {
-        return createTracer(serviceInstanceId, serviceName, serviceNamespace, serviceVersion, instrumenterTracerFactories, null);
+        return createTracer(
+            serviceInstanceId,
+            serviceName,
+            serviceNamespace,
+            serviceVersion,
+            instrumenterTracerFactories,
+            null,
+            RedactionConfig.EMPTY
+        );
     }
 
     @Override
@@ -78,14 +89,59 @@ public class OpenTelemetryFactory implements TracerFactory {
         final List<InstrumenterTracerFactory> instrumenterTracerFactories,
         final Map<String, String> additionalResourceAttributes
     ) {
+        return createTracer(
+            serviceInstanceId,
+            serviceName,
+            serviceNamespace,
+            serviceVersion,
+            instrumenterTracerFactories,
+            additionalResourceAttributes,
+            RedactionConfig.EMPTY
+        );
+    }
+
+    @Override
+    public Tracer createTracer(
+        final String serviceInstanceId,
+        final String serviceName,
+        final String serviceNamespace,
+        final String serviceVersion,
+        final List<InstrumenterTracerFactory> instrumenterTracerFactories,
+        final Map<String, String> additionalResourceAttributes,
+        final RedactionConfig redactionConfig
+    ) {
         if (configuration.isTracesEnabled()) {
-            final Resource resource = createResource(
+            Resource resource = createResource(
                 serviceInstanceId,
                 serviceName,
                 serviceNamespace,
                 serviceVersion,
                 additionalResourceAttributes
             );
+
+            // YAML rules are the base; any product-supplied rules are merged on top.
+            // Products that pass RedactionConfig.EMPTY (or nothing) automatically benefit
+            // from operator-configured YAML rules without any code change in APIM or AM.
+            RedactionConfig effectiveConfig = configuration.getRedactionConfig().mergeWith(redactionConfig);
+            SpanExporter exporter = spanExporterFactory.getSpanExporter();
+            if (effectiveConfig.hasRules()) {
+                // Create the exporter once and reuse its compiled rules to redact resource
+                // attributes (service.instance.id, hostname, ip, …) upfront so the already-clean
+                // values are baked into the SdkTracerProvider. Resource attrs live in
+                // SpanData.getResource(), not SpanData.getAttributes(), so they are invisible
+                // to per-span redaction inside the exporter.
+                // @SuppressWarnings: lifecycle is transferred to BatchSpanProcessor below.
+                @SuppressWarnings("resource")
+                RedactSpanExporter redactExporter = new RedactSpanExporter(exporter, effectiveConfig);
+                resource = redactExporter.redactResource(resource);
+                exporter = redactExporter;
+            }
+
+            SdkTracerProvider tracerProvider = SdkTracerProvider
+                .builder()
+                .addSpanProcessor(BatchSpanProcessor.builder(exporter).build())
+                .setResource(resource)
+                .build();
 
             final OpenTelemetrySdkBuilder builder = OpenTelemetrySdk
                 .builder()
@@ -94,12 +150,6 @@ public class OpenTelemetryFactory implements TracerFactory {
                         TextMapPropagator.composite(W3CTraceContextPropagator.getInstance(), W3CBaggagePropagator.getInstance())
                     )
                 );
-
-            SdkTracerProvider tracerProvider = SdkTracerProvider
-                .builder()
-                .addSpanProcessor(BatchSpanProcessor.builder(spanExporterFactory.getSpanExporter()).build())
-                .setResource(resource)
-                .build();
 
             builder.setTracerProvider(tracerProvider);
             OpenTelemetrySdk openTelemetrySdk = builder.build();
@@ -120,8 +170,9 @@ public class OpenTelemetryFactory implements TracerFactory {
         String ipv4;
 
         try {
-            hostname = InetAddress.getLocalHost().getHostName();
-            ipv4 = InetAddress.getLocalHost().getHostAddress();
+            InetAddress localHost = InetAddress.getLocalHost();
+            hostname = localHost.getHostName();
+            ipv4 = localHost.getHostAddress();
         } catch (UnknownHostException e) {
             log.warn("Unable to retrieve current host and ip for OpenTelemetry Tracer, fallback to default value");
             hostname = DEFAULT_HOST_NAME;

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/configuration/OpenTelemetryConfiguration.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/configuration/OpenTelemetryConfiguration.java
@@ -16,9 +16,13 @@
 package io.gravitee.node.opentelemetry.configuration;
 
 import io.gravitee.common.util.EnvironmentUtils;
+import io.gravitee.node.api.opentelemetry.redaction.MaskingStrategy;
+import io.gravitee.node.api.opentelemetry.redaction.RedactionConfig;
+import io.gravitee.node.api.opentelemetry.redaction.RedactionRule;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.internal.AttributesMap;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -198,6 +202,73 @@ public class OpenTelemetryConfiguration {
 
     @Value("${services.opentelemetry.exporter.proxy.password:#{null}}")
     String proxyPassword;
+
+    @Getter(AccessLevel.NONE)
+    private RedactionConfig redactionConfig;
+
+    public RedactionConfig getRedactionConfig() {
+        if (redactionConfig != null) {
+            return redactionConfig;
+        }
+        Map<String, Object> allRuleProperties = EnvironmentUtils.getPropertiesStartingWith(
+            environment,
+            "services.opentelemetry.redactionRules"
+        );
+        if (allRuleProperties.isEmpty()) {
+            return redactionConfig = RedactionConfig.EMPTY;
+        }
+        List<RedactionRule> rules = new ArrayList<>();
+        int ruleIndex = 0;
+        while (true) {
+            String rulePrefix = "services.opentelemetry.redactionRules[" + ruleIndex + "].";
+            String pattern = getString(allRuleProperties, rulePrefix + "attributeNamePattern");
+            if (pattern == null) break;
+            rules.add(buildRule(allRuleProperties, rulePrefix, pattern));
+            ruleIndex++;
+        }
+        String defaultReplacement = getString(
+            EnvironmentUtils.getPropertiesStartingWith(environment, "services.opentelemetry.redactionDefaultReplacement"),
+            "services.opentelemetry.redactionDefaultReplacement"
+        );
+        return redactionConfig = rules.isEmpty() ? RedactionConfig.EMPTY : new RedactionConfig(rules, defaultReplacement);
+    }
+
+    private RedactionRule buildRule(Map<String, Object> ruleProperties, String rulePrefix, String pattern) {
+        return new RedactionRule(
+            pattern,
+            buildMaskingStrategy(ruleProperties, rulePrefix),
+            getString(ruleProperties, rulePrefix + "valuePattern")
+        );
+    }
+
+    private MaskingStrategy buildMaskingStrategy(Map<String, Object> ruleProperties, String rulePrefix) {
+        String type = getString(ruleProperties, rulePrefix + "maskingStrategy.type");
+        if ("PARTIAL".equalsIgnoreCase(type)) {
+            int prefixLength = getInt(ruleProperties, rulePrefix + "maskingStrategy.prefixLength", 0);
+            int suffixLength = getInt(ruleProperties, rulePrefix + "maskingStrategy.suffixLength", 0);
+            String maskChar = Objects.requireNonNullElse(getString(ruleProperties, rulePrefix + "maskingStrategy.replacement"), "*");
+            return MaskingStrategy.partialMask(prefixLength, suffixLength, maskChar);
+        }
+        String replacement = getString(ruleProperties, rulePrefix + "maskingStrategy.replacement");
+        return replacement != null ? MaskingStrategy.fullMask(replacement) : MaskingStrategy.DEFAULT;
+    }
+
+    private static String getString(Map<String, Object> properties, String key) {
+        Object value = properties.get(key);
+        if (value == null) return null;
+        String str = value.toString().strip();
+        return str.isBlank() ? null : str;
+    }
+
+    private static int getInt(Map<String, Object> properties, String key, int defaultValue) {
+        String value = getString(properties, key);
+        if (value == null) return defaultValue;
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException ignored) {
+            return defaultValue;
+        }
+    }
 
     private List<String> getPropertyList(final String key, final String fallbackKey) {
         Map<String, Object> properties = EnvironmentUtils.getPropertiesStartingWith(environment, key);

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/redact/CompiledRedactionRule.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/redact/CompiledRedactionRule.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.opentelemetry.exporter.redact;
+
+import io.gravitee.node.api.opentelemetry.redaction.FullMaskingStrategy;
+import io.gravitee.node.api.opentelemetry.redaction.MaskingStrategy;
+import io.gravitee.node.api.opentelemetry.redaction.PartialMaskingStrategy;
+import io.gravitee.node.api.opentelemetry.redaction.RedactionRule;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+final class CompiledRedactionRule {
+
+    private static final String REGEX_PREFIX = "regex:";
+    private static final Pattern GLOB_WILDCARD = Pattern.compile("\\*\\*|\\*");
+
+    private final Pattern keyPattern;
+    private final Pattern valuePattern;
+    private final MaskingStrategy maskingStrategy;
+    private final String effectiveFullMaskReplacement;
+
+    CompiledRedactionRule(RedactionRule rule, String configDefaultReplacement) {
+        this.maskingStrategy = rule.maskingStrategy();
+        this.effectiveFullMaskReplacement =
+            switch (rule.maskingStrategy()) {
+                case FullMaskingStrategy full -> (full == MaskingStrategy.DEFAULT) ? configDefaultReplacement : full.replacement();
+                case PartialMaskingStrategy partial -> null;
+            };
+
+        String raw = rule.attributeNamePattern();
+        if (isShortName(raw)) {
+            raw = REGEX_PREFIX + "(.*[._])?" + Pattern.quote(raw) + "$";
+        }
+        String keyRegex = raw.startsWith(REGEX_PREFIX) ? raw.substring(REGEX_PREFIX.length()) : globToRegex(raw);
+        try {
+            this.keyPattern = Pattern.compile(keyRegex, Pattern.CASE_INSENSITIVE);
+        } catch (PatternSyntaxException e) {
+            throw new IllegalArgumentException(
+                "Invalid key pattern '" + rule.attributeNamePattern() + "' in RedactionRule: " + e.getMessage(),
+                e
+            );
+        }
+
+        if (rule.valuePattern() != null) {
+            try {
+                this.valuePattern = Pattern.compile(rule.valuePattern());
+            } catch (PatternSyntaxException e) {
+                throw new IllegalArgumentException(
+                    "Invalid value pattern '" +
+                    rule.valuePattern() +
+                    "' in RedactionRule for key '" +
+                    rule.attributeNamePattern() +
+                    "': " +
+                    e.getMessage(),
+                    e
+                );
+            }
+        } else {
+            this.valuePattern = null;
+        }
+    }
+
+    private static boolean isShortName(String s) {
+        return !s.contains(".") && !s.contains("*") && !s.startsWith(REGEX_PREFIX);
+    }
+
+    boolean shouldRedact(String attributeKey, String attributeValue) {
+        if (!keyPattern.matcher(attributeKey).matches()) {
+            return false;
+        }
+        if (valuePattern == null) {
+            return true;
+        }
+        if (attributeValue == null) {
+            return false;
+        }
+        return valuePattern.matcher(attributeValue).find();
+    }
+
+    String applyRedaction(String value) {
+        return switch (maskingStrategy) {
+            case FullMaskingStrategy full -> effectiveFullMaskReplacement;
+            case PartialMaskingStrategy partial -> {
+                String maskChar = partial.maskChar();
+                if (value == null) yield maskChar;
+                int prefix = partial.prefixLength();
+                int suffix = partial.suffixLength();
+                if (value.length() <= prefix + suffix) yield maskChar.repeat(value.length());
+                yield value.substring(0, prefix) +
+                maskChar.repeat(value.length() - prefix - suffix) +
+                value.substring(value.length() - suffix);
+            }
+        };
+    }
+
+    private static String globToRegex(String glob) {
+        var sb = new StringBuilder("^");
+        var m = GLOB_WILDCARD.matcher(glob);
+        int last = 0;
+        while (m.find()) {
+            sb.append(Pattern.quote(glob.substring(last, m.start())));
+            sb.append(m.end() - m.start() == 2 ? ".*" : "[^.]*");
+            last = m.end();
+        }
+        sb.append(Pattern.quote(glob.substring(last)));
+        return sb.append("$").toString();
+    }
+}

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/redact/RedactSpanExporter.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/redact/RedactSpanExporter.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.opentelemetry.exporter.redact;
+
+import io.gravitee.node.api.opentelemetry.redaction.RedactionConfig;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.data.EventData;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public final class RedactSpanExporter implements SpanExporter {
+
+    private final SpanExporter delegate;
+    private final SpanAttributeRedactor redactor;
+
+    public RedactSpanExporter(SpanExporter delegate, RedactionConfig config) {
+        this.delegate = delegate;
+        this.redactor = new SpanAttributeRedactor(config);
+    }
+
+    /** Redacts resource attributes at tracer-creation time. Returns the original if no rule matches. */
+    public Resource redactResource(Resource resource) {
+        Attributes redacted = redactor.redact(resource.getAttributes());
+        if (redacted == resource.getAttributes()) {
+            return resource;
+        }
+        return Resource.create(redacted, resource.getSchemaUrl());
+    }
+
+    @Override
+    public CompletableResultCode export(Collection<SpanData> spans) {
+        List<SpanData> spanList = (spans instanceof List<SpanData> l) ? l : new ArrayList<>(spans);
+        List<SpanData> result = null;
+
+        for (int i = 0, n = spanList.size(); i < n; i++) {
+            SpanData span = spanList.get(i);
+            Attributes spanAttrs = span.getAttributes();
+            Attributes redactedAttrs = redactor.redact(spanAttrs);
+            List<EventData> redactedEvents = redactor.redactEvents(span.getEvents());
+            boolean changed = redactedAttrs != spanAttrs || redactedEvents != span.getEvents();
+
+            if (changed && result == null) {
+                result = new ArrayList<>(n);
+                for (int j = 0; j < i; j++) {
+                    result.add(spanList.get(j));
+                }
+            }
+            if (result != null) {
+                result.add(changed ? new RedactedSpanData(span, redactedAttrs, redactedEvents) : span);
+            }
+        }
+        return delegate.export(result != null ? result : spans);
+    }
+
+    @Override
+    public CompletableResultCode flush() {
+        return delegate.flush();
+    }
+
+    @Override
+    public CompletableResultCode shutdown() {
+        return delegate.shutdown();
+    }
+}

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/redact/RedactedSpanData.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/redact/RedactedSpanData.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.opentelemetry.exporter.redact;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.trace.data.DelegatingSpanData;
+import io.opentelemetry.sdk.trace.data.EventData;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import java.util.List;
+
+final class RedactedSpanData extends DelegatingSpanData {
+
+    private final Attributes redactedAttributes;
+    private final List<EventData> redactedEvents;
+
+    RedactedSpanData(SpanData delegate, Attributes redactedAttributes, List<EventData> redactedEvents) {
+        super(delegate);
+        this.redactedAttributes = redactedAttributes;
+        this.redactedEvents = redactedEvents;
+    }
+
+    @Override
+    public Attributes getAttributes() {
+        return redactedAttributes;
+    }
+
+    @Override
+    public List<EventData> getEvents() {
+        return redactedEvents;
+    }
+}

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/redact/SpanAttributeRedactor.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/redact/SpanAttributeRedactor.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.opentelemetry.exporter.redact;
+
+import io.gravitee.node.api.opentelemetry.redaction.RedactionConfig;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.sdk.trace.data.EventData;
+import java.util.ArrayList;
+import java.util.List;
+
+final class SpanAttributeRedactor {
+
+    private final List<CompiledRedactionRule> rules;
+
+    SpanAttributeRedactor(RedactionConfig config) {
+        String defaultReplacement = config.defaultReplacement();
+        this.rules = config.rules().stream().map(rule -> new CompiledRedactionRule(rule, defaultReplacement)).toList();
+    }
+
+    boolean hasRules() {
+        return !rules.isEmpty();
+    }
+
+    List<EventData> redactEvents(List<EventData> events) {
+        if (events.isEmpty()) {
+            return events;
+        }
+        List<EventData> result = null;
+        for (int i = 0; i < events.size(); i++) {
+            EventData original = events.get(i);
+            Attributes redactedAttrs = redact(original.getAttributes());
+            if (redactedAttrs != original.getAttributes() && result == null) {
+                result = new ArrayList<>(events.size());
+                for (int j = 0; j < i; j++) {
+                    result.add(events.get(j));
+                }
+            }
+            if (result != null) {
+                result.add(
+                    redactedAttrs != original.getAttributes()
+                        ? EventData.create(original.getEpochNanos(), original.getName(), redactedAttrs, original.getTotalAttributeCount())
+                        : original
+                );
+            }
+        }
+        return result != null ? result : events;
+    }
+
+    Attributes redact(Attributes original) {
+        if (original == null || original.isEmpty()) {
+            return original;
+        }
+        var map = original.asMap();
+        // Phase 1: fast scan with no allocation — return original if nothing matches
+        boolean anyMatch = false;
+        for (var entry : map.entrySet()) {
+            if (findRule(entry.getKey().getKey(), valueAsString(entry.getValue())) != null) {
+                anyMatch = true;
+                break;
+            }
+        }
+        if (!anyMatch) {
+            return original;
+        }
+        // Phase 2: build redacted copy — allocates only when at least one rule matched
+        AttributesBuilder builder = Attributes.builder();
+        for (var entry : map.entrySet()) {
+            String strValue = valueAsString(entry.getValue());
+            CompiledRedactionRule rule = findRule(entry.getKey().getKey(), strValue);
+            if (rule != null) {
+                builder.put(AttributeKey.stringKey(entry.getKey().getKey()), rule.applyRedaction(strValue));
+            } else {
+                putRaw(builder, entry.getKey(), entry.getValue());
+            }
+        }
+        return builder.build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> void putRaw(AttributesBuilder builder, AttributeKey<T> key, Object value) {
+        builder.put(key, (T) value);
+    }
+
+    private CompiledRedactionRule findRule(String attributeKey, String attributeValue) {
+        for (CompiledRedactionRule rule : rules) {
+            if (rule.shouldRedact(attributeKey, attributeValue)) {
+                return rule;
+            }
+        }
+        return null;
+    }
+
+    private static String valueAsString(Object value) {
+        return value != null ? value.toString() : null;
+    }
+}

--- a/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/OpenTelemetryTracerIntegrationTest.java
+++ b/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/OpenTelemetryTracerIntegrationTest.java
@@ -21,6 +21,8 @@ import static org.awaitility.Awaitility.await;
 
 import io.gravitee.node.api.opentelemetry.Span;
 import io.gravitee.node.api.opentelemetry.internal.InternalRequest;
+import io.gravitee.node.api.opentelemetry.redaction.RedactionConfig;
+import io.gravitee.node.api.opentelemetry.redaction.RedactionRule;
 import io.gravitee.node.opentelemetry.configuration.OpenTelemetryConfiguration;
 import io.gravitee.node.opentelemetry.configuration.Protocol;
 import io.gravitee.node.opentelemetry.exporter.SpanExporterFactory;
@@ -234,6 +236,82 @@ public class OpenTelemetryTracerIntegrationTest {
 
                 assertThat(response.statusCode()).isEqualTo(200);
                 assertData(response.bodyAsJsonObject(), false, true, true);
+            });
+    }
+
+    @Test
+    void should_redact_configured_span_attributes_before_export(Vertx vertx) throws Exception {
+        var openTelemetryConfiguration = OpenTelemetryConfiguration
+            .builder()
+            .endpoint("http://localhost:" + container.getCollectorGrpcPort())
+            .tracesEnabled(true)
+            .protocol(Protocol.GRPC.value())
+            .environment(new MockEnvironment())
+            .build();
+
+        final var serviceName = "jaeger_grpc_redaction";
+        var redactionConfig = new RedactionConfig(List.of(new RedactionRule("custom")));
+
+        OpenTelemetryFactory openTelemetryFactory = openTelemetryFactory(vertx, openTelemetryConfiguration);
+        var tracer = openTelemetryFactory.createTracer(
+            "serviceInstanceId",
+            serviceName,
+            "serviceNamespace",
+            "serviceVersion",
+            List.of(new VertxHttpInstrumenterTracerFactory(), new InternalInstrumenterTracerFactory()),
+            redactionConfig
+        );
+        tracer.start();
+
+        Context vertxContext = vertx.getOrCreateContext();
+        Context duplicatedContext = VertxContext.createNewDuplicatedContext(vertxContext);
+        duplicatedContext.runOnContext(v -> {
+            var span = tracer.startSpanFrom(
+                duplicatedContext,
+                new InternalRequest("my-span", Map.of("custom", "secret-value", "http.method", "GET"))
+            );
+            tracer.end(duplicatedContext, span);
+        });
+
+        await()
+            .atMost(30, SECONDS)
+            .untilAsserted(() -> {
+                var client = container.client(vertx);
+                var response = client
+                    .get("/api/traces")
+                    .addQueryParam("service", serviceName)
+                    .send()
+                    .toCompletionStage()
+                    .toCompletableFuture()
+                    .get();
+
+                assertThat(response.statusCode()).isEqualTo(200);
+
+                var data = response.bodyAsJsonObject().getJsonArray("data");
+                assertThat(data).isNotEmpty();
+
+                JsonArray tags = data.getJsonObject(0).getJsonArray("spans").getJsonObject(0).getJsonArray("tags");
+                // Matching attribute must be redacted
+                assertThat(
+                    tags
+                        .stream()
+                        .anyMatch(t ->
+                            ((JsonObject) t).getString("key").equals("custom") &&
+                            ((JsonObject) t).getString("value").equals(RedactionRule.DEFAULT_REPLACEMENT)
+                        )
+                )
+                    .as("Attribute 'custom' should be redacted to '%s'", RedactionRule.DEFAULT_REPLACEMENT)
+                    .isTrue();
+                // Non-matching attribute must pass through unchanged
+                assertThat(
+                    tags
+                        .stream()
+                        .anyMatch(t ->
+                            ((JsonObject) t).getString("key").equals("http.method") && ((JsonObject) t).getString("value").equals("GET")
+                        )
+                )
+                    .as("Non-matching attribute 'http.method' should not be redacted")
+                    .isTrue();
             });
     }
 

--- a/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/configuration/OpenTelemetryConfigurationTest.java
+++ b/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/configuration/OpenTelemetryConfigurationTest.java
@@ -2,11 +2,17 @@ package io.gravitee.node.opentelemetry.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.gravitee.node.api.opentelemetry.redaction.FullMaskingStrategy;
+import io.gravitee.node.api.opentelemetry.redaction.MaskingStrategy;
+import io.gravitee.node.api.opentelemetry.redaction.PartialMaskingStrategy;
+import io.gravitee.node.api.opentelemetry.redaction.RedactionConfig;
+import io.gravitee.node.api.opentelemetry.redaction.RedactionRule;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.internal.AttributesMap;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.env.MockEnvironment;
 
@@ -83,5 +89,163 @@ class OpenTelemetryConfigurationTest {
     void should_get_empty_property_list() {
         assertThat(underTest.getKeystorePemCerts()).isEmpty();
         assertThat(underTest.getKeystorePemKeys()).isEmpty();
+    }
+
+    // -------------------------------------------------------------------------
+    // getRedactionConfig
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class GetRedactionConfig {
+
+        @Test
+        void returns_empty_config_when_no_rules_defined() {
+            assertThat(underTest.getRedactionConfig()).isSameAs(RedactionConfig.EMPTY);
+        }
+
+        @Test
+        void reads_single_full_mask_rule() {
+            environment.setProperty("services.opentelemetry.redactionRules[0].attributeNamePattern", "enduser.id");
+            environment.setProperty("services.opentelemetry.redactionRules[0].maskingStrategy.type", "FULL");
+            environment.setProperty("services.opentelemetry.redactionRules[0].maskingStrategy.replacement", "[HIDDEN]");
+
+            RedactionConfig config = underTest.getRedactionConfig();
+
+            assertThat(config.rules()).hasSize(1);
+            RedactionRule rule = config.rules().get(0);
+            assertThat(rule.attributeNamePattern()).isEqualTo("enduser.id");
+            assertThat(rule.maskingStrategy()).isInstanceOf(FullMaskingStrategy.class);
+            assertThat(((FullMaskingStrategy) rule.maskingStrategy()).replacement()).isEqualTo("[HIDDEN]");
+        }
+
+        @Test
+        void full_rule_without_replacement_uses_DEFAULT_sentinel_so_config_defaultReplacement_applies() {
+            // Critical: must produce MaskingStrategy.DEFAULT (==), not fullMask(), so the
+            // config-level defaultReplacement is honoured at evaluation time in CompiledRedactionRule.
+            environment.setProperty("services.opentelemetry.redactionRules[0].attributeNamePattern", "enduser.id");
+            environment.setProperty("services.opentelemetry.redactionRules[0].maskingStrategy.type", "FULL");
+            environment.setProperty("services.opentelemetry.redactionDefaultReplacement", "[CONFIG_DEFAULT]");
+
+            RedactionConfig config = underTest.getRedactionConfig();
+
+            assertThat(config.rules().get(0).maskingStrategy()).isSameAs(MaskingStrategy.DEFAULT);
+            assertThat(config.defaultReplacement()).isEqualTo("[CONFIG_DEFAULT]");
+        }
+
+        @Test
+        void full_rule_with_no_masking_strategy_block_defaults_to_DEFAULT_sentinel() {
+            environment.setProperty("services.opentelemetry.redactionRules[0].attributeNamePattern", "enduser.id");
+
+            RedactionConfig config = underTest.getRedactionConfig();
+
+            assertThat(config.rules().get(0).maskingStrategy()).isSameAs(MaskingStrategy.DEFAULT);
+        }
+
+        @Test
+        void reads_partial_mask_rule() {
+            environment.setProperty("services.opentelemetry.redactionRules[0].attributeNamePattern", "payment.card");
+            environment.setProperty("services.opentelemetry.redactionRules[0].maskingStrategy.type", "PARTIAL");
+            environment.setProperty("services.opentelemetry.redactionRules[0].maskingStrategy.prefixLength", "0");
+            environment.setProperty("services.opentelemetry.redactionRules[0].maskingStrategy.suffixLength", "4");
+            environment.setProperty("services.opentelemetry.redactionRules[0].maskingStrategy.replacement", "X");
+
+            RedactionConfig config = underTest.getRedactionConfig();
+
+            RedactionRule rule = config.rules().get(0);
+            assertThat(rule.maskingStrategy()).isInstanceOf(PartialMaskingStrategy.class);
+            PartialMaskingStrategy partial = (PartialMaskingStrategy) rule.maskingStrategy();
+            assertThat(partial.prefixLength()).isZero();
+            assertThat(partial.suffixLength()).isEqualTo(4);
+            assertThat(partial.maskChar()).isEqualTo("X");
+        }
+
+        @Test
+        void reads_value_pattern() {
+            environment.setProperty("services.opentelemetry.redactionRules[0].attributeNamePattern", "*");
+            environment.setProperty("services.opentelemetry.redactionRules[0].valuePattern", "(5[1-5][0-9]{14})");
+
+            RedactionConfig config = underTest.getRedactionConfig();
+
+            assertThat(config.rules().get(0).valuePattern()).isEqualTo("(5[1-5][0-9]{14})");
+        }
+
+        @Test
+        void reads_multiple_rules_in_order() {
+            environment.setProperty("services.opentelemetry.redactionRules[0].attributeNamePattern", "enduser.id");
+            environment.setProperty("services.opentelemetry.redactionRules[0].maskingStrategy.type", "FULL");
+            environment.setProperty("services.opentelemetry.redactionRules[1].attributeNamePattern", "payment.card");
+            environment.setProperty("services.opentelemetry.redactionRules[1].maskingStrategy.type", "PARTIAL");
+            environment.setProperty("services.opentelemetry.redactionRules[1].maskingStrategy.suffixLength", "4");
+
+            RedactionConfig config = underTest.getRedactionConfig();
+
+            assertThat(config.rules()).hasSize(2);
+            assertThat(config.rules().get(0).attributeNamePattern()).isEqualTo("enduser.id");
+            assertThat(config.rules().get(1).attributeNamePattern()).isEqualTo("payment.card");
+        }
+
+        @Test
+        void stops_reading_rules_at_first_missing_index() {
+            // rules[0] and [2] defined but [1] is missing — should read only [0]
+            environment.setProperty("services.opentelemetry.redactionRules[0].attributeNamePattern", "enduser.id");
+            environment.setProperty("services.opentelemetry.redactionRules[2].attributeNamePattern", "payment.card");
+
+            RedactionConfig config = underTest.getRedactionConfig();
+
+            assertThat(config.rules()).hasSize(1);
+        }
+
+        @Test
+        void result_is_cached_across_calls() {
+            environment.setProperty("services.opentelemetry.redactionRules[0].attributeNamePattern", "enduser.id");
+
+            assertThat(underTest.getRedactionConfig()).isSameAs(underTest.getRedactionConfig());
+        }
+
+        @Test
+        void merge_yaml_rules_with_explicit_rules() {
+            environment.setProperty("services.opentelemetry.redactionRules[0].attributeNamePattern", "enduser.id");
+
+            RedactionConfig yamlConfig = underTest.getRedactionConfig();
+            RedactionConfig explicit = new RedactionConfig(java.util.List.of(new RedactionRule("payment.card")));
+
+            RedactionConfig merged = yamlConfig.mergeWith(explicit);
+
+            assertThat(merged.rules()).hasSize(2);
+            assertThat(merged.rules().get(0).attributeNamePattern()).isEqualTo("enduser.id");
+            assertThat(merged.rules().get(1).attributeNamePattern()).isEqualTo("payment.card");
+        }
+
+        @Test
+        void merge_returns_yaml_config_when_explicit_is_empty() {
+            environment.setProperty("services.opentelemetry.redactionRules[0].attributeNamePattern", "enduser.id");
+
+            RedactionConfig yamlConfig = underTest.getRedactionConfig();
+            RedactionConfig merged = yamlConfig.mergeWith(RedactionConfig.EMPTY);
+
+            assertThat(merged).isSameAs(yamlConfig);
+        }
+
+        @Test
+        void merge_returns_explicit_config_when_yaml_is_empty() {
+            RedactionConfig explicit = new RedactionConfig(java.util.List.of(new RedactionRule("payment.card")));
+            RedactionConfig merged = RedactionConfig.EMPTY.mergeWith(explicit);
+
+            assertThat(merged).isSameAs(explicit);
+        }
+
+        @Test
+        void merge_preserves_yaml_default_replacement_when_product_config_has_no_explicit_replacement() {
+            environment.setProperty("services.opentelemetry.redactionRules[0].attributeNamePattern", "enduser.id");
+            environment.setProperty("services.opentelemetry.redactionDefaultReplacement", "[YAML_DEFAULT]");
+
+            RedactionConfig yamlConfig = underTest.getRedactionConfig();
+            // Product config has no explicit defaultReplacement — compact constructor normalises to "[REDACTED]"
+            RedactionConfig productConfig = new RedactionConfig(java.util.List.of(new RedactionRule("payment.card")));
+
+            RedactionConfig merged = yamlConfig.mergeWith(productConfig);
+
+            assertThat(merged.defaultReplacement()).isEqualTo("[YAML_DEFAULT]");
+        }
     }
 }

--- a/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/exporter/redact/RedactSpanExporterTest.java
+++ b/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/exporter/redact/RedactSpanExporterTest.java
@@ -1,0 +1,380 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.opentelemetry.exporter.redact;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.node.api.opentelemetry.internal.InternalRequest;
+import io.gravitee.node.api.opentelemetry.redaction.RedactionConfig;
+import io.gravitee.node.api.opentelemetry.redaction.RedactionRule;
+import io.gravitee.node.opentelemetry.tracer.instrumentation.internal.InternalInstrumenterTracer;
+import io.gravitee.node.opentelemetry.tracer.vertx.VertxContext;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.testing.trace.TestSpanData;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.EventData;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.data.StatusData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxExtension;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(VertxExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class RedactSpanExporterTest {
+
+    private InMemorySpanExporter inMemoryExporter;
+
+    @BeforeEach
+    void setUp() {
+        inMemoryExporter = InMemorySpanExporter.create();
+    }
+
+    @Test
+    void should_redact_span_attribute_matching_rule(Vertx vertx) {
+        var tracer = buildTracer(new RedactionConfig(List.of(new RedactionRule("custom"))));
+        var vertxCtx = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+
+        var span = tracer.startSpan(
+            vertxCtx,
+            InternalRequest.builder().name("test-span").attributes(Map.of("custom", "secret-value")).build(),
+            false,
+            null
+        );
+        tracer.endSpan(vertxCtx, span, null, null);
+
+        List<SpanData> spans = inMemoryExporter.getFinishedSpanItems();
+        assertThat(spans).hasSize(1);
+        assertThat(spans.get(0).getAttributes().get(AttributeKey.stringKey("custom"))).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+    }
+
+    @Test
+    void should_not_redact_non_matching_span_attribute(Vertx vertx) {
+        var tracer = buildTracer(new RedactionConfig(List.of(new RedactionRule("enduser.id"))));
+        var vertxCtx = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+
+        var span = tracer.startSpan(
+            vertxCtx,
+            InternalRequest.builder().name("test-span").attributes(Map.of("custom", "value")).build(),
+            false,
+            null
+        );
+        tracer.endSpan(vertxCtx, span, null, null);
+
+        List<SpanData> spans = inMemoryExporter.getFinishedSpanItems();
+        assertThat(spans).hasSize(1);
+        assertThat(spans.get(0).getAttributes().get(AttributeKey.stringKey("custom"))).isEqualTo("value");
+    }
+
+    @Test
+    void should_redact_attributes_matching_glob_pattern(Vertx vertx) {
+        var tracer = buildTracer(new RedactionConfig(List.of(new RedactionRule("http.request.header.*"))));
+        var vertxCtx = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+
+        var request = InternalRequest
+            .builder()
+            .name("test-span")
+            .attributes(
+                Map.of("http.request.header.authorization", "Bearer token", "http.request.header.x-api-key", "my-key", "http.method", "GET")
+            )
+            .build();
+        var span = tracer.startSpan(vertxCtx, request, false, null);
+        tracer.endSpan(vertxCtx, span, null, null);
+
+        List<SpanData> spans = inMemoryExporter.getFinishedSpanItems();
+        assertThat(spans).hasSize(1);
+        var attrs = spans.get(0).getAttributes();
+        assertThat(attrs.get(AttributeKey.stringKey("http.request.header.authorization"))).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+        assertThat(attrs.get(AttributeKey.stringKey("http.request.header.x-api-key"))).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+        assertThat(attrs.get(AttributeKey.stringKey("http.method"))).isEqualTo("GET");
+    }
+
+    @Test
+    void should_delegate_flush() {
+        try (var exporter = new RedactSpanExporter(inMemoryExporter, new RedactionConfig(List.of(new RedactionRule("anything"))))) {
+            assertThat(exporter.flush().isSuccess()).isTrue();
+        }
+    }
+
+    @Test
+    void should_delegate_shutdown() {
+        try (var exporter = new RedactSpanExporter(inMemoryExporter, new RedactionConfig(List.of(new RedactionRule("anything"))))) {
+            assertThat(exporter.shutdown().isSuccess()).isTrue();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Export fast-path: original collection returned when no span changes
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class ExportCollectionIdentity {
+
+        @Test
+        void should_return_original_collection_reference_when_no_span_matches() {
+            // Arrange: exporter with a rule that will not match any attribute
+            AtomicReference<Collection<SpanData>> received = new AtomicReference<>();
+            SpanExporter tracking = capturingExporter(received);
+            var exporter = new RedactSpanExporter(tracking, new RedactionConfig(List.of(new RedactionRule("never.matches.key"))));
+
+            var span = testSpan("http.method", "GET");
+            var original = List.of(span);
+
+            // Act
+            exporter.export(original);
+
+            // Assert: the exact same collection reference was forwarded — zero allocation
+            assertThat(received.get()).isSameAs(original);
+        }
+
+        @Test
+        void should_only_wrap_spans_that_need_redaction() {
+            // Arrange: two spans — only the second has a matching attribute
+            AtomicReference<Collection<SpanData>> received = new AtomicReference<>();
+            SpanExporter tracking = capturingExporter(received);
+            var exporter = new RedactSpanExporter(tracking, new RedactionConfig(List.of(new RedactionRule("secret.key"))));
+
+            SpanData safe = testSpan("http.method", "GET");
+            SpanData sensitive = testSpan("secret.key", "password");
+
+            // Act
+            exporter.export(List.of(safe, sensitive));
+
+            // Assert: result list has two entries
+            var resultList = new ArrayList<>(received.get());
+            assertThat(resultList).hasSize(2);
+            // First span was unchanged — original reference is reused
+            assertThat(resultList.get(0)).isSameAs(safe);
+            // Second span was wrapped — reference is NOT the original
+            assertThat(resultList.get(1)).isNotSameAs(sensitive);
+            assertThat(resultList.get(1).getAttributes().get(AttributeKey.stringKey("secret.key")))
+                .isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Event attribute redaction through export()
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class EventRedaction {
+
+        @Test
+        void should_redact_event_attribute_matching_rule() {
+            // Span has no matching span-level attribute; the matching key is on a span event.
+            AtomicReference<Collection<SpanData>> received = new AtomicReference<>();
+            var exporter = new RedactSpanExporter(
+                capturingExporter(received),
+                new RedactionConfig(List.of(new RedactionRule("secret.key")))
+            );
+
+            SpanData span = TestSpanData
+                .builder()
+                .setName("test")
+                .setKind(SpanKind.INTERNAL)
+                .setStartEpochNanos(0)
+                .setEndEpochNanos(1)
+                .setHasEnded(true)
+                .setStatus(StatusData.ok())
+                .setAttributes(Attributes.empty())
+                .setEvents(
+                    List.of(EventData.create(1L, "request-received", Attributes.of(AttributeKey.stringKey("secret.key"), "password"), 1))
+                )
+                .build();
+
+            exporter.export(List.of(span));
+
+            var result = new ArrayList<>(received.get());
+            assertThat(result).hasSize(1);
+            // Span was wrapped — not the original reference
+            assertThat(result.get(0)).isNotSameAs(span);
+            // Event attribute is redacted
+            assertThat(result.get(0).getEvents().get(0).getAttributes().get(AttributeKey.stringKey("secret.key")))
+                .isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+        }
+
+        @Test
+        void should_return_original_collection_when_event_attributes_do_not_match() {
+            AtomicReference<Collection<SpanData>> received = new AtomicReference<>();
+            var exporter = new RedactSpanExporter(
+                capturingExporter(received),
+                new RedactionConfig(List.of(new RedactionRule("never.matches")))
+            );
+
+            SpanData span = TestSpanData
+                .builder()
+                .setName("test")
+                .setKind(SpanKind.INTERNAL)
+                .setStartEpochNanos(0)
+                .setEndEpochNanos(1)
+                .setHasEnded(true)
+                .setStatus(StatusData.ok())
+                .setAttributes(Attributes.empty())
+                .setEvents(List.of(EventData.create(1L, "safe-event", Attributes.of(AttributeKey.stringKey("safe"), "value"), 1)))
+                .build();
+
+            var original = List.of(span);
+            exporter.export(original);
+
+            // No match — original collection reference forwarded unchanged
+            assertThat(received.get()).isSameAs(original);
+        }
+
+        @Test
+        void should_preserve_unchanged_events_by_reference_when_only_middle_event_matches() {
+            // Events: [safe, sensitive, safe] — only the second changes.
+            // Verifies the lazy-backfill logic in redactEvents(): first and third events
+            // must be the exact same EventData instances as the originals.
+            AtomicReference<Collection<SpanData>> received = new AtomicReference<>();
+            var exporter = new RedactSpanExporter(
+                capturingExporter(received),
+                new RedactionConfig(List.of(new RedactionRule("secret.key")))
+            );
+
+            EventData safeEvent1 = EventData.create(1L, "evt1", Attributes.of(AttributeKey.stringKey("safe"), "a"), 1);
+            EventData sensitiveEvent = EventData.create(2L, "evt2", Attributes.of(AttributeKey.stringKey("secret.key"), "password"), 1);
+            EventData safeEvent2 = EventData.create(3L, "evt3", Attributes.of(AttributeKey.stringKey("safe"), "b"), 1);
+
+            SpanData span = TestSpanData
+                .builder()
+                .setName("test")
+                .setKind(SpanKind.INTERNAL)
+                .setStartEpochNanos(0)
+                .setEndEpochNanos(1)
+                .setHasEnded(true)
+                .setStatus(StatusData.ok())
+                .setAttributes(Attributes.empty())
+                .setEvents(List.of(safeEvent1, sensitiveEvent, safeEvent2))
+                .build();
+
+            exporter.export(List.of(span));
+
+            var events = new ArrayList<>(received.get()).get(0).getEvents();
+            assertThat(events).hasSize(3);
+            // First and third are unchanged — same references
+            assertThat(events.get(0)).isSameAs(safeEvent1);
+            assertThat(events.get(2)).isSameAs(safeEvent2);
+            // Second is a new EventData with the redacted value
+            assertThat(events.get(1)).isNotSameAs(sensitiveEvent);
+            assertThat(events.get(1).getAttributes().get(AttributeKey.stringKey("secret.key")))
+                .isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // redactResource instance method
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class RedactResourceMethod {
+
+        @Test
+        void should_redact_resource_attribute_matching_rule() {
+            var exporter = new RedactSpanExporter(inMemoryExporter, new RedactionConfig(List.of(new RedactionRule("hostname"))));
+            var resource = Resource.create(Attributes.of(AttributeKey.stringKey("hostname"), "prod-host-01"));
+
+            var result = exporter.redactResource(resource);
+
+            assertThat(result.getAttributes().get(AttributeKey.stringKey("hostname"))).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+        }
+
+        @Test
+        void should_return_same_resource_reference_when_no_rule_matches() {
+            var exporter = new RedactSpanExporter(inMemoryExporter, new RedactionConfig(List.of(new RedactionRule("never.matches"))));
+            var resource = Resource.create(Attributes.of(AttributeKey.stringKey("hostname"), "prod-host-01"));
+
+            assertThat(exporter.redactResource(resource)).isSameAs(resource);
+        }
+
+        @Test
+        void should_preserve_schema_url_when_resource_attribute_is_redacted() {
+            var exporter = new RedactSpanExporter(inMemoryExporter, new RedactionConfig(List.of(new RedactionRule("hostname"))));
+            var schemaUrl = "https://opentelemetry.io/schemas/1.21.0";
+            var resource = Resource.create(Attributes.of(AttributeKey.stringKey("hostname"), "prod-host-01"), schemaUrl);
+
+            var result = exporter.redactResource(resource);
+
+            assertThat(result.getSchemaUrl()).isEqualTo(schemaUrl);
+            assertThat(result.getAttributes().get(AttributeKey.stringKey("hostname"))).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns a {@link SpanExporter} that captures every collection passed to {@link SpanExporter#export}
+     * into {@code sink}. SpanExporter has three abstract methods so it cannot be a lambda.
+     */
+    private static SpanExporter capturingExporter(AtomicReference<Collection<SpanData>> sink) {
+        return new SpanExporter() {
+            @Override
+            public io.opentelemetry.sdk.common.CompletableResultCode export(Collection<SpanData> spans) {
+                sink.set(spans);
+                return io.opentelemetry.sdk.common.CompletableResultCode.ofSuccess();
+            }
+
+            @Override
+            public io.opentelemetry.sdk.common.CompletableResultCode flush() {
+                return io.opentelemetry.sdk.common.CompletableResultCode.ofSuccess();
+            }
+
+            @Override
+            public io.opentelemetry.sdk.common.CompletableResultCode shutdown() {
+                return io.opentelemetry.sdk.common.CompletableResultCode.ofSuccess();
+            }
+        };
+    }
+
+    /** Builds a minimal {@link SpanData} with a single string attribute for unit tests. */
+    private static SpanData testSpan(String attrKey, String attrValue) {
+        return TestSpanData
+            .builder()
+            .setName("test")
+            .setKind(SpanKind.INTERNAL)
+            .setStartEpochNanos(0)
+            .setEndEpochNanos(1)
+            .setHasEnded(true)
+            .setStatus(StatusData.ok())
+            .setAttributes(Attributes.of(AttributeKey.stringKey(attrKey), attrValue))
+            .build();
+    }
+
+    private InternalInstrumenterTracer buildTracer(RedactionConfig config) {
+        var redactExporter = new RedactSpanExporter(inMemoryExporter, config);
+        SdkTracerProvider tracerProvider = SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(redactExporter)).build();
+        OpenTelemetrySdk openTelemetry = OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).build();
+        return new InternalInstrumenterTracer(openTelemetry);
+    }
+}

--- a/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/exporter/redact/SpanAttributeRedactorTest.java
+++ b/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/exporter/redact/SpanAttributeRedactorTest.java
@@ -1,0 +1,712 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.opentelemetry.exporter.redact;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.gravitee.node.api.opentelemetry.redaction.MaskingStrategy;
+import io.gravitee.node.api.opentelemetry.redaction.PartialMaskingStrategy;
+import io.gravitee.node.api.opentelemetry.redaction.RedactionConfig;
+import io.gravitee.node.api.opentelemetry.redaction.RedactionRule;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class SpanAttributeRedactorTest {
+
+    @Test
+    void should_return_same_attributes_instance_when_no_rules_configured() {
+        var redactor = new SpanAttributeRedactor(RedactionConfig.EMPTY);
+        var attrs = Attributes.of(AttributeKey.stringKey("foo"), "bar");
+
+        assertThat(redactor.redact(attrs)).isSameAs(attrs);
+    }
+
+    @Test
+    void should_return_same_attributes_instance_when_no_key_matches() {
+        var redactor = redactor("db.statement");
+        var attrs = Attributes.of(AttributeKey.stringKey("http.method"), "GET");
+
+        assertThat(redactor.redact(attrs)).isSameAs(attrs);
+    }
+
+    @Test
+    void should_redact_exact_matching_string_attribute() {
+        var redactor = redactor("enduser.id");
+        var attrs = Attributes.of(AttributeKey.stringKey("enduser.id"), "alice");
+
+        assertThat(redactor.redact(attrs).get(AttributeKey.stringKey("enduser.id"))).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+    }
+
+    @Test
+    void should_not_redact_non_matching_attribute() {
+        var redactor = redactor("enduser.id");
+        var attrs = Attributes.of(AttributeKey.stringKey("enduser.id"), "alice", AttributeKey.stringKey("http.method"), "GET");
+
+        var result = redactor.redact(attrs);
+
+        assertThat(result.get(AttributeKey.stringKey("enduser.id"))).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+        assertThat(result.get(AttributeKey.stringKey("http.method"))).isEqualTo("GET");
+    }
+
+    @Test
+    void should_redact_attributes_matching_single_star_glob() {
+        var redactor = redactor("http.request.header.*");
+        var attrs = Attributes.of(
+            AttributeKey.stringKey("http.request.header.authorization"),
+            "Bearer secret",
+            AttributeKey.stringKey("http.request.header.x-api-key"),
+            "key123",
+            AttributeKey.stringKey("http.method"),
+            "GET"
+        );
+
+        var result = redactor.redact(attrs);
+
+        assertThat(result.get(AttributeKey.stringKey("http.request.header.authorization"))).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+        assertThat(result.get(AttributeKey.stringKey("http.request.header.x-api-key"))).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+        assertThat(result.get(AttributeKey.stringKey("http.method"))).isEqualTo("GET");
+    }
+
+    @Test
+    void should_not_cross_dot_boundary_with_single_star() {
+        var redactor = redactor("http.request.*");
+        var attrs = Attributes.of(
+            AttributeKey.stringKey("http.request.header.authorization"),
+            "Bearer secret",
+            AttributeKey.stringKey("http.request.method"),
+            "GET"
+        );
+
+        var result = redactor.redact(attrs);
+
+        assertThat(result.get(AttributeKey.stringKey("http.request.header.authorization"))).isEqualTo("Bearer secret");
+        assertThat(result.get(AttributeKey.stringKey("http.request.method"))).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+    }
+
+    @Test
+    void double_star_alone_matches_all_attribute_keys() {
+        // "**" is the correct pattern to scan every attribute regardless of name
+        var rule = new RedactionRule("**", MaskingStrategy.DEFAULT, "5[1-5][0-9]{14}");
+        var redactor = new SpanAttributeRedactor(new RedactionConfig(java.util.List.of(rule)));
+        var attrs = Attributes.of(
+            AttributeKey.stringKey("payment.card.number"),
+            "5111111111111111",
+            AttributeKey.stringKey("http.method"),
+            "GET"
+        );
+
+        var result = redactor.redact(attrs);
+
+        assertThat(result.get(AttributeKey.stringKey("payment.card.number"))).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+        assertThat(result.get(AttributeKey.stringKey("http.method"))).isEqualTo("GET");
+    }
+
+    @Test
+    void single_star_alone_does_not_match_dotted_attribute_keys() {
+        // "*" only matches single-segment keys (no dots) — use "**" to match all
+        var redactor = redactor("*");
+        var attrs = Attributes.of(AttributeKey.stringKey("http.method"), "GET");
+
+        assertThat(redactor.redact(attrs)).isSameAs(attrs);
+    }
+
+    @Test
+    void should_cross_dot_boundary_with_double_star_glob() {
+        var redactor = redactor("http.request.**");
+        var attrs = Attributes.of(
+            AttributeKey.stringKey("http.request.header.authorization"),
+            "Bearer secret",
+            AttributeKey.stringKey("http.request.method"),
+            "GET",
+            AttributeKey.stringKey("http.response.status"),
+            "200"
+        );
+
+        var result = redactor.redact(attrs);
+
+        assertThat(result.get(AttributeKey.stringKey("http.request.header.authorization"))).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+        assertThat(result.get(AttributeKey.stringKey("http.request.method"))).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+        assertThat(result.get(AttributeKey.stringKey("http.response.status"))).isEqualTo("200");
+    }
+
+    @Test
+    void should_redact_attributes_matching_regex_pattern() {
+        var redactor = redactor("regex:enduser\\.(id|email)");
+        var attrs = Attributes.of(
+            AttributeKey.stringKey("enduser.id"),
+            "alice",
+            AttributeKey.stringKey("enduser.email"),
+            "alice@example.com",
+            AttributeKey.stringKey("enduser.role"),
+            "admin"
+        );
+
+        var result = redactor.redact(attrs);
+
+        assertThat(result.get(AttributeKey.stringKey("enduser.id"))).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+        assertThat(result.get(AttributeKey.stringKey("enduser.email"))).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+        assertThat(result.get(AttributeKey.stringKey("enduser.role"))).isEqualTo("admin");
+    }
+
+    @Test
+    void should_use_custom_replacement_when_configured() {
+        var redactor = new SpanAttributeRedactor(new RedactionConfig(List.of(new RedactionRule("enduser.id", "***"))));
+        var attrs = Attributes.of(AttributeKey.stringKey("enduser.id"), "alice");
+
+        assertThat(redactor.redact(attrs).get(AttributeKey.stringKey("enduser.id"))).isEqualTo("***");
+    }
+
+    @Test
+    void should_redact_long_attribute_as_string() {
+        var redactor = redactor("user.id");
+        var attrs = Attributes.of(AttributeKey.longKey("user.id"), 12345L);
+
+        var result = redactor.redact(attrs);
+
+        assertThat(result.get(AttributeKey.stringKey("user.id"))).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+        assertThat(result.get(AttributeKey.longKey("user.id"))).isNull();
+    }
+
+    @Test
+    void should_preserve_non_matching_long_attribute() {
+        var redactor = redactor("enduser.id");
+        var attrs = Attributes.of(AttributeKey.longKey("http.status_code"), 200L);
+
+        assertThat(redactor.redact(attrs)).isSameAs(attrs);
+    }
+
+    @Test
+    void should_handle_null_attributes_gracefully() {
+        assertThat(redactor("anything").redact(null)).isNull();
+    }
+
+    @Test
+    void should_return_empty_attributes_unchanged() {
+        assertThat(redactor("anything").redact(Attributes.empty())).isSameAs(Attributes.empty());
+    }
+
+    @Test
+    void should_apply_first_matching_rule_replacement() {
+        var rules = List.of(new RedactionRule("enduser.*", "RULE_1"), new RedactionRule("enduser.id", "RULE_2"));
+        var redactor = new SpanAttributeRedactor(new RedactionConfig(rules));
+        var attrs = Attributes.of(AttributeKey.stringKey("enduser.id"), "alice");
+
+        assertThat(redactor.redact(attrs).get(AttributeKey.stringKey("enduser.id"))).isEqualTo("RULE_1");
+    }
+
+    @Test
+    void should_report_no_rules_for_empty_config() {
+        assertThat(new SpanAttributeRedactor(RedactionConfig.EMPTY).hasRules()).isFalse();
+    }
+
+    @Test
+    void should_report_rules_when_configured() {
+        assertThat(redactor("anything").hasRules()).isTrue();
+    }
+
+    @Test
+    void should_redact_only_when_value_matches_value_pattern() {
+        var rule = new RedactionRule("enduser.id", MaskingStrategy.DEFAULT, "^alice$");
+        var redactor = new SpanAttributeRedactor(new RedactionConfig(List.of(rule)));
+        var attrs = Attributes.of(AttributeKey.stringKey("enduser.id"), "alice");
+
+        assertThat(redactor.redact(attrs).get(AttributeKey.stringKey("enduser.id"))).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+    }
+
+    @Test
+    void should_not_redact_when_value_does_not_match_value_pattern() {
+        var rule = new RedactionRule("enduser.id", MaskingStrategy.DEFAULT, "^alice$");
+        var redactor = new SpanAttributeRedactor(new RedactionConfig(List.of(rule)));
+        var attrs = Attributes.of(AttributeKey.stringKey("enduser.id"), "bob");
+
+        assertThat(redactor.redact(attrs)).isSameAs(attrs);
+    }
+
+    @Test
+    void should_redact_all_matching_attributes_regardless_of_other_span_attributes() {
+        var rules = List.of(new RedactionRule("req.secret", "[R1]"), new RedactionRule("res.secret", "[R2]"));
+        var redactor = new SpanAttributeRedactor(new RedactionConfig(rules));
+        var attrs = Attributes.of(
+            AttributeKey.stringKey("req.secret"),
+            "sensitive",
+            AttributeKey.stringKey("res.secret"),
+            "also-sensitive"
+        );
+
+        var result = redactor.redact(attrs);
+
+        assertThat(result.get(AttributeKey.stringKey("req.secret"))).isEqualTo("[R1]");
+        assertThat(result.get(AttributeKey.stringKey("res.secret"))).isEqualTo("[R2]");
+    }
+
+    @Test
+    void should_apply_custom_full_replacement_string() {
+        var redactor = new SpanAttributeRedactor(
+            new RedactionConfig(List.of(new RedactionRule("enduser.id", MaskingStrategy.fullMask("<<<<>>>"))))
+        );
+        var attrs = Attributes.of(AttributeKey.stringKey("enduser.id"), "alice");
+
+        assertThat(redactor.redact(attrs).get(AttributeKey.stringKey("enduser.id"))).isEqualTo("<<<<>>>");
+    }
+
+    @Test
+    void should_apply_partial_mask_hiding_middle_keeping_suffix() {
+        var redactor = new SpanAttributeRedactor(
+            new RedactionConfig(List.of(new RedactionRule("payment.card", MaskingStrategy.partialMask(0, 4))))
+        );
+        var attrs = Attributes.of(AttributeKey.stringKey("payment.card"), "4111111111111111");
+
+        assertThat(redactor.redact(attrs).get(AttributeKey.stringKey("payment.card"))).isEqualTo("************1111");
+    }
+
+    @Test
+    void should_apply_partial_mask_keeping_prefix() {
+        var redactor = new SpanAttributeRedactor(
+            new RedactionConfig(List.of(new RedactionRule("http.request.header.authorization", MaskingStrategy.partialMask(7, 0))))
+        );
+        var attrs = Attributes.of(AttributeKey.stringKey("http.request.header.authorization"), "Bearer eyJhbGciOiJSUzI1NiJ9");
+
+        var result = redactor.redact(attrs).get(AttributeKey.stringKey("http.request.header.authorization"));
+        assertThat(result).startsWith("Bearer ");
+        assertThat(result).doesNotContain("eyJhbGciOiJSUzI1NiJ9");
+        assertThat(result).hasSize("Bearer eyJhbGciOiJSUzI1NiJ9".length());
+    }
+
+    @Test
+    void should_apply_partial_mask_keeping_prefix_and_suffix() {
+        var redactor = new SpanAttributeRedactor(
+            new RedactionConfig(List.of(new RedactionRule("api.key", MaskingStrategy.partialMask(3, 3))))
+        );
+        var attrs = Attributes.of(AttributeKey.stringKey("api.key"), "sk-live-abc123xyz");
+
+        var result = redactor.redact(attrs).get(AttributeKey.stringKey("api.key"));
+        assertThat(result).startsWith("sk-");
+        assertThat(result).endsWith("xyz");
+        assertThat(result).contains("*");
+    }
+
+    @Test
+    void should_apply_custom_mask_character_for_partial_mask() {
+        var redactor = new SpanAttributeRedactor(
+            new RedactionConfig(List.of(new RedactionRule("enduser.id", MaskingStrategy.partialMask(2, 2, "X"))))
+        );
+        var attrs = Attributes.of(AttributeKey.stringKey("enduser.id"), "alice123");
+
+        assertThat(redactor.redact(attrs).get(AttributeKey.stringKey("enduser.id"))).isEqualTo("alXXXX23");
+    }
+
+    @Test
+    void should_mask_entire_value_when_too_short_for_prefix_and_suffix() {
+        var redactor = new SpanAttributeRedactor(
+            new RedactionConfig(List.of(new RedactionRule("enduser.id", MaskingStrategy.partialMask(3, 3))))
+        );
+        var attrs = Attributes.of(AttributeKey.stringKey("enduser.id"), "ab");
+
+        assertThat(redactor.redact(attrs).get(AttributeKey.stringKey("enduser.id"))).isEqualTo("**");
+    }
+
+    @Test
+    void should_preserve_original_value_length_with_partial_mask() {
+        var value = "4111 1111 1111 1111";
+        var redactor = new SpanAttributeRedactor(
+            new RedactionConfig(List.of(new RedactionRule("payment.card", MaskingStrategy.partialMask(0, 4))))
+        );
+        var attrs = Attributes.of(AttributeKey.stringKey("payment.card"), value);
+
+        assertThat(redactor.redact(attrs).get(AttributeKey.stringKey("payment.card"))).hasSameSizeAs(value);
+    }
+
+    @Test
+    void should_throw_when_partial_mask_char_is_multi_character() {
+        assertThatThrownBy(() -> new PartialMaskingStrategy(0, 4, "XX"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("exactly one character");
+    }
+
+    @Test
+    void should_throw_when_partial_mask_factory_receives_multi_char_mask_char() {
+        assertThatThrownBy(() -> MaskingStrategy.partialMask(0, 4, "**"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("exactly one character");
+    }
+
+    @Test
+    void should_accept_single_char_mask_character() {
+        var strategy = (PartialMaskingStrategy) MaskingStrategy.partialMask(0, 4, "X");
+        assertThat(strategy.maskChar()).isEqualTo("X");
+    }
+
+    @Test
+    void should_redact_dot_separated_attribute_using_short_name() {
+        var redactor = redactor("user-id");
+        var attrs = Attributes.of(AttributeKey.stringKey("gravitee.attribute.user-id"), "alice");
+
+        assertThat(redactor.redact(attrs).get(AttributeKey.stringKey("gravitee.attribute.user-id")))
+            .isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+    }
+
+    @Test
+    void should_redact_bare_attribute_using_short_name() {
+        var redactor = redactor("custom");
+        var attrs = Attributes.of(AttributeKey.stringKey("custom"), "secret-value");
+
+        assertThat(redactor.redact(attrs).get(AttributeKey.stringKey("custom"))).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+    }
+
+    @Test
+    void should_redact_underscore_separated_attribute_using_short_name() {
+        var redactor = redactor("my_id");
+        var attrs = Attributes.of(AttributeKey.stringKey("http.request.my_id"), "value");
+
+        assertThat(redactor.redact(attrs).get(AttributeKey.stringKey("http.request.my_id"))).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+    }
+
+    @Test
+    void should_redact_old_semconv_underscore_attribute_using_short_name() {
+        var redactor = redactor("content_length");
+        var attrs = Attributes.of(AttributeKey.stringKey("http.response_content_length"), "1024");
+
+        assertThat(redactor.redact(attrs).get(AttributeKey.stringKey("http.response_content_length")))
+            .isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+    }
+
+    @Test
+    void should_redact_status_code_using_short_name_regardless_of_separator() {
+        var redactor = redactor("status_code");
+        var dotAttrs = Attributes.of(AttributeKey.stringKey("http.response.status_code"), "200");
+        var underscoreAttrs = Attributes.of(AttributeKey.stringKey("http.status_code"), "200");
+
+        assertThat(redactor.redact(dotAttrs).get(AttributeKey.stringKey("http.response.status_code")))
+            .isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+        assertThat(redactor.redact(underscoreAttrs).get(AttributeKey.stringKey("http.status_code")))
+            .isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+    }
+
+    @Test
+    void should_not_partially_match_hyphenated_short_name() {
+        // api-key should NOT match x-api-key (different attribute)
+        var redactor = redactor("api-key");
+        var attrs = Attributes.of(AttributeKey.stringKey("http.request.header.x-api-key"), "secret");
+
+        assertThat(redactor.redact(attrs)).isSameAs(attrs);
+    }
+
+    @Test
+    void should_not_apply_short_name_expansion_when_full_pattern_given() {
+        // full name with dots is NOT expanded — exact glob matching applies
+        var redactor = redactor("gravitee.attribute.user-id");
+        var attrs = Attributes.of(AttributeKey.stringKey("gravitee.attribute.user-id"), "alice");
+
+        assertThat(redactor.redact(attrs).get(AttributeKey.stringKey("gravitee.attribute.user-id")))
+            .isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+    }
+
+    @Test
+    void should_redact_when_attribute_key_casing_differs_from_pattern() {
+        var redactor = redactor("http.request.header.authorization");
+        var attrs = Attributes.of(AttributeKey.stringKey("http.request.header.Authorization"), "Bearer secret");
+
+        assertThat(redactor.redact(attrs).get(AttributeKey.stringKey("http.request.header.Authorization")))
+            .isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+    }
+
+    @Test
+    void should_redact_when_pattern_is_uppercase_and_attribute_is_lowercase() {
+        var redactor = redactor("HTTP.REQUEST.HEADER.AUTHORIZATION");
+        var attrs = Attributes.of(AttributeKey.stringKey("http.request.header.authorization"), "Bearer secret");
+
+        assertThat(redactor.redact(attrs).get(AttributeKey.stringKey("http.request.header.authorization")))
+            .isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+    }
+
+    @Test
+    void should_redact_glob_case_insensitive() {
+        var redactor = redactor("http.request.header.**");
+        var attrs = Attributes.of(AttributeKey.stringKey("http.request.header.X-Api-Key"), "my-key");
+
+        assertThat(redactor.redact(attrs).get(AttributeKey.stringKey("http.request.header.X-Api-Key")))
+            .isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+    }
+
+    // -------------------------------------------------------------------------
+    // Contract: config-level defaultReplacement
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class ConfigDefaultReplacement {
+
+        @Test
+        void uses_config_default_replacement_when_rule_has_no_explicit_strategy() {
+            // Rule with no explicit replacement uses MaskingStrategy.DEFAULT → resolved from config.
+            var config = new RedactionConfig(List.of(new RedactionRule("enduser.id")), "[HIDDEN]");
+            var redactor = new SpanAttributeRedactor(config);
+            var attrs = Attributes.of(AttributeKey.stringKey("enduser.id"), "alice");
+
+            assertThat(redactor.redact(attrs).get(AttributeKey.stringKey("enduser.id"))).isEqualTo("[HIDDEN]");
+        }
+
+        @Test
+        void explicit_rule_replacement_is_not_overridden_by_config_default() {
+            // fullMask("MY_MASK") is an explicit strategy — config default must not override it.
+            var config = new RedactionConfig(List.of(new RedactionRule("enduser.id", MaskingStrategy.fullMask("MY_MASK"))), "[HIDDEN]");
+            var redactor = new SpanAttributeRedactor(config);
+            var attrs = Attributes.of(AttributeKey.stringKey("enduser.id"), "alice");
+
+            assertThat(redactor.redact(attrs).get(AttributeKey.stringKey("enduser.id"))).isEqualTo("MY_MASK");
+        }
+
+        @Test
+        void explicit_full_mask_with_same_string_as_default_is_not_overridden_by_config_default() {
+            // fullMask("[REDACTED]") has the same field values as MaskingStrategy.DEFAULT but is a
+            // NEW instance — it represents an explicit choice and must NOT be overridden by config.
+            // This test catches a regression where .equals() was used instead of == for the sentinel.
+            var config = new RedactionConfig(List.of(new RedactionRule("enduser.id", MaskingStrategy.fullMask("[REDACTED]"))), "[HIDDEN]");
+            var redactor = new SpanAttributeRedactor(config);
+            var attrs = Attributes.of(AttributeKey.stringKey("enduser.id"), "alice");
+
+            // Must use the rule's explicit "[REDACTED]", NOT the config default "[HIDDEN]"
+            assertThat(redactor.redact(attrs).get(AttributeKey.stringKey("enduser.id"))).isEqualTo("[REDACTED]");
+        }
+
+        @Test
+        void partial_mask_rule_is_not_affected_by_config_default_replacement() {
+            var config = new RedactionConfig(List.of(new RedactionRule("payment.card", MaskingStrategy.partialMask(0, 4))), "[HIDDEN]");
+            var redactor = new SpanAttributeRedactor(config);
+            var attrs = Attributes.of(AttributeKey.stringKey("payment.card"), "4111111111111111");
+
+            // Partial mask outcome depends on the mask char, not the config default replacement.
+            assertThat(redactor.redact(attrs).get(AttributeKey.stringKey("payment.card"))).isEqualTo("************1111");
+        }
+
+        @Test
+        void null_config_default_falls_back_to_built_in_default() {
+            // null is normalised to "[REDACTED]" in the RedactionConfig compact constructor.
+            var config = new RedactionConfig(List.of(new RedactionRule("enduser.id")), null);
+            var redactor = new SpanAttributeRedactor(config);
+            var attrs = Attributes.of(AttributeKey.stringKey("enduser.id"), "alice");
+
+            assertThat(redactor.redact(attrs).get(AttributeKey.stringKey("enduser.id"))).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+        }
+
+        @Test
+        void blank_config_default_falls_back_to_built_in_default() {
+            var config = new RedactionConfig(List.of(new RedactionRule("enduser.id")), "   ");
+            var redactor = new SpanAttributeRedactor(config);
+            var attrs = Attributes.of(AttributeKey.stringKey("enduser.id"), "alice");
+
+            assertThat(redactor.redact(attrs).get(AttributeKey.stringKey("enduser.id"))).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+        }
+
+        @Test
+        void single_arg_constructor_uses_built_in_default() {
+            // Verify backward-compat constructor still produces "[REDACTED]".
+            var config = new RedactionConfig(List.of(new RedactionRule("enduser.id")));
+            var redactor = new SpanAttributeRedactor(config);
+            var attrs = Attributes.of(AttributeKey.stringKey("enduser.id"), "alice");
+
+            assertThat(redactor.redact(attrs).get(AttributeKey.stringKey("enduser.id"))).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Contract: value-pattern semantics (find vs matches, case sensitivity)
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class ValuePatternSemantics {
+
+        @Test
+        void value_pattern_is_substring_match_not_full_string() {
+            // valuePattern uses find() — "Bearer" matches "Bearer eyJhbGci…" without anchoring.
+            var rule = new RedactionRule("enduser.token", MaskingStrategy.DEFAULT, "Bearer");
+            var redactor = new SpanAttributeRedactor(new RedactionConfig(List.of(rule)));
+            var attrs = Attributes.of(AttributeKey.stringKey("enduser.token"), "Bearer eyJhbGciOiJSUzI1NiJ9.some.payload");
+
+            assertThat(redactor.redact(attrs).get(AttributeKey.stringKey("enduser.token"))).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+        }
+
+        @Test
+        void value_pattern_matches_when_value_contains_pattern_as_substring() {
+            // "alice" appears somewhere inside the value — find() fires.
+            var rule = new RedactionRule("enduser.id", MaskingStrategy.DEFAULT, "alice");
+            var redactor = new SpanAttributeRedactor(new RedactionConfig(List.of(rule)));
+            var attrs = Attributes.of(AttributeKey.stringKey("enduser.id"), "prefix-alice-suffix");
+
+            assertThat(redactor.redact(attrs).get(AttributeKey.stringKey("enduser.id"))).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+        }
+
+        @Test
+        void value_pattern_does_not_match_when_anchored_and_value_has_extra_content() {
+            // Operators must use ^…$ anchors when they want a full-string match.
+            var rule = new RedactionRule("enduser.id", MaskingStrategy.DEFAULT, "^alice$");
+            var redactor = new SpanAttributeRedactor(new RedactionConfig(List.of(rule)));
+            var attrs = Attributes.of(AttributeKey.stringKey("enduser.id"), "prefix-alice");
+
+            assertThat(redactor.redact(attrs)).isSameAs(attrs);
+        }
+
+        @Test
+        void value_pattern_is_case_sensitive_unlike_key_pattern() {
+            // Key patterns are CASE_INSENSITIVE; value patterns are NOT.
+            var rule = new RedactionRule("enduser.id", MaskingStrategy.DEFAULT, "Alice");
+            var redactor = new SpanAttributeRedactor(new RedactionConfig(List.of(rule)));
+            var attrs = Attributes.of(AttributeKey.stringKey("enduser.id"), "alice"); // lowercase — no match
+
+            assertThat(redactor.redact(attrs)).isSameAs(attrs);
+        }
+
+        @Test
+        void value_pattern_case_sensitive_matches_on_exact_case() {
+            var rule = new RedactionRule("enduser.id", MaskingStrategy.DEFAULT, "Alice");
+            var redactor = new SpanAttributeRedactor(new RedactionConfig(List.of(rule)));
+            var attrs = Attributes.of(AttributeKey.stringKey("enduser.id"), "Alice");
+
+            assertThat(redactor.redact(attrs).get(AttributeKey.stringKey("enduser.id"))).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Contract: type coercion when non-string attributes are redacted
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class TypeCoercion {
+
+        @Test
+        void redacted_boolean_attribute_is_written_back_as_string() {
+            // Boolean type is coerced to String when redacted; original typed key is removed.
+            var redactor = redactor("feature.enabled");
+            var attrs = Attributes.of(AttributeKey.booleanKey("feature.enabled"), true);
+
+            var result = redactor.redact(attrs);
+
+            assertThat(result.get(AttributeKey.stringKey("feature.enabled"))).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+            assertThat(result.get(AttributeKey.booleanKey("feature.enabled"))).isNull();
+        }
+
+        @Test
+        void redacted_double_attribute_is_written_back_as_string() {
+            var redactor = redactor("billing.amount");
+            var attrs = Attributes.of(AttributeKey.doubleKey("billing.amount"), 99.99);
+
+            var result = redactor.redact(attrs);
+
+            assertThat(result.get(AttributeKey.stringKey("billing.amount"))).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+            assertThat(result.get(AttributeKey.doubleKey("billing.amount"))).isNull();
+        }
+
+        @Test
+        void redacted_string_array_attribute_is_written_back_as_string() {
+            var redactor = redactor("user.roles");
+            var attrs = Attributes.of(AttributeKey.stringArrayKey("user.roles"), List.of("admin", "user"));
+
+            var result = redactor.redact(attrs);
+
+            assertThat(result.get(AttributeKey.stringKey("user.roles"))).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+            assertThat(result.get(AttributeKey.stringArrayKey("user.roles"))).isNull();
+        }
+
+        @Test
+        void non_matching_typed_attributes_preserve_their_original_type() {
+            var redactor = redactor("enduser.id");
+            var attrs = Attributes.of(
+                AttributeKey.longKey("http.status_code"),
+                200L,
+                AttributeKey.booleanKey("http.request.resend_count"),
+                false
+            );
+
+            assertThat(redactor.redact(attrs)).isSameAs(attrs);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Contract: MaskingStrategy fail-fast on invalid construction arguments
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class MaskingStrategyValidation {
+
+        @Test
+        void should_throw_on_negative_prefix_length() {
+            assertThatThrownBy(() -> MaskingStrategy.partialMask(-1, 4))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("prefixLength");
+        }
+
+        @Test
+        void should_throw_on_negative_suffix_length() {
+            assertThatThrownBy(() -> MaskingStrategy.partialMask(4, -1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("suffixLength");
+        }
+
+        @Test
+        void should_accept_zero_prefix_and_suffix() {
+            // zero is a valid boundary value — must not throw
+            var strategy = (PartialMaskingStrategy) MaskingStrategy.partialMask(0, 0);
+            assertThat(strategy.prefixLength()).isZero();
+            assertThat(strategy.suffixLength()).isZero();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Contract: fail-fast on invalid patterns at construction time
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class PatternValidation {
+
+        @Test
+        void should_throw_on_invalid_regex_key_pattern_at_construction() {
+            var rule = new RedactionRule("regex:[unclosed-bracket");
+            assertThatThrownBy(() -> new SpanAttributeRedactor(new RedactionConfig(List.of(rule))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("[unclosed-bracket");
+        }
+
+        @Test
+        void should_throw_on_invalid_regex_value_pattern_at_construction() {
+            var rule = new RedactionRule("enduser.id", MaskingStrategy.DEFAULT, "[bad-value-regex");
+            assertThatThrownBy(() -> new SpanAttributeRedactor(new RedactionConfig(List.of(rule))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("[bad-value-regex");
+        }
+
+        @Test
+        void should_accept_valid_regex_key_pattern() {
+            var rule = new RedactionRule("regex:enduser\\.(id|email)");
+            // must not throw
+            var redactor = new SpanAttributeRedactor(new RedactionConfig(List.of(rule)));
+            assertThat(redactor.hasRules()).isTrue();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper
+    // -------------------------------------------------------------------------
+
+    private static SpanAttributeRedactor redactor(String pattern) {
+        return new SpanAttributeRedactor(new RedactionConfig(List.of(new RedactionRule(pattern))));
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-13568

**Description**

Introduce RedactSpanExporter to wrap any SpanExporter and redact span/event attributes before export
Add redaction APIs: RedactionConfig, RedactionRule, MaskingStrategy supporting:
Full masking
Partial masking (prefix/suffix retention)
Pattern-based rules
Enable phase-scoped redaction (REQUEST, RESPONSE, ERROR, ALL) using gravitee.phase
ERROR rules also apply to spans with StatusCode.ERROR
Redact resource attributes at tracer creation via RedactSpanExporter#redactResource (e.g., hostname, IP)
Extend TracerFactory with a 7-arg createTracer overload accepting RedactionConfig (implemented in OpenTelemetryFactory)
Implement single-pass lazy-backfill algorithm with zero allocation when no rules match

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `9.0.0-feat-redact-span-attribute-otel-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/9.0.0-feat-redact-span-attribute-otel-SNAPSHOT/gravitee-node-9.0.0-feat-redact-span-attribute-otel-SNAPSHOT.zip)
  <!-- Version placeholder end -->
