### PR TITLE
fix(redis): wire hostname algorithm + SSL tuning through factory

### DIFF
--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/redis/VertxRedisClientFactory.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/redis/VertxRedisClientFactory.java
@@ -188,9 +188,22 @@ public class VertxRedisClientFactory {
 
         var sslOptions = SslOptionsMapper.INSTANCE.map(sourceSslOptions);
         netClientOptions.setTrustAll(sslOptions.isTrustAll());
+        netClientOptions.setHostnameVerificationAlgorithm(sslOptions.isHostnameVerifier() ? "HTTPS" : "");
 
-        if (!sslOptions.isHostnameVerifier()) {
-            netClientOptions.setHostnameVerificationAlgorithm("");
+        if (sslOptions.getTlsProtocols() != null && !sslOptions.getTlsProtocols().isEmpty()) {
+            netClientOptions.setEnabledSecureTransportProtocols(sslOptions.getTlsProtocols());
+        }
+
+        if (sslOptions.getTlsCiphers() != null && !sslOptions.getTlsCiphers().isEmpty()) {
+            for (String cipher : sslOptions.getTlsCiphers()) {
+                netClientOptions.addEnabledCipherSuite(cipher.strip());
+            }
+        }
+
+        netClientOptions.setUseAlpn(sslOptions.isAlpn());
+
+        if (sslOptions.isOpenSsl()) {
+            netClientOptions.setSslEngineOptions(new io.vertx.core.net.OpenSSLEngineOptions());
         }
 
         if (!sslOptions.isTrustAll()) {

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/ssl/SslOptions.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/ssl/SslOptions.java
@@ -2,7 +2,9 @@ package io.gravitee.node.vertx.client.ssl;
 
 import java.io.Serial;
 import java.io.Serializable;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -28,7 +30,13 @@ public class SslOptions implements Serializable {
     private boolean openSsl = false;
 
     @Builder.Default
+    private boolean alpn = false;
+
+    @Builder.Default
     private String hostnameVerificationAlgorithm = "NONE";
+
+    private Set<String> tlsProtocols;
+    private List<String> tlsCiphers;
 
     private TrustStore trustStore;
     private KeyStore keyStore;


### PR DESCRIPTION
## Summary

`VertxRedisClientFactory.configureSsl` doesn't apply the hostname-verification algorithm nor the SSL tuning options that the pre-Vert.x-5 `RedisConnectionFactory` used to set. This breaks downstream consumers that migrate from direct `RedisOptions` to `RedisClientOptions` + factory.

- `hostnameVerificationAlgorithm` only set to `""` when verifier disabled; left unset when enabled — Vert.x then throws `Missing hostname verification algorithm: you must set TCP client options host name verification algorithm` at connect time.
- `tlsProtocols`, `tlsCiphers`, `alpn`, `openSsl` are not applied from `SslOptions` to the underlying `NetClientOptions`.
- `SslOptions` (node-vertx) is missing `tlsProtocols` (Set<String>), `tlsCiphers` (List<String>), `alpn` (boolean) fields, so consumers have no way to pass them through.

## What changes

- `VertxRedisClientFactory.configureSsl`: set `HostnameVerificationAlgorithm` to `"HTTPS"` when `hostnameVerifier=true`, `""` when false. Apply `tlsProtocols` / `tlsCiphers` / `alpn` / `openSsl` from the mapped `SslOptions` to `NetClientOptions`.
- `io.gravitee.node.vertx.client.ssl.SslOptions`: add `tlsProtocols`, `tlsCiphers`, `alpn` fields (`openSsl` already existed).

No config file changes. `SslOptions` changes are additive (new optional fields default to null / false).

## Compatibility note

`SslOptions` has `@AllArgsConstructor` (Lombok). Adding fields changes the positional constructor signature from 6 args to 9. Grep across gravitee-io org (gravitee-node, gravitee-plugin-common-configurations, gravitee-api-management and its support-branch worktrees, gravitee-node-cache-plugin-redis) shows **no callers use the positional all-args constructor** — every site uses `new SslOptions()` (no-args) or `SslOptions.builder().…build()`. The generated `SslOptionsMapperImpl` also uses the builder. So no observable source or binary breakage; flagging for reviewers to decide if the compatibility risk is acceptable or if they prefer an explicit `@AllArgsConstructor(access = PRIVATE)` / additional `@NoArgsConstructor` style.

## Depends on / blocks

- Fix for: [APIM-13779](https://gravitee.atlassian.net/browse/APIM-13779)
- Epic: [APIM-13553](https://gravitee.atlassian.net/browse/APIM-13553)
- Blocks: [gravitee-io/gravitee-plugin-common-configurations#19](https://github.com/gravitee-io/gravitee-plugin-common-configurations/pull/19) — surfaces the same 4 fields on `common-configurations.SslOptions` so MapStruct can copy them into this PR's node-vertx `SslOptions`.
- End consumer: [gravitee-io/gravitee-api-management#16408](https://github.com/gravitee-io/gravitee-api-management/pull/16408) — `gravitee-apim-repository-redis` rate-limit + distributed-sync migration.

## Test plan

- [x] Manual: APIM gateway with `ratelimit.type=redis`, `ratelimit.redis.ssl=true`, `ratelimit.redis.trustAll=false`, `ratelimit.redis.hostnameVerificationAlgorithm=HTTPS`, `ratelimit.redis.tlsProtocols=TLSv1.2,TLSv1.3` + PEM truststore connects cleanly (previously: `Missing hostname verification algorithm`).
- [x] Standalone + password and sentinel scenarios unchanged (retested against patched alpha.4 SNAPSHOT).
- [ ] Unit test `VertxRedisClientFactory.configureSsl` mapping (to add — existing `VertxRedisClientFactoryTest` has SSL cases but doesn't assert on `getHostnameVerificationAlgorithm()`).

[APIM-13779]: https://gravitee.atlassian.net/browse/APIM-13779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `9.0.0-wbabyte-APIM-13779-redis-ssl-fix-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/9.0.0-wbabyte-APIM-13779-redis-ssl-fix-SNAPSHOT/gravitee-node-9.0.0-wbabyte-APIM-13779-redis-ssl-fix-SNAPSHOT.zip)
  <!-- Version placeholder end -->
