### PR TITLE
feat(APIM-13618): add OTel Logger API, logsEndpoint config and Loki HTTP log exporter

### DIFF
--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/Logger.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/Logger.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.api.opentelemetry;
+
+import io.gravitee.common.service.Service;
+import io.vertx.core.Context;
+import java.util.Map;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface Logger extends Service<Logger> {
+    /**
+     * Log a body associated to this context
+     *
+     * @param vertxContext current vert context used to store tracing information
+     * @param body the body to be logged
+     */
+    void record(final Context vertxContext, String body);
+
+    /**
+     * Log a body with attributes associated to this context
+     *
+     * @param vertxContext current vert context used to store tracing information
+     * @param body the body to be logged
+     * @param attributes the attributes to attach to the Log
+     */
+    void record(final Context vertxContext, String body, Map<String, Object> attributes);
+}

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/Logger.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/Logger.java
@@ -40,4 +40,14 @@ public interface Logger extends Service<Logger> {
      * @param attributes the attributes to attach to the Log
      */
     void record(final Context vertxContext, String body, Map<String, Object> attributes);
+
+    /**
+     * Log a body with attributes associated to this context
+     *
+     * @param vertxContext current vert context used to store tracing information
+     * @param span extract OpenTelemetry context from this span
+     * @param body the body to be logged
+     * @param attributes the attributes to attach to the Log
+     */
+    void record(final Context vertxContext, Span span, String body, Map<String, Object> attributes);
 }

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/LoggerFactory.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/LoggerFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.api.opentelemetry;
+
+import java.util.Map;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface LoggerFactory {
+    Logger createLogger(
+        final String serviceInstanceId,
+        final String serviceName,
+        final String serviceNamespace,
+        final String serviceVersion,
+        final Map<String, String> additionalResourceAttributes
+    );
+}

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/Span.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/Span.java
@@ -49,4 +49,18 @@ public interface Span {
      * @return current {@link Span}
      */
     Span addEvent(final String name, final Map<String, Object> attributes);
+
+    /**
+     * Get the span id from this span
+     *
+     * @return the span id of this span
+     */
+    String spanId();
+
+    /**
+     * Get the trace id from this span
+     *
+     * @return the trace id of this span
+     */
+    String traceId();
 }

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/Tracer.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/Tracer.java
@@ -108,18 +108,41 @@ public interface Tracer extends Service<Tracer> {
     <R> void endWithResponseAndError(final Context vertxContext, final Span span, final R response, final String message);
 
     /**
-     * Returns the trace ID of the currently active span, or an empty string if tracing is disabled or no span is active.
+     * Returns the trace ID of the span currently attached to the given Vert.x context, or an empty
+     * string if tracing is disabled or no span is currently attached.
+     *
+     * <p><b>Caveat — reliability depends on span nesting.</b> The returned ID is read from the single
+     * OpenTelemetry context slot stored on the Vert.x context. That slot behaves like a stack and is
+     * only guaranteed to reflect the logically active span when spans on the same Vert.x context are
+     * strictly LIFO-nested (e.g., classic request/response HTTP flows). In reactors that multiplex
+     * concurrent spans onto a single Vert.x context — for example the Kafka native reactor, where many
+     * in-flight protocol requests share one duplicated context, or any flow that creates spans inside
+     * {@code doOnSubscribe} / {@code Completable.defer} — the slot can hold a sibling span, be
+     * restored to {@code null} by an out-of-order end, or otherwise not match the span the caller has
+     * in mind. In those cases, resolve the specific {@link Span} the caller cares about (e.g. from a
+     * context attribute) and use {@link Span#traceId()} instead.
      *
      * @param vertxContext current vert context used to store tracing information
      * @return W3C TraceContext trace ID (32 lowercase hex chars), or {@code ""} if none
+     * @see Span#traceId()
      */
     String traceId(final Context vertxContext);
 
     /**
-     * Returns the span ID of the currently active span, or an empty string if tracing is disabled or no span is active.
+     * Returns the span ID of the span currently attached to the given Vert.x context, or an empty
+     * string if tracing is disabled or no span is currently attached.
+     *
+     * <p><b>Caveat — reliability depends on span nesting.</b> Same restriction as
+     * {@link #traceId(Context)}: the ID is read from a single per-context slot and is only meaningful
+     * when spans on the Vert.x context are strictly LIFO-nested. In multiplexed or reactively-deferred
+     * flows the slot may not match the span the caller has in mind; in those cases, resolve the
+     * specific {@link Span} and use {@link Span#spanId()} instead. The trace ID is more forgiving than
+     * the span ID here, since all spans of a single logical flow share one trace — the span ID is the
+     * one you are most likely to get wrong.
      *
      * @param vertxContext current vert context used to store tracing information
      * @return W3C TraceContext span ID (16 lowercase hex chars), or {@code ""} if none
+     * @see Span#spanId()
      */
     String spanId(final Context vertxContext);
 

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/Tracer.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/Tracer.java
@@ -108,6 +108,22 @@ public interface Tracer extends Service<Tracer> {
     <R> void endWithResponseAndError(final Context vertxContext, final Span span, final R response, final String message);
 
     /**
+     * Returns the trace ID of the currently active span, or an empty string if tracing is disabled or no span is active.
+     *
+     * @param vertxContext current vert context used to store tracing information
+     * @return W3C TraceContext trace ID (32 lowercase hex chars), or {@code ""} if none
+     */
+    String traceId(final Context vertxContext);
+
+    /**
+     * Returns the span ID of the currently active span, or an empty string if tracing is disabled or no span is active.
+     *
+     * @param vertxContext current vert context used to store tracing information
+     * @return W3C TraceContext span ID (16 lowercase hex chars), or {@code ""} if none
+     */
+    String spanId(final Context vertxContext);
+
+    /**
      * Inject into the given carrier the current span context
      *
      * @param vertxContext current vert context used to store tracing information

--- a/gravitee-node-opentelemetry/pom.xml
+++ b/gravitee-node-opentelemetry/pom.xml
@@ -101,6 +101,10 @@
             <artifactId>opentelemetry-exporter-otlp-common</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>
             <artifactId>opentelemetry-instrumentation-api</artifactId>
         </dependency>

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/OpenTelemetryFactory.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/OpenTelemetryFactory.java
@@ -16,12 +16,15 @@
 package io.gravitee.node.opentelemetry;
 
 import io.gravitee.node.api.opentelemetry.InstrumenterTracerFactory;
+import io.gravitee.node.api.opentelemetry.Logger;
+import io.gravitee.node.api.opentelemetry.LoggerFactory;
 import io.gravitee.node.api.opentelemetry.Tracer;
 import io.gravitee.node.api.opentelemetry.TracerFactory;
 import io.gravitee.node.api.opentelemetry.redaction.RedactionConfig;
 import io.gravitee.node.opentelemetry.configuration.OpenTelemetryConfiguration;
 import io.gravitee.node.opentelemetry.exporter.SpanExporterFactory;
 import io.gravitee.node.opentelemetry.exporter.redact.RedactSpanExporter;
+import io.gravitee.node.opentelemetry.logger.OpenTelemetryLogger;
 import io.gravitee.node.opentelemetry.tracer.OpenTelemetryTracer;
 import io.gravitee.node.opentelemetry.tracer.noop.NoOpTracer;
 import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
@@ -29,8 +32,11 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.OpenTelemetrySdkBuilder;
+import io.opentelemetry.sdk.logs.SdkLoggerProvider;
+import io.opentelemetry.sdk.logs.export.BatchLogRecordProcessor;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.resources.ResourceBuilder;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
@@ -50,7 +56,7 @@ import lombok.RequiredArgsConstructor;
  */
 @CustomLog
 @RequiredArgsConstructor
-public class OpenTelemetryFactory implements TracerFactory {
+public class OpenTelemetryFactory implements TracerFactory, LoggerFactory {
 
     private static final String DEFAULT_HOST_NAME = "unknown";
     private static final String DEFAULT_IP = "0.0.0.0";
@@ -157,6 +163,54 @@ public class OpenTelemetryFactory implements TracerFactory {
         } else {
             return new NoOpTracer();
         }
+    }
+
+    @Override
+    public Logger createLogger(
+        final String serviceInstanceId,
+        final String serviceName,
+        final String serviceNamespace,
+        final String serviceVersion,
+        final Map<String, String> additionalResourceAttributes
+    ) {
+        if (!configuration.isTracesEnabled()) {
+            return new io.gravitee.node.opentelemetry.logger.noop.NoOpLogger();
+        }
+
+        final Resource resource = createResource(
+            serviceInstanceId,
+            serviceName,
+            serviceNamespace,
+            serviceVersion,
+            additionalResourceAttributes
+        );
+
+        final OpenTelemetrySdkBuilder builder = OpenTelemetrySdk
+            .builder()
+            .setPropagators(
+                ContextPropagators.create(
+                    TextMapPropagator.composite(W3CTraceContextPropagator.getInstance(), W3CBaggagePropagator.getInstance())
+                )
+            );
+
+        var exporterBuilder = OtlpHttpLogRecordExporter
+            .builder()
+            .setEndpoint(configuration.getLogsEndpoint())
+            .setTimeout(configuration.getTimeout())
+            .setCompression(configuration.getCompressionType().name().toLowerCase());
+
+        if (configuration.getCustomHeaders() != null) {
+            configuration.getCustomHeaders().forEach(exporterBuilder::addHeader);
+        }
+
+        SdkLoggerProvider loggerProvider = SdkLoggerProvider
+            .builder()
+            .addLogRecordProcessor(BatchLogRecordProcessor.builder(exporterBuilder.build()).build())
+            .setResource(resource)
+            .build();
+
+        builder.setLoggerProvider(loggerProvider);
+        return new OpenTelemetryLogger(builder.build());
     }
 
     private Resource createResource(

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/configuration/OpenTelemetryConfiguration.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/configuration/OpenTelemetryConfiguration.java
@@ -81,6 +81,14 @@ public class OpenTelemetryConfiguration {
     private String endpoint;
 
     /**
+     * Sets the OTLP HTTP endpoint for log records. If unset, defaults to <code>http://localhost:3100/otlp/v1/logs</code> (Loki).
+     * Log records are always exported over HTTP/protobuf (not gRPC) because Loki does not implement the gRPC LogsService.
+     * Must be the full URL including signal path (e.g. /v1/logs) — the SDK does not append it automatically.
+     */
+    @Value("${services.opentelemetry.exporter.logsEndpoint:http://localhost:3100/otlp/v1/logs}")
+    private String logsEndpoint;
+
+    /**
      * Key-value pairs to be used as headers associated with exporter requests.
      */
     @Getter(AccessLevel.NONE)

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/logger/OpenTelemetryLogger.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/logger/OpenTelemetryLogger.java
@@ -17,6 +17,8 @@ package io.gravitee.node.opentelemetry.logger;
 
 import io.gravitee.common.service.AbstractService;
 import io.gravitee.node.api.opentelemetry.Logger;
+import io.gravitee.node.api.opentelemetry.Span;
+import io.gravitee.node.opentelemetry.tracer.span.OpenTelemetrySpan;
 import io.gravitee.node.opentelemetry.tracer.vertx.VertxContextStorage;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
@@ -54,7 +56,15 @@ public class OpenTelemetryLogger extends AbstractService<Logger> implements Logg
 
     @Override
     public void record(final Context vertxContext, final String body, final Map<String, Object> attributes) {
+        this.record(vertxContext, null, body, attributes);
+    }
+
+    @Override
+    public void record(Context vertxContext, Span span, String body, Map<String, Object> attributes) {
         io.opentelemetry.context.Context openTelemetryContext = VertxContextStorage.getContext(vertxContext);
+        if (span instanceof OpenTelemetrySpan<?> openTelemetrySpan) {
+            openTelemetryContext = openTelemetrySpan.otelContext();
+        }
 
         AttributesBuilder builder = Attributes.builder();
         if (attributes != null) {

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/logger/OpenTelemetryLogger.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/logger/OpenTelemetryLogger.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.opentelemetry.logger;
+
+import io.gravitee.common.service.AbstractService;
+import io.gravitee.node.api.opentelemetry.Logger;
+import io.gravitee.node.opentelemetry.tracer.vertx.VertxContextStorage;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.vertx.core.Context;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RequiredArgsConstructor
+public class OpenTelemetryLogger extends AbstractService<Logger> implements Logger {
+
+    private final OpenTelemetrySdk openTelemetrySdk;
+    private io.opentelemetry.api.logs.Logger logger;
+
+    @Override
+    protected void doStart() throws Exception {
+        super.doStart();
+        logger = openTelemetrySdk.getSdkLoggerProvider().loggerBuilder("gravitee").build();
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        super.doStop();
+        openTelemetrySdk.close();
+    }
+
+    @Override
+    public void record(final Context vertxContext, final String body) {
+        this.record(vertxContext, body, Map.of());
+    }
+
+    @Override
+    public void record(final Context vertxContext, final String body, final Map<String, Object> attributes) {
+        io.opentelemetry.context.Context openTelemetryContext = VertxContextStorage.getContext(vertxContext);
+
+        AttributesBuilder builder = Attributes.builder();
+        if (attributes != null) {
+            attributes.forEach((key, value) -> {
+                if (value == null) return;
+                switch (value) {
+                    case String s -> builder.put(key, s);
+                    case Integer i -> builder.put(key, (long) i);
+                    case Long l -> builder.put(key, l);
+                    case Double d -> builder.put(key, d);
+                    case Boolean b -> builder.put(key, b);
+                    default -> builder.put(key, String.valueOf(value));
+                }
+            });
+        }
+
+        var logRecordBuilder = logger.logRecordBuilder().setAllAttributes(builder.build()).setBody(body);
+        if (openTelemetryContext != null) {
+            logRecordBuilder.setContext(openTelemetryContext);
+        }
+        logRecordBuilder.emit();
+    }
+}

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/logger/noop/NoOpLogger.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/logger/noop/NoOpLogger.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.opentelemetry.logger.noop;
+
+import io.gravitee.common.service.AbstractService;
+import io.gravitee.node.api.opentelemetry.Logger;
+import io.vertx.core.Context;
+import java.util.Map;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class NoOpLogger extends AbstractService<Logger> implements Logger {
+
+    @Override
+    public void record(final Context vertxContext, final String body) {}
+
+    @Override
+    public void record(final Context vertxContext, final String body, final Map<String, Object> attributes) {}
+}

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/logger/noop/NoOpLogger.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/logger/noop/NoOpLogger.java
@@ -17,6 +17,7 @@ package io.gravitee.node.opentelemetry.logger.noop;
 
 import io.gravitee.common.service.AbstractService;
 import io.gravitee.node.api.opentelemetry.Logger;
+import io.gravitee.node.api.opentelemetry.Span;
 import io.vertx.core.Context;
 import java.util.Map;
 
@@ -31,4 +32,7 @@ public class NoOpLogger extends AbstractService<Logger> implements Logger {
 
     @Override
     public void record(final Context vertxContext, final String body, final Map<String, Object> attributes) {}
+
+    @Override
+    public void record(Context vertxContext, Span span, String body, Map<String, Object> attributes) {}
 }

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/tracer/OpenTelemetryTracer.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/tracer/OpenTelemetryTracer.java
@@ -172,6 +172,26 @@ public class OpenTelemetryTracer extends AbstractService<Tracer> implements Trac
     }
 
     @Override
+    public String traceId(final Context vertxContext) {
+        io.opentelemetry.context.Context currentContext = VertxContextStorage.getContext(vertxContext);
+        if (currentContext == null) {
+            return "";
+        }
+        var spanContext = io.opentelemetry.api.trace.Span.fromContext(currentContext).getSpanContext();
+        return spanContext.isValid() ? spanContext.getTraceId() : "";
+    }
+
+    @Override
+    public String spanId(final Context vertxContext) {
+        io.opentelemetry.context.Context currentContext = VertxContextStorage.getContext(vertxContext);
+        if (currentContext == null) {
+            return "";
+        }
+        var spanContext = io.opentelemetry.api.trace.Span.fromContext(currentContext).getSpanContext();
+        return spanContext.isValid() ? spanContext.getSpanId() : "";
+    }
+
+    @Override
     public void injectSpanContext(final Context vertxContext, final BiConsumer<String, String> textMapSetter) {
         io.opentelemetry.context.Context currentContext = VertxContextStorage.getContext(vertxContext);
         if (currentContext != null) {

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/tracer/noop/NoOpSpan.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/tracer/noop/NoOpSpan.java
@@ -56,4 +56,14 @@ public class NoOpSpan implements Span {
     public Span addEvent(final String name, final Map<String, Object> attributes) {
         return this;
     }
+
+    @Override
+    public String spanId() {
+        return "";
+    }
+
+    @Override
+    public String traceId() {
+        return "";
+    }
 }

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/tracer/noop/NoOpTracer.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/tracer/noop/NoOpTracer.java
@@ -61,6 +61,16 @@ public class NoOpTracer extends AbstractService<Tracer> implements Tracer {
     public <R> void endWithResponseAndError(final Context vertxContext, final Span span, final R response, final String message) {}
 
     @Override
+    public String traceId(final Context vertxContext) {
+        return "";
+    }
+
+    @Override
+    public String spanId(final Context vertxContext) {
+        return "";
+    }
+
+    @Override
     public void injectSpanContext(final Context vertxContext, final BiConsumer<String, String> textMapSetter) {}
 
     @Override

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/tracer/span/OpenTelemetrySpan.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/tracer/span/OpenTelemetrySpan.java
@@ -119,4 +119,14 @@ public class OpenTelemetrySpan<R> implements Span {
         }
         return this;
     }
+
+    @Override
+    public String spanId() {
+        return span().getSpanContext().getSpanId();
+    }
+
+    @Override
+    public String traceId() {
+        return span().getSpanContext().getTraceId();
+    }
 }

--- a/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/logger/OpenTelemetryLoggerTest.java
+++ b/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/logger/OpenTelemetryLoggerTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.opentelemetry.logger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.node.api.opentelemetry.Span;
+import io.gravitee.node.opentelemetry.logger.noop.NoOpLogger;
+import io.gravitee.node.opentelemetry.tracer.span.OpenTelemetrySpan;
+import io.gravitee.node.opentelemetry.tracer.vertx.VertxContext;
+import io.gravitee.node.opentelemetry.tracer.vertx.VertxContextStorage;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.logs.SdkLoggerProvider;
+import io.opentelemetry.sdk.logs.data.LogRecordData;
+import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxExtension;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(VertxExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class OpenTelemetryLoggerTest {
+
+    private InMemoryLogRecordExporter logExporter;
+    private OpenTelemetrySdk openTelemetry;
+    private OpenTelemetryLogger logger;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        logExporter = InMemoryLogRecordExporter.create();
+        SdkLoggerProvider loggerProvider = SdkLoggerProvider
+            .builder()
+            .addLogRecordProcessor(SimpleLogRecordProcessor.create(logExporter))
+            .build();
+        openTelemetry = OpenTelemetrySdk.builder().setLoggerProvider(loggerProvider).build();
+        logger = new OpenTelemetryLogger(openTelemetry);
+        logger.start();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        logger.stop();
+    }
+
+    @Test
+    void record_should_attach_log_to_explicit_span_context(Vertx vertx) {
+        var vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+        var otelSpan = openTelemetry.getTracer("test").spanBuilder("test-span").startSpan();
+        Span span = new OpenTelemetrySpan<>(vertxContext, Context.root().with(otelSpan), Scope.noop(), false, "request");
+
+        logger.record(vertxContext, span, "hello", Map.of("key", "value"));
+
+        List<LogRecordData> records = logExporter.getFinishedLogRecordItems();
+        assertThat(records).hasSize(1);
+        assertThat(records.get(0).getBody().asString()).isEqualTo("hello");
+        assertThat(records.get(0).getSpanContext().getTraceId()).isEqualTo(otelSpan.getSpanContext().getTraceId());
+        assertThat(records.get(0).getSpanContext().getSpanId()).isEqualTo(otelSpan.getSpanContext().getSpanId());
+        otelSpan.end();
+    }
+
+    @Test
+    void record_should_correlate_log_with_span_even_when_slot_is_empty(Vertx vertx) {
+        // The motivating case: in multiplexed flows the per-context slot may not reflect the span
+        // the caller cares about. Passing the span explicitly bypasses the slot lookup.
+        var vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+        var otelSpan = openTelemetry.getTracer("test").spanBuilder("test-span").startSpan();
+        Span span = new OpenTelemetrySpan<>(vertxContext, Context.root().with(otelSpan), Scope.noop(), false, "request");
+        // Slot is intentionally never attached.
+        assertThat(VertxContextStorage.getContext(vertxContext)).isNull();
+
+        logger.record(vertxContext, span, "hello", Map.of());
+
+        List<LogRecordData> records = logExporter.getFinishedLogRecordItems();
+        assertThat(records).hasSize(1);
+        assertThat(records.get(0).getSpanContext().getSpanId()).isEqualTo(otelSpan.getSpanContext().getSpanId());
+        otelSpan.end();
+    }
+
+    @Test
+    void record_with_null_span_should_fall_back_to_vertx_context_slot(Vertx vertx) {
+        var vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+        var otelSpan = openTelemetry.getTracer("test").spanBuilder("test-span").startSpan();
+
+        try (var ignored = VertxContextStorage.INSTANCE.attach(vertxContext, Context.root().with(otelSpan))) {
+            logger.record(vertxContext, null, "hello", Map.of());
+        }
+
+        List<LogRecordData> records = logExporter.getFinishedLogRecordItems();
+        assertThat(records).hasSize(1);
+        assertThat(records.get(0).getSpanContext().getSpanId()).isEqualTo(otelSpan.getSpanContext().getSpanId());
+        otelSpan.end();
+    }
+
+    @Test
+    void record_with_null_span_and_empty_slot_should_emit_uncorrelated_record(Vertx vertx) {
+        var vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+
+        logger.record(vertxContext, null, "hello", Map.of());
+
+        List<LogRecordData> records = logExporter.getFinishedLogRecordItems();
+        assertThat(records).hasSize(1);
+        assertThat(records.get(0).getBody().asString()).isEqualTo("hello");
+        assertThat(records.get(0).getSpanContext().isValid()).isFalse();
+    }
+
+    @Test
+    void record_should_propagate_string_attribute(Vertx vertx) {
+        var vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+
+        logger.record(vertxContext, null, "body", Map.of("k", "v"));
+
+        var attrs = logExporter.getFinishedLogRecordItems().get(0).getAttributes();
+        assertThat(attrs.get(AttributeKey.stringKey("k"))).isEqualTo("v");
+    }
+
+    @Test
+    void record_should_propagate_long_attribute(Vertx vertx) {
+        var vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+
+        logger.record(vertxContext, null, "body", Map.of("k", 42L));
+
+        var attrs = logExporter.getFinishedLogRecordItems().get(0).getAttributes();
+        assertThat(attrs.get(AttributeKey.longKey("k"))).isEqualTo(42L);
+    }
+
+    @Test
+    void record_should_propagate_integer_as_long_attribute(Vertx vertx) {
+        var vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+
+        logger.record(vertxContext, null, "body", Map.of("k", 7));
+
+        var attrs = logExporter.getFinishedLogRecordItems().get(0).getAttributes();
+        assertThat(attrs.get(AttributeKey.longKey("k"))).isEqualTo(7L);
+    }
+
+    @Test
+    void record_should_propagate_double_attribute(Vertx vertx) {
+        var vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+
+        logger.record(vertxContext, null, "body", Map.of("k", 1.5d));
+
+        var attrs = logExporter.getFinishedLogRecordItems().get(0).getAttributes();
+        assertThat(attrs.get(AttributeKey.doubleKey("k"))).isEqualTo(1.5d);
+    }
+
+    @Test
+    void record_should_propagate_boolean_attribute(Vertx vertx) {
+        var vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+
+        logger.record(vertxContext, null, "body", Map.of("k", true));
+
+        var attrs = logExporter.getFinishedLogRecordItems().get(0).getAttributes();
+        assertThat(attrs.get(AttributeKey.booleanKey("k"))).isTrue();
+    }
+
+    @Test
+    void record_should_stringify_unsupported_attribute_types(Vertx vertx) {
+        var vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+
+        logger.record(vertxContext, null, "body", Map.of("k", List.of("a", "b")));
+
+        var attrs = logExporter.getFinishedLogRecordItems().get(0).getAttributes();
+        assertThat(attrs.get(AttributeKey.stringKey("k"))).isEqualTo(List.of("a", "b").toString());
+    }
+
+    @Test
+    void record_should_skip_null_attribute_values(Vertx vertx) {
+        var vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("present", "value");
+        attributes.put("absent", null);
+
+        logger.record(vertxContext, null, "body", attributes);
+
+        var attrs = logExporter.getFinishedLogRecordItems().get(0).getAttributes();
+        assertThat(attrs.get(AttributeKey.stringKey("present"))).isEqualTo("value");
+        assertThat(attrs.asMap()).doesNotContainKey(AttributeKey.stringKey("absent"));
+    }
+
+    @Test
+    void record_with_null_attributes_map_should_emit_record_with_no_attributes(Vertx vertx) {
+        var vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+
+        logger.record(vertxContext, null, "body", null);
+
+        var record = logExporter.getFinishedLogRecordItems().get(0);
+        assertThat(record.getBody().asString()).isEqualTo("body");
+        assertThat(record.getAttributes().isEmpty()).isTrue();
+    }
+
+    @Test
+    void record_two_arg_overload_should_emit_record_with_empty_attributes(Vertx vertx) {
+        var vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+
+        logger.record(vertxContext, "body");
+
+        var record = logExporter.getFinishedLogRecordItems().get(0);
+        assertThat(record.getBody().asString()).isEqualTo("body");
+        assertThat(record.getAttributes().isEmpty()).isTrue();
+    }
+
+    @Test
+    void noOpLogger_record_should_not_throw(Vertx vertx) {
+        var noOp = new NoOpLogger();
+        var vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+
+        noOp.record(vertxContext, "body");
+        noOp.record(vertxContext, "body", Map.of("k", "v"));
+        noOp.record(vertxContext, null, "body", Map.of("k", "v"));
+    }
+}

--- a/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/tracer/OpenTelemetryTracerTraceContextTest.java
+++ b/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/tracer/OpenTelemetryTracerTraceContextTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.opentelemetry.tracer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.node.opentelemetry.tracer.noop.NoOpTracer;
+import io.gravitee.node.opentelemetry.tracer.vertx.VertxContext;
+import io.gravitee.node.opentelemetry.tracer.vertx.VertxContextStorage;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxExtension;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(VertxExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class OpenTelemetryTracerTraceContextTest {
+
+    private OpenTelemetryTracer tracer;
+    private OpenTelemetrySdk openTelemetry;
+
+    @BeforeEach
+    void setUp() {
+        InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
+        SdkTracerProvider tracerProvider = SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)).build();
+        openTelemetry = OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).build();
+        tracer = new OpenTelemetryTracer(openTelemetry, List.of());
+    }
+
+    @Test
+    void traceId_should_return_empty_when_no_span_in_context(Vertx vertx) {
+        var vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+        assertThat(tracer.traceId(vertxContext)).isEmpty();
+    }
+
+    @Test
+    void spanId_should_return_empty_when_no_span_in_context(Vertx vertx) {
+        var vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+        assertThat(tracer.spanId(vertxContext)).isEmpty();
+    }
+
+    @Test
+    void traceId_should_return_valid_32_char_hex_when_span_is_active(Vertx vertx) {
+        var vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+
+        var otelTracer = openTelemetry.getTracer("test");
+        var span = otelTracer.spanBuilder("test-span").startSpan();
+        Context otelContextWithSpan = Context.root().with(span);
+
+        try (var ignored = VertxContextStorage.INSTANCE.attach(vertxContext, otelContextWithSpan)) {
+            assertThat(tracer.traceId(vertxContext)).hasSize(32);
+            assertThat(tracer.traceId(vertxContext)).isEqualTo(span.getSpanContext().getTraceId());
+        } finally {
+            span.end();
+        }
+    }
+
+    @Test
+    void spanId_should_return_valid_16_char_hex_when_span_is_active(Vertx vertx) {
+        var vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+
+        var otelTracer = openTelemetry.getTracer("test");
+        var span = otelTracer.spanBuilder("test-span").startSpan();
+        Context otelContextWithSpan = Context.root().with(span);
+
+        try (var ignored = VertxContextStorage.INSTANCE.attach(vertxContext, otelContextWithSpan)) {
+            assertThat(tracer.spanId(vertxContext)).hasSize(16);
+            assertThat(tracer.spanId(vertxContext)).isEqualTo(span.getSpanContext().getSpanId());
+        } finally {
+            span.end();
+        }
+    }
+
+    @Test
+    void noOpTracer_traceId_should_always_return_empty(Vertx vertx) {
+        var noOp = new NoOpTracer();
+        var vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+        assertThat(noOp.traceId(vertxContext)).isEmpty();
+    }
+
+    @Test
+    void noOpTracer_spanId_should_always_return_empty(Vertx vertx) {
+        var noOp = new NoOpTracer();
+        var vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+        assertThat(noOp.spanId(vertxContext)).isEmpty();
+    }
+}

--- a/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/tracer/OpenTelemetryTracerTraceContextTest.java
+++ b/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/tracer/OpenTelemetryTracerTraceContextTest.java
@@ -106,4 +106,36 @@ class OpenTelemetryTracerTraceContextTest {
         var vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
         assertThat(noOp.spanId(vertxContext)).isEmpty();
     }
+
+    @Test
+    void spanId_is_unreliable_when_sibling_spans_close_out_of_order_on_same_context(Vertx vertx) {
+        // Documents the caveat called out in Tracer#spanId(Context) javadoc: the per-context slot
+        // behaves like a stack and does not survive non-LIFO close ordering. Asserts that the
+        // Span-level accessor remains correct in the same scenario.
+        var vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+        var otelTracer = openTelemetry.getTracer("test");
+
+        var spanA = otelTracer.spanBuilder("A").startSpan();
+        var spanB = otelTracer.spanBuilder("B").startSpan();
+        var scopeA = VertxContextStorage.INSTANCE.attach(vertxContext, Context.root().with(spanA));
+        var scopeB = VertxContextStorage.INSTANCE.attach(vertxContext, Context.root().with(spanB));
+
+        // Slot currently holds B (most recently attached) — Tracer#spanId reflects that.
+        assertThat(tracer.spanId(vertxContext)).isEqualTo(spanB.getSpanContext().getSpanId());
+
+        // Closing A's scope out of order restores the slot to A's pre-attach snapshot (null),
+        // even though B is logically still in flight. Tracer#spanId now returns "" — the bug.
+        scopeA.close();
+        assertThat(tracer.spanId(vertxContext)).isEmpty();
+
+        // The SDK span objects themselves still carry their IDs regardless of the slot state.
+        // This is what consumers should rely on when spans are not strictly LIFO-nested.
+        assertThat(spanA.getSpanContext().getSpanId()).hasSize(16);
+        assertThat(spanB.getSpanContext().getSpanId()).hasSize(16);
+        assertThat(spanA.getSpanContext().getSpanId()).isNotEqualTo(spanB.getSpanContext().getSpanId());
+
+        scopeB.close();
+        spanA.end();
+        spanB.end();
+    }
 }

--- a/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/tracer/span/OpenTelemetrySpanIdTest.java
+++ b/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/tracer/span/OpenTelemetrySpanIdTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.opentelemetry.tracer.span;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.node.opentelemetry.tracer.noop.NoOpSpan;
+import io.gravitee.node.opentelemetry.tracer.vertx.VertxContext;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(VertxExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class OpenTelemetrySpanIdTest {
+
+    private OpenTelemetrySdk openTelemetry;
+
+    @BeforeEach
+    void setUp() {
+        InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
+        SdkTracerProvider tracerProvider = SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)).build();
+        openTelemetry = OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).build();
+    }
+
+    @Test
+    void traceId_should_match_underlying_otel_span_context(Vertx vertx) {
+        var vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+        var otelSpan = openTelemetry.getTracer("test").spanBuilder("test-span").startSpan();
+        var otelContext = Context.root().with(otelSpan);
+        var span = new OpenTelemetrySpan<>(vertxContext, otelContext, Scope.noop(), false, "request");
+
+        assertThat(span.traceId()).hasSize(32);
+        assertThat(span.traceId()).isEqualTo(otelSpan.getSpanContext().getTraceId());
+        otelSpan.end();
+    }
+
+    @Test
+    void spanId_should_match_underlying_otel_span_context(Vertx vertx) {
+        var vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+        var otelSpan = openTelemetry.getTracer("test").spanBuilder("test-span").startSpan();
+        var otelContext = Context.root().with(otelSpan);
+        var span = new OpenTelemetrySpan<>(vertxContext, otelContext, Scope.noop(), false, "request");
+
+        assertThat(span.spanId()).hasSize(16);
+        assertThat(span.spanId()).isEqualTo(otelSpan.getSpanContext().getSpanId());
+        otelSpan.end();
+    }
+
+    @Test
+    void traceId_and_spanId_should_remain_valid_after_otel_span_ended(Vertx vertx) {
+        // Span IDs come from SpanContext, which is immutable — ending the span does not invalidate
+        // the IDs. This is the property that makes Span#spanId() reliable in non-LIFO flows where
+        // the per-context slot has already been restored to null by an out-of-order end.
+        var vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+        var otelSpan = openTelemetry.getTracer("test").spanBuilder("test-span").startSpan();
+        var otelContext = Context.root().with(otelSpan);
+        var span = new OpenTelemetrySpan<>(vertxContext, otelContext, Scope.noop(), false, "request");
+        var expectedTraceId = otelSpan.getSpanContext().getTraceId();
+        var expectedSpanId = otelSpan.getSpanContext().getSpanId();
+        otelSpan.end();
+
+        assertThat(span.traceId()).isEqualTo(expectedTraceId);
+        assertThat(span.spanId()).isEqualTo(expectedSpanId);
+    }
+
+    @Test
+    void sibling_spans_should_each_return_their_own_ids(Vertx vertx) {
+        // Two spans sharing the same Vert.x context still report their own IDs, regardless of
+        // which one is currently attached to the context slot.
+        var vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+        var otelTracer = openTelemetry.getTracer("test");
+
+        var otelSpanA = otelTracer.spanBuilder("A").startSpan();
+        var otelSpanB = otelTracer.spanBuilder("B").startSpan();
+        var spanA = new OpenTelemetrySpan<>(vertxContext, Context.root().with(otelSpanA), Scope.noop(), false, "A");
+        var spanB = new OpenTelemetrySpan<>(vertxContext, Context.root().with(otelSpanB), Scope.noop(), false, "B");
+
+        assertThat(spanA.spanId()).isEqualTo(otelSpanA.getSpanContext().getSpanId());
+        assertThat(spanB.spanId()).isEqualTo(otelSpanB.getSpanContext().getSpanId());
+        assertThat(spanA.spanId()).isNotEqualTo(spanB.spanId());
+
+        otelSpanA.end();
+        otelSpanB.end();
+    }
+
+    @Test
+    void noOpSpan_traceId_should_return_empty() {
+        assertThat(NoOpSpan.asRoot().traceId()).isEmpty();
+        assertThat(NoOpSpan.asDefault().traceId()).isEmpty();
+    }
+
+    @Test
+    void noOpSpan_spanId_should_return_empty() {
+        assertThat(NoOpSpan.asRoot().spanId()).isEmpty();
+        assertThat(NoOpSpan.asDefault().spanId()).isEmpty();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <gravitee-common.version>4.6.0</gravitee-common.version>
         <gravitee-plugin.version>4.2.1</gravitee-plugin.version>
         <gravitee-plugin-common-configurations.version>1.2.3</gravitee-plugin-common-configurations.version>
-        <gravitee-reporter-api.version>1.33.0</gravitee-reporter-api.version>
+        <gravitee-reporter-api.version>2.3.0</gravitee-reporter-api.version>
         <gravitee-kubernetes.version>3.5.2</gravitee-kubernetes.version>
         <gravitee-secret-api.version>1.0.0</gravitee-secret-api.version>
         <snakeyaml.version>2.0</snakeyaml.version>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-13618

**Description**

Introduces a Logger interface and OpenTelemetryLogger implementation for emitting OTel log records to an OTLP endpoint
Adds OpenTelemetryFactory.createLogger() and a NoOpLogger fallback. Extends OpenTelemetryConfiguration with logsEndpoint.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `9.0.0-feat-APIM-13618-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/9.0.0-feat-APIM-13618-SNAPSHOT/gravitee-node-9.0.0-feat-APIM-13618-SNAPSHOT.zip)
  <!-- Version placeholder end -->
