### PR TITLE
feat: implement a tracing query service based on Tempo

### DIFF
--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/Tracer.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/Tracer.java
@@ -123,4 +123,13 @@ public interface Tracer extends Service<Tracer> {
      * @param textMapSetter a text map setter used to set fields into carrier
      */
     void injectSpanContext(final Context vertxContext, final Span span, final BiConsumer<String, String> textMapSetter);
+
+    /**
+     * Flush any pending spans to the configured exporter. Production callers should not need this — span batching is the
+     * intended export model. Test code uses it to drain the BatchSpanProcessor queue eagerly so the export latency does not
+     * dominate test runtime.
+     * <p>
+     * Default implementation is a no-op for tracers that are synchronous or do not buffer.
+     */
+    default void forceFlush() {}
 }

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/query/TracingQueryService.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/query/TracingQueryService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.api.opentelemetry.query;
+
+import io.gravitee.node.api.opentelemetry.query.model.Trace;
+import io.gravitee.node.api.opentelemetry.query.model.TraceSearchCriteria;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import java.util.List;
+
+/**
+ * Backend-agnostic port for querying stored traces. Implementations adapt this contract to a specific tracing backend
+ * (Grafana Tempo today; Jaeger / direct OTLP could follow).
+ *
+ * @author GraviteeSource Team
+ */
+public interface TracingQueryService {
+    /**
+     * List traces matching the given filter. The returned {@link Trace} entries carry summary fields only; {@code spans} is
+     * always empty — call {@link #getTrace(String)} to fetch a trace's spans.
+     *
+     * @param criteria filter (tags, time window, limit)
+     * @return list of matching traces; emits an empty list when no trace matches
+     */
+    Single<List<Trace>> searchTraces(TraceSearchCriteria criteria);
+
+    /**
+     * Fetch a single trace by id, including its full span tree.
+     *
+     * @param traceId the trace identifier
+     * @return the trace; completes empty when the backend has no trace for that id
+     */
+    Maybe<Trace> getTrace(String traceId);
+}

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/query/model/Trace.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/query/model/Trace.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.api.opentelemetry.query.model;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Aggregated view of a distributed trace returned by a {@link io.gravitee.node.api.opentelemetry.query.TracingQueryService}.
+ * <p>
+ * In list responses {@code spans} is empty (the backend only carries summary attributes); {@code spans} is populated when the
+ * trace is fetched by id. {@code hasError} may be {@code null} when the backend cannot determine the error status (e.g. older
+ * Tempo builds that do not support the {@code status = error} TraceQL intrinsic).
+ *
+ * @author GraviteeSource Team
+ */
+public record Trace(
+    String traceId,
+    Instant startTime,
+    long durationNanos,
+    String rootService,
+    String rootOperation,
+    Boolean hasError,
+    List<TraceSpan> spans
+) {
+    public Trace {
+        if (spans == null) {
+            spans = new ArrayList<>();
+        }
+    }
+}

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/query/model/TraceSearchCriteria.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/query/model/TraceSearchCriteria.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.api.opentelemetry.query.model;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Filter passed to {@link io.gravitee.node.api.opentelemetry.query.TracingQueryService#searchTraces(TraceSearchCriteria)}.
+ * <p>
+ * {@code tags} is a structured key/value filter — the backend decides where each key lands (resource vs. span attribute) and
+ * how it is encoded into the backend query language.
+ *
+ * @author GraviteeSource Team
+ */
+public record TraceSearchCriteria(Map<String, String> tags, Integer limit, Instant start, Instant end) {
+    public TraceSearchCriteria {
+        if (limit == null || limit <= 0) {
+            limit = 20;
+        }
+        if (tags == null) {
+            tags = new HashMap<>();
+        }
+    }
+}

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/query/model/TraceSpan.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/query/model/TraceSpan.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.api.opentelemetry.query.model;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A single span inside a {@link Trace}. {@code children} is a tree-projection field reserved for callers that want to rebuild
+ * the parent/child hierarchy locally — backends return spans flat and leave it empty (see {@link #of}).
+ *
+ * @author GraviteeSource Team
+ */
+public record TraceSpan(
+    String traceId,
+    String spanId,
+    String parentSpanId,
+    String operationName,
+    String serviceName,
+    Instant startTime,
+    long durationNanos,
+    Map<String, String> attributes,
+    List<TraceSpanEvent> events,
+    List<TraceSpan> children
+) {
+    public TraceSpan {
+        if (children == null) {
+            children = new ArrayList<>();
+        }
+        if (attributes == null) {
+            attributes = new HashMap<>();
+        }
+        if (events == null) {
+            events = new ArrayList<>();
+        }
+    }
+
+    public static TraceSpan of(
+        String traceId,
+        String spanId,
+        String parentSpanId,
+        String operationName,
+        String serviceName,
+        Instant startTime,
+        long durationNanos,
+        Map<String, String> attributes,
+        List<TraceSpanEvent> events
+    ) {
+        return new TraceSpan(
+            traceId,
+            spanId,
+            parentSpanId,
+            operationName,
+            serviceName,
+            startTime,
+            durationNanos,
+            attributes,
+            events,
+            new ArrayList<>()
+        );
+    }
+}

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/query/model/TraceSpanEvent.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/query/model/TraceSpanEvent.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.api.opentelemetry.query.model;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * A timestamped event attached to a {@link TraceSpan} (e.g. {@code exception}, {@code gravitee.policy.pre},
+ * {@code gravitee.policy.post}).
+ *
+ * @author GraviteeSource Team
+ */
+public record TraceSpanEvent(String name, Instant time, Map<String, String> attributes) {
+    public TraceSpanEvent {
+        if (attributes == null) {
+            attributes = new LinkedHashMap<>();
+        }
+    }
+}

--- a/gravitee-node-opentelemetry/README.adoc
+++ b/gravitee-node-opentelemetry/README.adoc
@@ -161,3 +161,210 @@ services:
           path: /path/to/truststore
           password: password
 ----
+
+== Tracing Query
+
+In addition to *exporting* spans (the OTLP exporter described above), the module also offers an
+opt-in *query* side: a `TracingQueryService` port that fetches stored traces back from a tracing
+backend. Today only a Grafana Tempo adapter is shipped; the port is generic enough for other
+backends (Jaeger, direct OTLP, …) to be added later.
+
+=== Port and model
+
+The contract lives in `gravitee-node-api` under
+`io.gravitee.node.api.opentelemetry.query`:
+
+[source,java]
+----
+public interface TracingQueryService {
+    Single<List<Trace>> searchTraces(TraceSearchCriteria criteria);
+    Maybe<Trace> getTrace(String traceId);
+}
+----
+
+`Trace`, `TraceSpan`, `TraceSpanEvent` and `TraceSearchCriteria` are records under
+`io.gravitee.node.api.opentelemetry.query.model`. The records themselves are immutable, but the
+collections they expose (`Trace.spans`, `TraceSpan.attributes`/`events`/`children`,
+`TraceSpanEvent.attributes`, `TraceSearchCriteria.tags`) are deliberately mutable: callers can rebuild
+or augment them — for example to apply product-specific overrides on top of what the Tempo adapter
+returns — without hitting `UnsupportedOperationException`. The API is reactive (RxJava 3) so it
+composes naturally with the Vert.x HTTP client used by the Tempo adapter.
+
+`TraceSearchCriteria` is structured (`Map<String,String> tags` + `Instant start`/`end` +
+`Integer limit`); the implementation decides how to translate keys into the backend query
+language. For Tempo, keys prefixed with `service.` or `telemetry.` go on the resource, everything
+else on the span.
+
+=== Backend behaviour
+
+The Tempo adapter returns Tempo's data as-is. In particular:
+
+* `searchTraces` returns one `Trace` per Tempo search hit with `rootService = rootServiceName`
+  and `rootOperation = rootTraceName` verbatim. `spans` is empty in list responses — call
+  `getTrace` to fetch a trace's spans.
+* `getTrace` returns the full span tree. `rootOperation` is taken from the parent-less span's
+  `name`. OTLP status codes are normalised so both numeric (`"0"`/`"1"`/`"2"`) and proto-enum
+  (`STATUS_CODE_UNSET/OK/ERROR`) Tempo serialisations surface as `"UNSET"`/`"OK"`/`"ERROR"` in
+  `TraceSpan.attributes["otel.status_code"]`.
+* `Trace.hasError` is set by a parallel second-pass TraceQL query (`status = error`) merged onto
+  the primary search response. Older Tempo builds that don't support the `status` intrinsic are
+  handled gracefully — the second pass is wrapped in `onErrorReturnItem(Set.of())` so the list
+  still loads with `hasError=false` instead of failing.
+
+Product-specific overrides (e.g. preferring an inbound HTTP server span's `http.target` +
+`http.method` over `rootTraceName` when an internal policy mutates `http.route`) are deliberately
+left to callers — they have access to the full span list returned by `getTrace` and can apply
+their own rule by rebuilding the `Trace` record before returning it from their use case.
+
+=== Configuration
+
+The module ships the building blocks; *consumers* (APIM, AM, …) register the bean in their own
+`@Configuration` and pick the property prefix that fits their namespace. The pattern mirrors the
+Redis cache plugin's `RedisConfigurationProvider` — the base library has no opinionated `@Bean`.
+
+Two entry points:
+
+* `TracingQueryConfigurationProvider.from(Environment, prefix)` — reads keys under `prefix` and
+  returns a populated `TracingQueryConfiguration` POJO.
+* `TempoTracingQueryServiceFactory.create(Vertx, Configuration, TracingQueryConfiguration)` —
+  builds a fully wired `TempoTracingQueryService` (Vert.x `HttpClient` via
+  `VertxHttpClientFactory`, headers, lifecycle).
+
+Typical wiring in a consumer module:
+
+[source,java]
+----
+@Bean(destroyMethod = "close")
+public TracingQueryService tempoTracingQueryService(
+    Environment environment,
+    Vertx vertx,
+    Configuration nodeConfiguration
+) {
+    var configuration = TracingQueryConfigurationProvider.from(environment, "apim.tracing.tempo");
+    return TempoTracingQueryServiceFactory.create(vertx, nodeConfiguration, configuration);
+}
+----
+
+==== General
+
+|===
+|Parameter |Default |Description
+
+|{prefix}.url
+|http://localhost:3200
+|Base URL of the Tempo HTTP API. The adapter calls `/api/traces/{id}` and `/api/search` against
+this host. `https://` triggers TLS using the SSL settings below.
+|===
+
+==== Headers
+
+Static headers added to every Tempo request. Useful for `X-Scope-OrgID` on multi-tenant Tempo
+deployments (Grafana Cloud) and for `Authorization` when Tempo is behind an auth-enforcing
+reverse proxy.
+
+|===
+|Parameter |Default |Description
+
+|{prefix}.headers[N].name
+|
+|Header name.
+
+|{prefix}.headers[N].value
+|
+|Header value.
+|===
+
+==== SSL settings
+
+|===
+|Parameter |Default |Description
+
+|{prefix}.ssl.trustAll
+|false
+|Disable certificate validation. Use with care.
+
+|{prefix}.ssl.verifyHost
+|true
+|Verify the certificate's subject / SANs against the target host.
+|===
+
+==== Proxy settings
+
+|===
+|Parameter |Default |Description
+
+|{prefix}.proxy.enabled
+|false
+|Enable proxy configuration.
+
+|{prefix}.proxy.useSystemProxy
+|false
+|Use the JVM's system proxy settings instead of an explicit host/port.
+
+|{prefix}.proxy.host
+|
+|Proxy host (when `useSystemProxy=false`).
+
+|{prefix}.proxy.port
+|0
+|Proxy port (when `useSystemProxy=false`).
+
+|{prefix}.proxy.username
+|
+|Optional proxy credentials.
+
+|{prefix}.proxy.password
+|
+|Optional proxy credentials.
+
+|{prefix}.proxy.type
+|HTTP
+|`HTTP`, `SOCKS4` or `SOCKS5`.
+|===
+
+==== HTTP timeouts
+
+|===
+|Parameter |Default |Description
+
+|{prefix}.http.connectTimeout
+|5000
+|(Milliseconds) TCP connect timeout for calls to Tempo.
+
+|{prefix}.http.idleTimeout
+|60000
+|(Milliseconds) Idle timeout on the connection. Closes the connection if no read/write activity
+is observed within the window.
+|===
+
+=== Example
+
+YAML for a consumer that picked the prefix `apim.tracing.tempo`:
+
+[source,yaml]
+----
+apim:
+  tracing:
+    tempo:
+      url: http://tempo.observability.svc:3200
+      headers:
+        - name: X-Scope-OrgID
+          value: tenant-prod
+        - name: Authorization
+          value: Bearer eyJhbGciOi...
+      ssl:
+        trustAll: false
+        verifyHost: true
+      http:
+        connectTimeout: 3000
+        idleTimeout: 30000
+----
+
+=== Lifecycle
+
+`TempoTracingQueryService` implements `AutoCloseable`. Its `close()` subscribes to the underlying
+Vert.x `HttpClient`'s close `Completable` so the connection pool is torn down cleanly on shutdown.
+
+The consumer owns the lifecycle. When registering the service as a Spring bean, use
+`@Bean(destroyMethod = "close")` (as in the wiring snippet above) so Spring closes it on context
+shutdown. Outside Spring the caller must invoke `close()` itself on shutdown.

--- a/gravitee-node-opentelemetry/pom.xml
+++ b/gravitee-node-opentelemetry/pom.xml
@@ -41,6 +41,11 @@
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-logging</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-vertx</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <!-- Vert.x -->
         <dependency>
             <groupId>io.vertx</groupId>
@@ -62,6 +67,12 @@
         <dependency>
             <groupId>io.smallrye.common</groupId>
             <artifactId>smallrye-common-vertx-context</artifactId>
+        </dependency>
+
+        <!-- Jackson -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
 
         <!-- Spring -->

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/configuration/TracingQueryConfiguration.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/configuration/TracingQueryConfiguration.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.opentelemetry.configuration;
+
+import io.gravitee.node.vertx.client.http.VertxHttpClientOptions;
+import io.gravitee.node.vertx.client.http.VertxHttpProxyOptions;
+import io.gravitee.node.vertx.client.ssl.SslOptions;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Data;
+
+/**
+ * POJO holding the connection settings for a tracing query backend (currently Tempo). Construct via
+ * {@link TracingQueryConfigurationProvider#from} when reading from a Spring {@code Environment}, or instantiate directly when
+ * a caller already has the values in hand.
+ *
+ * @author GraviteeSource Team
+ */
+@Data
+public class TracingQueryConfiguration {
+
+    private String url = "http://localhost:3200";
+    private Map<String, String> headers = new HashMap<>();
+    private SslOptions sslOptions = SslOptions.builder().build();
+    private VertxHttpProxyOptions proxyOptions;
+    private VertxHttpClientOptions httpOptions = VertxHttpClientOptions.builder().build();
+}

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/configuration/TracingQueryConfigurationProvider.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/configuration/TracingQueryConfigurationProvider.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.opentelemetry.configuration;
+
+import io.gravitee.node.vertx.client.http.VertxHttpClientOptions;
+import io.gravitee.node.vertx.client.http.VertxHttpProxyOptions;
+import io.gravitee.node.vertx.client.http.VertxHttpProxyType;
+import io.gravitee.node.vertx.client.ssl.SslOptions;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.core.env.Environment;
+
+/**
+ * Builds a {@link TracingQueryConfiguration} by reading keys under a caller-chosen property prefix from a Spring
+ * {@link Environment}. Mirrors the pattern used by the Redis cache plugin's {@code RedisConfigurationProvider} so any caller
+ * can plug the tracing query service into its own configuration namespace by passing the matching prefix.
+ *
+ * <p>Expected key layout (relative to {@code prefix}):
+ * <pre>
+ * {prefix}.url                          : String,  default "http://localhost:3200"
+ * {prefix}.headers[N].name              : String   (repeatable, indexed from 0)
+ * {prefix}.headers[N].value             : String
+ * {prefix}.ssl.trustAll                 : Boolean, default false
+ * {prefix}.ssl.verifyHost               : Boolean, default true
+ * {prefix}.proxy.enabled                : Boolean, default false
+ * {prefix}.proxy.useSystemProxy         : Boolean, default false
+ * {prefix}.proxy.host                   : String
+ * {prefix}.proxy.port                   : Integer, default 0
+ * {prefix}.proxy.username               : String
+ * {prefix}.proxy.password               : String
+ * {prefix}.proxy.type                   : VertxHttpProxyType (HTTP|SOCKS4|SOCKS5), default HTTP
+ * {prefix}.http.connectTimeout          : Long,    default 5000
+ * {prefix}.http.idleTimeout             : Long,    default 60000
+ * </pre>
+ *
+ * @author GraviteeSource Team
+ */
+public final class TracingQueryConfigurationProvider {
+
+    private TracingQueryConfigurationProvider() {
+        // no instances
+    }
+
+    public static TracingQueryConfiguration from(final Environment environment, final String prefix) {
+        TracingQueryConfiguration configuration = new TracingQueryConfiguration();
+        configuration.setUrl(environment.getProperty(prefix + ".url", String.class, configuration.getUrl()));
+        configuration.setHeaders(readHeaders(environment, prefix));
+        configuration.setSslOptions(readSslOptions(environment, prefix));
+        configuration.setProxyOptions(readProxyOptions(environment, prefix));
+        configuration.setHttpOptions(readHttpOptions(environment, prefix));
+        return configuration;
+    }
+
+    private static Map<String, String> readHeaders(final Environment environment, final String prefix) {
+        Map<String, String> headers = new HashMap<>();
+        for (int index = 0;; index++) {
+            String name = environment.getProperty(prefix + ".headers[" + index + "].name", String.class);
+            if (name == null) {
+                break;
+            }
+            String value = environment.getProperty(prefix + ".headers[" + index + "].value", String.class, "");
+            headers.put(name, value);
+        }
+        return headers;
+    }
+
+    private static SslOptions readSslOptions(final Environment environment, final String prefix) {
+        return SslOptions
+            .builder()
+            .trustAll(environment.getProperty(prefix + ".ssl.trustAll", Boolean.class, false))
+            .hostnameVerifier(environment.getProperty(prefix + ".ssl.verifyHost", Boolean.class, true))
+            .build();
+    }
+
+    private static VertxHttpProxyOptions readProxyOptions(final Environment environment, final String prefix) {
+        if (!environment.getProperty(prefix + ".proxy.enabled", Boolean.class, false)) {
+            return null;
+        }
+        return VertxHttpProxyOptions
+            .builder()
+            .enabled(true)
+            .useSystemProxy(environment.getProperty(prefix + ".proxy.useSystemProxy", Boolean.class, false))
+            .host(environment.getProperty(prefix + ".proxy.host", String.class))
+            .port(environment.getProperty(prefix + ".proxy.port", Integer.class, 0))
+            .username(environment.getProperty(prefix + ".proxy.username", String.class))
+            .password(environment.getProperty(prefix + ".proxy.password", String.class))
+            .type(environment.getProperty(prefix + ".proxy.type", VertxHttpProxyType.class, VertxHttpProxyType.HTTP))
+            .build();
+    }
+
+    private static VertxHttpClientOptions readHttpOptions(final Environment environment, final String prefix) {
+        return VertxHttpClientOptions
+            .builder()
+            .connectTimeout(environment.getProperty(prefix + ".http.connectTimeout", Long.class, 5000L))
+            .idleTimeout(environment.getProperty(prefix + ".http.idleTimeout", Long.class, 60000L))
+            .build();
+    }
+}

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/query/tempo/TempoHttpClient.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/query/tempo/TempoHttpClient.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.opentelemetry.query.tempo;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.reactivex.rxjava3.core.Single;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import lombok.CustomLog;
+
+/**
+ * Reactive Vert.x wrapper around Tempo's HTTP API. The underlying {@link HttpClient} is built by {@code VertxHttpClientFactory}
+ * with host/port/SSL/proxy already configured, so requests carry only the relative URI.
+ *
+ * @author GraviteeSource Team
+ */
+@CustomLog
+public class TempoHttpClient implements AutoCloseable {
+
+    private final HttpClient httpClient;
+    private final Map<String, String> staticHeaders;
+    private final ObjectMapper objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    public TempoHttpClient(final HttpClient httpClient, final Map<String, String> staticHeaders) {
+        this.httpClient = httpClient;
+        this.staticHeaders = staticHeaders == null ? Map.of() : Map.copyOf(staticHeaders);
+    }
+
+    public Single<TempoTraceResponse> getTrace(final String traceId) {
+        return executeGet("/api/traces/" + URLEncoder.encode(traceId, StandardCharsets.UTF_8), TempoTraceResponse.class);
+    }
+
+    public Single<TempoSearchResponse> searchTracesTraceQL(final String traceQL, final Integer limit, final Long start, final Long end) {
+        StringBuilder uri = new StringBuilder("/api/search");
+        String separator = "?";
+
+        if (traceQL != null) {
+            uri.append(separator).append("q=").append(URLEncoder.encode(traceQL, StandardCharsets.UTF_8));
+            separator = "&";
+        }
+        if (limit != null) {
+            uri.append(separator).append("limit=").append(limit);
+            separator = "&";
+        }
+        if (start != null) {
+            uri.append(separator).append("start=").append(start);
+            separator = "&";
+        }
+        if (end != null) {
+            uri.append(separator).append("end=").append(end);
+        }
+
+        return executeGet(uri.toString(), TempoSearchResponse.class);
+    }
+
+    /**
+     * Closes the underlying Vert.x {@link HttpClient}. Subscribed eagerly because the close result is not awaited — the bean
+     * lifecycle hook only triggers the close, it does not block on its completion.
+     */
+    @Override
+    public void close() {
+        httpClient.close().subscribe();
+    }
+
+    private <T> Single<T> executeGet(final String requestUri, final Class<T> responseType) {
+        return httpClient
+            .rxRequest(HttpMethod.GET, requestUri)
+            .map(req -> {
+                req.putHeader("Accept", "application/json");
+                staticHeaders.forEach(req::putHeader);
+                return req;
+            })
+            .flatMap(req -> req.rxSend())
+            .flatMap(resp -> {
+                int status = resp.statusCode();
+                if (status < 200 || status >= 300) {
+                    // Strip the query string from the logged path: encoded TraceQL can carry user-controlled tag values that
+                    // do not belong in operational logs.
+                    log.warn("Tempo API returned HTTP {} for {}", status, pathOnly(requestUri));
+                    return Single.error(new TempoClientException("Tempo API returned HTTP " + status));
+                }
+                return resp.body();
+            })
+            .map(buffer -> objectMapper.readValue(buffer.getBytes(), responseType));
+    }
+
+    private static String pathOnly(final String requestUri) {
+        int q = requestUri.indexOf('?');
+        return q < 0 ? requestUri : requestUri.substring(0, q);
+    }
+
+    public static class TempoClientException extends RuntimeException {
+
+        public TempoClientException(final String message) {
+            super(message);
+        }
+    }
+}

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/query/tempo/TempoSearchResponse.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/query/tempo/TempoSearchResponse.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.opentelemetry.query.tempo;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+
+/**
+ * Jackson model for Tempo's {@code GET /api/search} payload.
+ *
+ * @author GraviteeSource Team
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TempoSearchResponse(List<TraceResult> traces) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record TraceResult(String traceID, String rootServiceName, String rootTraceName, long startTimeUnixNano, long durationMs) {}
+}

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/query/tempo/TempoTraceResponse.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/query/tempo/TempoTraceResponse.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.opentelemetry.query.tempo;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+
+/**
+ * Jackson model for Tempo's {@code GET /api/traces/{id}} payload (OTLP-JSON).
+ * <p>
+ * {@code @JsonAlias("instrumentationLibrarySpans")} on {@code scopeSpans} accepts both the legacy and current OTLP JSON shapes.
+ * Tempo exposes attribute values as a tagged-union of {@code stringValue} / {@code intValue} / {@code boolValue} /
+ * {@code doubleValue} — see {@link Value#asString()}.
+ *
+ * @author GraviteeSource Team
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TempoTraceResponse(List<ResourceSpans> batches) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record ResourceSpans(Resource resource, @JsonAlias("instrumentationLibrarySpans") List<ScopeSpans> scopeSpans) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Resource(List<KeyValue> attributes) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record ScopeSpans(@JsonAlias("instrumentationLibrary") Scope scope, List<Span> spans) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Scope(String name) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Span(
+        String traceId,
+        String spanId,
+        String parentSpanId,
+        String name,
+        String startTimeUnixNano,
+        String endTimeUnixNano,
+        List<KeyValue> attributes,
+        Status status,
+        List<Event> events
+    ) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Event(String name, String timeUnixNano, List<KeyValue> attributes) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Status(String code, String message) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record KeyValue(String key, Value value) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Value(String stringValue, Long intValue, Boolean boolValue, Double doubleValue) {
+        public String asString() {
+            if (stringValue != null) return stringValue;
+            if (intValue != null) return intValue.toString();
+            if (boolValue != null) return boolValue.toString();
+            if (doubleValue != null) return doubleValue.toString();
+            return null;
+        }
+    }
+}

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/query/tempo/TempoTracingQueryService.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/query/tempo/TempoTracingQueryService.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.opentelemetry.query.tempo;
+
+import io.gravitee.node.api.opentelemetry.query.TracingQueryService;
+import io.gravitee.node.api.opentelemetry.query.model.Trace;
+import io.gravitee.node.api.opentelemetry.query.model.TraceSearchCriteria;
+import io.gravitee.node.api.opentelemetry.query.model.TraceSpan;
+import io.gravitee.node.api.opentelemetry.query.model.TraceSpanEvent;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Tempo-backed {@link TracingQueryService}.
+ *
+ * @author GraviteeSource Team
+ */
+public class TempoTracingQueryService implements TracingQueryService, AutoCloseable {
+
+    private final TempoHttpClient tempoClient;
+
+    public TempoTracingQueryService(TempoHttpClient tempoClient) {
+        this.tempoClient = tempoClient;
+    }
+
+    /**
+     * Releases the underlying HTTP client. Wired through Spring's {@code destroyMethod="close"} so the Vert.x client's pool is
+     * torn down cleanly on bean shutdown.
+     */
+    @Override
+    public void close() {
+        tempoClient.close();
+    }
+
+    @Override
+    public Single<List<Trace>> searchTraces(TraceSearchCriteria criteria) {
+        String traceQL = buildTraceQL(criteria.tags(), false);
+        String errorTraceQL = buildTraceQL(criteria.tags(), true);
+        Long start = criteria.start() != null ? criteria.start().getEpochSecond() : null;
+        Long end = criteria.end() != null ? criteria.end().getEpochSecond() : null;
+        if (start == null && end != null) {
+            start = end - 7 * 24 * 3600L;
+        }
+        Long startParam = start;
+        Long endParam = end;
+
+        Single<TempoSearchResponse> primary = tempoClient.searchTracesTraceQL(traceQL, criteria.limit(), startParam, endParam);
+        // Older Tempo builds may not support the `status = error` intrinsic; fall back to an empty error set rather than
+        // failing the whole list — the status column then renders as "unknown" instead of breaking the page.
+        Single<Set<String>> errorIds = tempoClient
+            .searchTracesTraceQL(errorTraceQL, criteria.limit(), startParam, endParam)
+            .map(TempoTracingQueryService::extractTraceIds)
+            .onErrorReturnItem(Set.of());
+
+        return Single.zip(primary, errorIds, this::buildTraces);
+    }
+
+    @Override
+    public Maybe<Trace> getTrace(String traceId) {
+        return tempoClient
+            .getTrace(traceId)
+            .flatMapMaybe(response -> {
+                if (response == null || response.batches() == null || response.batches().isEmpty()) {
+                    return Maybe.empty();
+                }
+                return Maybe.just(convertToTrace(traceId, response));
+            });
+    }
+
+    private static Set<String> extractTraceIds(TempoSearchResponse response) {
+        if (response.traces() == null) {
+            return Set.of();
+        }
+        Set<String> ids = new HashSet<>();
+        for (TempoSearchResponse.TraceResult r : response.traces()) {
+            ids.add(r.traceID());
+        }
+        return ids;
+    }
+
+    private List<Trace> buildTraces(TempoSearchResponse response, Set<String> errorTraceIds) {
+        List<Trace> traces = new ArrayList<>();
+        if (response.traces() != null) {
+            for (TempoSearchResponse.TraceResult result : response.traces()) {
+                traces.add(
+                    new Trace(
+                        result.traceID(),
+                        Instant.ofEpochMilli(result.startTimeUnixNano() / 1_000_000),
+                        result.durationMs() * 1_000_000,
+                        result.rootServiceName(),
+                        result.rootTraceName(),
+                        errorTraceIds.contains(result.traceID()),
+                        new ArrayList<>()
+                    )
+                );
+            }
+        }
+        return traces;
+    }
+
+    private Trace convertToTrace(String traceId, TempoTraceResponse response) {
+        List<TraceSpan> allSpans = new ArrayList<>();
+        String rootService = null;
+        String rootOperation = null;
+        Instant startTime = null;
+        long maxEndTime = 0;
+
+        for (TempoTraceResponse.ResourceSpans batch : response.batches()) {
+            String serviceName = extractServiceName(batch.resource());
+            if (batch.scopeSpans() == null) continue;
+
+            for (TempoTraceResponse.ScopeSpans scopeSpans : batch.scopeSpans()) {
+                if (scopeSpans.spans() == null) continue;
+
+                for (TempoTraceResponse.Span span : scopeSpans.spans()) {
+                    TraceSpan traceSpan = convertSpan(span, serviceName);
+                    allSpans.add(traceSpan);
+
+                    if (span.parentSpanId() == null || span.parentSpanId().isEmpty()) {
+                        rootService = serviceName;
+                        rootOperation = span.name();
+                        startTime = traceSpan.startTime();
+                    }
+
+                    long endNanos = Long.parseLong(span.endTimeUnixNano());
+                    if (endNanos > maxEndTime) {
+                        maxEndTime = endNanos;
+                    }
+                }
+            }
+        }
+
+        long durationNanos = 0;
+        if (startTime != null) {
+            long startNanos = startTime.getEpochSecond() * 1_000_000_000 + startTime.getNano();
+            durationNanos = maxEndTime - startNanos;
+        }
+
+        boolean hasError = allSpans.stream().anyMatch(s -> "ERROR".equals(s.attributes().get("otel.status_code")));
+
+        return new Trace(traceId, startTime, durationNanos, rootService, rootOperation, hasError, allSpans);
+    }
+
+    private TraceSpan convertSpan(TempoTraceResponse.Span span, String serviceName) {
+        Map<String, String> attrs = new HashMap<>();
+        if (span.attributes() != null) {
+            for (TempoTraceResponse.KeyValue kv : span.attributes()) {
+                String value = kv.value() != null ? kv.value().asString() : null;
+                if (value != null) {
+                    attrs.put(kv.key(), value);
+                }
+            }
+        }
+
+        // OTLP status codes: 0=UNSET, 1=OK, 2=ERROR. Tempo serialises them either as the numeric index ("0"/"1"/"2") or as the
+        // proto enum name ("STATUS_CODE_UNSET"/"STATUS_CODE_OK"/"STATUS_CODE_ERROR") depending on the version, so both forms
+        // are normalised here.
+        if (span.status() != null && span.status().code() != null) {
+            String statusCode =
+                switch (span.status().code()) {
+                    case "0", "STATUS_CODE_UNSET" -> "UNSET";
+                    case "1", "STATUS_CODE_OK" -> "OK";
+                    case "2", "STATUS_CODE_ERROR" -> "ERROR";
+                    default -> span.status().code();
+                };
+            attrs.put("otel.status_code", statusCode);
+        }
+
+        long startNanos = Long.parseLong(span.startTimeUnixNano());
+        long endNanos = Long.parseLong(span.endTimeUnixNano());
+        long durationNanos = endNanos - startNanos;
+
+        Instant startTime = Instant.ofEpochSecond(startNanos / 1_000_000_000, startNanos % 1_000_000_000);
+
+        List<TraceSpanEvent> events = convertEvents(span.events());
+
+        return TraceSpan.of(
+            span.traceId(),
+            span.spanId(),
+            span.parentSpanId(),
+            span.name(),
+            serviceName,
+            startTime,
+            durationNanos,
+            attrs,
+            events
+        );
+    }
+
+    private List<TraceSpanEvent> convertEvents(List<TempoTraceResponse.Event> rawEvents) {
+        if (rawEvents == null || rawEvents.isEmpty()) {
+            return new ArrayList<>();
+        }
+        List<TraceSpanEvent> events = new ArrayList<>(rawEvents.size());
+        for (TempoTraceResponse.Event rawEvent : rawEvents) {
+            Map<String, String> eventAttrs = new LinkedHashMap<>();
+            if (rawEvent.attributes() != null) {
+                for (TempoTraceResponse.KeyValue kv : rawEvent.attributes()) {
+                    String value = kv.value() != null ? kv.value().asString() : null;
+                    if (value != null) {
+                        eventAttrs.put(kv.key(), value);
+                    }
+                }
+            }
+            Instant eventTime = null;
+            if (rawEvent.timeUnixNano() != null) {
+                long nanos = Long.parseLong(rawEvent.timeUnixNano());
+                eventTime = Instant.ofEpochSecond(nanos / 1_000_000_000, nanos % 1_000_000_000);
+            }
+            events.add(new TraceSpanEvent(rawEvent.name(), eventTime, eventAttrs));
+        }
+        return events;
+    }
+
+    /**
+     * Turn a structured tag filter into TraceQL. {@code service.*} and {@code telemetry.*} keys go on the resource, everything
+     * else on the span. Multiple keys are joined with {@code &&}. When {@code errorsOnly} is true a {@code status = error}
+     * intrinsic is added so only traces with at least one errored span match.
+     */
+    private String buildTraceQL(Map<String, String> tags, boolean errorsOnly) {
+        StringBuilder sb = new StringBuilder("{ ");
+        boolean hasTag = tags != null && !tags.isEmpty();
+        if (hasTag) {
+            boolean first = true;
+            for (Map.Entry<String, String> entry : tags.entrySet()) {
+                if (!first) sb.append(" && ");
+                String key = entry.getKey();
+                String prefix = isResourceAttribute(key) ? "resource." : "span.";
+                sb.append(prefix).append(key).append(" = \"").append(entry.getValue()).append("\"");
+                first = false;
+            }
+        }
+        if (errorsOnly) {
+            if (hasTag) sb.append(" && ");
+            sb.append("status = error");
+        }
+        sb.append(" }");
+        return sb.toString();
+    }
+
+    private boolean isResourceAttribute(String key) {
+        return key.startsWith("service.") || key.startsWith("telemetry.");
+    }
+
+    private String extractServiceName(TempoTraceResponse.Resource resource) {
+        if (resource != null && resource.attributes() != null) {
+            for (TempoTraceResponse.KeyValue kv : resource.attributes()) {
+                if ("service.name".equals(kv.key()) && kv.value() != null) {
+                    return kv.value().asString();
+                }
+            }
+        }
+        return "unknown";
+    }
+}

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/query/tempo/TempoTracingQueryServiceFactory.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/query/tempo/TempoTracingQueryServiceFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.opentelemetry.query.tempo;
+
+import io.gravitee.node.api.configuration.Configuration;
+import io.gravitee.node.opentelemetry.configuration.TracingQueryConfiguration;
+import io.gravitee.node.vertx.client.http.VertxHttpClientFactory;
+import io.vertx.rxjava3.core.Vertx;
+import io.vertx.rxjava3.core.http.HttpClient;
+
+/**
+ * Wires a {@link TempoTracingQueryService} from a {@link TracingQueryConfiguration}. Callers can hold their own
+ * configuration (typically built via {@link io.gravitee.node.opentelemetry.configuration.TracingQueryConfigurationProvider})
+ * and ask the factory for a fully wired service without re-implementing the Vert.x HTTP client glue.
+ *
+ * @author GraviteeSource Team
+ */
+public final class TempoTracingQueryServiceFactory {
+
+    private static final String CLIENT_NAME = "opentelemetry-tracing-query";
+
+    private TempoTracingQueryServiceFactory() {
+        // no instances
+    }
+
+    public static TempoTracingQueryService create(
+        final Vertx vertx,
+        final Configuration nodeConfiguration,
+        final TracingQueryConfiguration configuration
+    ) {
+        HttpClient httpClient = VertxHttpClientFactory
+            .builder()
+            .vertx(vertx)
+            .nodeConfiguration(nodeConfiguration)
+            .defaultTarget(configuration.getUrl())
+            .name(CLIENT_NAME)
+            .sslOptions(configuration.getSslOptions())
+            .proxyOptions(configuration.getProxyOptions())
+            .httpOptions(configuration.getHttpOptions())
+            .build()
+            .createHttpClient();
+        return new TempoTracingQueryService(new TempoHttpClient(httpClient, configuration.getHeaders()));
+    }
+}

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/tracer/OpenTelemetryTracer.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/tracer/OpenTelemetryTracer.java
@@ -30,6 +30,7 @@ import io.vertx.core.Context;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
@@ -74,6 +75,11 @@ public class OpenTelemetryTracer extends AbstractService<Tracer> implements Trac
     protected void doStop() throws Exception {
         super.doStop();
         openTelemetrySdk.close();
+    }
+
+    @Override
+    public void forceFlush() {
+        openTelemetrySdk.getSdkTracerProvider().forceFlush().join(2, TimeUnit.SECONDS);
     }
 
     @Override

--- a/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/OpenTelemetryTracerIntegrationTest.java
+++ b/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/OpenTelemetryTracerIntegrationTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import io.gravitee.node.api.opentelemetry.Span;
+import io.gravitee.node.api.opentelemetry.Tracer;
 import io.gravitee.node.api.opentelemetry.internal.InternalRequest;
 import io.gravitee.node.api.opentelemetry.redaction.RedactionConfig;
 import io.gravitee.node.api.opentelemetry.redaction.RedactionRule;
@@ -38,6 +39,9 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxExtension;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 import lombok.NonNull;
 import org.junit.jupiter.api.AfterAll;
@@ -120,15 +124,17 @@ public class OpenTelemetryTracerIntegrationTest {
         );
         tracer.start();
 
-        Context vertxContext = vertx.getOrCreateContext();
-        Context duplicatedContext = VertxContext.createNewDuplicatedContext(vertxContext);
-        duplicatedContext.runOnContext(v -> {
-            var span = tracer.startSpanFrom(duplicatedContext, new InternalRequest("my-span", Map.of("custom", "value")));
-            tracer.end(duplicatedContext, span);
-        });
+        emitSpan(
+            vertx,
+            tracer,
+            ctx -> {
+                var span = tracer.startSpanFrom(ctx, new InternalRequest("my-span", Map.of("custom", "value")));
+                tracer.end(ctx, span);
+            }
+        );
 
         await()
-            .atMost(30, SECONDS)
+            .atMost(10, SECONDS)
             .untilAsserted(() -> {
                 var client = container.client(vertx);
                 var response = client
@@ -167,15 +173,17 @@ public class OpenTelemetryTracerIntegrationTest {
         );
         tracer.start();
 
-        Context vertxContext = vertx.getOrCreateContext();
-        Context duplicatedContext = VertxContext.createNewDuplicatedContext(vertxContext);
-        duplicatedContext.runOnContext(v -> {
-            var span = tracer.startSpanFrom(duplicatedContext, new InternalRequest("my-span", Map.of("custom", "value")));
-            tracer.end(duplicatedContext, span);
-        });
+        emitSpan(
+            vertx,
+            tracer,
+            ctx -> {
+                var span = tracer.startSpanFrom(ctx, new InternalRequest("my-span", Map.of("custom", "value")));
+                tracer.end(ctx, span);
+            }
+        );
 
         await()
-            .atMost(30, SECONDS)
+            .atMost(10, SECONDS)
             .untilAsserted(() -> {
                 var client = container.client(vertx);
                 var response = client
@@ -213,17 +221,19 @@ public class OpenTelemetryTracerIntegrationTest {
         );
         tracer.start();
 
-        Context vertxContext = vertx.getOrCreateContext();
-        Context duplicatedContext = VertxContext.createNewDuplicatedContext(vertxContext);
-        duplicatedContext.runOnContext(v -> {
-            Span span = tracer.startSpanFrom(duplicatedContext, new InternalRequest("my-span", Map.of("custom", "value")));
-            span.addEvent("my-event", Map.of("event.attribute", "event.value"));
-            span.inError();
-            tracer.end(duplicatedContext, span);
-        });
+        emitSpan(
+            vertx,
+            tracer,
+            ctx -> {
+                Span span = tracer.startSpanFrom(ctx, new InternalRequest("my-span", Map.of("custom", "value")));
+                span.addEvent("my-event", Map.of("event.attribute", "event.value"));
+                span.inError();
+                tracer.end(ctx, span);
+            }
+        );
 
         await()
-            .atMost(30, SECONDS)
+            .atMost(10, SECONDS)
             .untilAsserted(() -> {
                 var client = container.client(vertx);
                 var response = client
@@ -263,18 +273,20 @@ public class OpenTelemetryTracerIntegrationTest {
         );
         tracer.start();
 
-        Context vertxContext = vertx.getOrCreateContext();
-        Context duplicatedContext = VertxContext.createNewDuplicatedContext(vertxContext);
-        duplicatedContext.runOnContext(v -> {
-            var span = tracer.startSpanFrom(
-                duplicatedContext,
-                new InternalRequest("my-span", Map.of("custom", "secret-value", "http.method", "GET"))
-            );
-            tracer.end(duplicatedContext, span);
-        });
+        emitSpan(
+            vertx,
+            tracer,
+            ctx -> {
+                var span = tracer.startSpanFrom(
+                    ctx,
+                    new InternalRequest("my-span", Map.of("custom", "secret-value", "http.method", "GET"))
+                );
+                tracer.end(ctx, span);
+            }
+        );
 
         await()
-            .atMost(30, SECONDS)
+            .atMost(10, SECONDS)
             .untilAsserted(() -> {
                 var client = container.client(vertx);
                 var response = client
@@ -323,6 +335,27 @@ public class OpenTelemetryTracerIntegrationTest {
         return new OpenTelemetryFactory(openTelemetryConfiguration, new SpanExporterFactory(openTelemetryConfiguration, vertx));
     }
 
+    /**
+     * Runs the span work on a fresh Vert.x duplicated context, waits for the callback to complete, then drains the
+     * BatchSpanProcessor queue via {@link Tracer#forceFlush()}. Without this the tests pay the SDK's default 5s schedule
+     * delay per assertion, which dominates the suite runtime.
+     */
+    private static void emitSpan(Vertx vertx, Tracer tracer, Consumer<Context> work) throws InterruptedException {
+        CountDownLatch done = new CountDownLatch(1);
+        Context duplicatedContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+        duplicatedContext.runOnContext(v -> {
+            try {
+                work.accept(duplicatedContext);
+            } finally {
+                done.countDown();
+            }
+        });
+        if (!done.await(5, TimeUnit.SECONDS)) {
+            throw new IllegalStateException("Span work did not complete within 5 seconds");
+        }
+        tracer.forceFlush();
+    }
+
     @ParameterizedTest(name = "{0}")
     @MethodSource("generator")
     void should_connect_to_a_secure_jaeger_over_grpc(String name, JsonObject sslConfig, Vertx vertx) throws Exception {
@@ -361,15 +394,17 @@ public class OpenTelemetryTracerIntegrationTest {
         );
         tracer.start();
 
-        Context vertxContext = vertx.getOrCreateContext();
-        Context duplicatedContext = VertxContext.createNewDuplicatedContext(vertxContext);
-        duplicatedContext.runOnContext(v -> {
-            var span = tracer.startSpanFrom(duplicatedContext, new InternalRequest("my-span", Map.of("custom", "value")));
-            tracer.end(duplicatedContext, span);
-        });
+        emitSpan(
+            vertx,
+            tracer,
+            ctx -> {
+                var span = tracer.startSpanFrom(ctx, new InternalRequest("my-span", Map.of("custom", "value")));
+                tracer.end(ctx, span);
+            }
+        );
 
         await()
-            .atMost(30, SECONDS)
+            .atMost(10, SECONDS)
             .untilAsserted(() -> {
                 var client = containerTLS.client(vertx);
                 var response = client
@@ -406,15 +441,17 @@ public class OpenTelemetryTracerIntegrationTest {
         );
         tracer.start();
 
-        Context vertxContext = vertx.getOrCreateContext();
-        Context duplicatedContext = VertxContext.createNewDuplicatedContext(vertxContext);
-        duplicatedContext.runOnContext(v -> {
-            var span = tracer.startSpanFrom(duplicatedContext, new InternalRequest("my-span", Map.of("custom", "value")));
-            tracer.end(duplicatedContext, span);
-        });
+        emitSpan(
+            vertx,
+            tracer,
+            ctx -> {
+                var span = tracer.startSpanFrom(ctx, new InternalRequest("my-span", Map.of("custom", "value")));
+                tracer.end(ctx, span);
+            }
+        );
 
         await()
-            .atMost(30, SECONDS)
+            .atMost(10, SECONDS)
             .untilAsserted(() -> {
                 var client = container.client(vertx);
                 var response = client
@@ -467,15 +504,17 @@ public class OpenTelemetryTracerIntegrationTest {
         );
         tracer.start();
 
-        Context vertxContext = vertx.getOrCreateContext();
-        Context duplicatedContext = VertxContext.createNewDuplicatedContext(vertxContext);
-        duplicatedContext.runOnContext(v -> {
-            var span = tracer.startSpanFrom(duplicatedContext, new InternalRequest("my-span", Map.of("custom", "value")));
-            tracer.end(duplicatedContext, span);
-        });
+        emitSpan(
+            vertx,
+            tracer,
+            ctx -> {
+                var span = tracer.startSpanFrom(ctx, new InternalRequest("my-span", Map.of("custom", "value")));
+                tracer.end(ctx, span);
+            }
+        );
 
         await()
-            .atMost(30, SECONDS)
+            .atMost(10, SECONDS)
             .untilAsserted(() -> {
                 var client = containerTLS.client(vertx);
                 var response = client

--- a/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/configuration/TracingQueryConfigurationProviderTest.java
+++ b/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/configuration/TracingQueryConfigurationProviderTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.opentelemetry.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.node.vertx.client.http.VertxHttpProxyType;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class TracingQueryConfigurationProviderTest {
+
+    private static final String PREFIX = "services.opentelemetry.query.tempo";
+
+    private final MockEnvironment environment = new MockEnvironment();
+
+    @Test
+    void should_return_defaults_when_nothing_is_configured() {
+        TracingQueryConfiguration cfg = TracingQueryConfigurationProvider.from(environment, PREFIX);
+
+        assertThat(cfg.getUrl()).isEqualTo("http://localhost:3200");
+        assertThat(cfg.getHeaders()).isEmpty();
+        assertThat(cfg.getSslOptions().isTrustAll()).isFalse();
+        assertThat(cfg.getSslOptions().isHostnameVerifier()).isTrue();
+        assertThat(cfg.getProxyOptions()).isNull();
+        assertThat(cfg.getHttpOptions().getConnectTimeout()).isEqualTo(5000);
+        assertThat(cfg.getHttpOptions().getIdleTimeout()).isEqualTo(60000);
+    }
+
+    @Test
+    void should_read_url_under_the_provided_prefix() {
+        environment.setProperty(PREFIX + ".url", "http://tempo:3200");
+
+        assertThat(TracingQueryConfigurationProvider.from(environment, PREFIX).getUrl()).isEqualTo("http://tempo:3200");
+    }
+
+    @Test
+    void should_resolve_headers_from_bracket_list() {
+        environment.setProperty(PREFIX + ".headers[0].name", "X-Scope-OrgID");
+        environment.setProperty(PREFIX + ".headers[0].value", "tenant-1");
+        environment.setProperty(PREFIX + ".headers[1].name", "Authorization");
+        environment.setProperty(PREFIX + ".headers[1].value", "Bearer secret");
+
+        assertThat(TracingQueryConfigurationProvider.from(environment, PREFIX).getHeaders())
+            .containsExactlyInAnyOrderEntriesOf(Map.of("X-Scope-OrgID", "tenant-1", "Authorization", "Bearer secret"));
+    }
+
+    @Test
+    void should_default_header_value_to_empty_string_when_unset() {
+        environment.setProperty(PREFIX + ".headers[0].name", "X-Empty");
+
+        assertThat(TracingQueryConfigurationProvider.from(environment, PREFIX).getHeaders()).containsEntry("X-Empty", "");
+    }
+
+    @Test
+    void should_apply_ssl_overrides() {
+        environment.setProperty(PREFIX + ".ssl.trustAll", "true");
+        environment.setProperty(PREFIX + ".ssl.verifyHost", "false");
+
+        var ssl = TracingQueryConfigurationProvider.from(environment, PREFIX).getSslOptions();
+        assertThat(ssl.isTrustAll()).isTrue();
+        assertThat(ssl.isHostnameVerifier()).isFalse();
+    }
+
+    @Test
+    void should_build_proxy_options_when_enabled() {
+        environment.setProperty(PREFIX + ".proxy.enabled", "true");
+        environment.setProperty(PREFIX + ".proxy.host", "proxy.internal");
+        environment.setProperty(PREFIX + ".proxy.port", "8080");
+        environment.setProperty(PREFIX + ".proxy.username", "user");
+        environment.setProperty(PREFIX + ".proxy.password", "pass");
+        environment.setProperty(PREFIX + ".proxy.type", "SOCKS5");
+
+        var proxy = TracingQueryConfigurationProvider.from(environment, PREFIX).getProxyOptions();
+        assertThat(proxy).isNotNull();
+        assertThat(proxy.isEnabled()).isTrue();
+        assertThat(proxy.getHost()).isEqualTo("proxy.internal");
+        assertThat(proxy.getPort()).isEqualTo(8080);
+        assertThat(proxy.getUsername()).isEqualTo("user");
+        assertThat(proxy.getPassword()).isEqualTo("pass");
+        assertThat(proxy.getType()).isEqualTo(VertxHttpProxyType.SOCKS5);
+    }
+
+    @Test
+    void should_omit_proxy_options_when_disabled() {
+        environment.setProperty(PREFIX + ".proxy.host", "proxy.internal");
+
+        assertThat(TracingQueryConfigurationProvider.from(environment, PREFIX).getProxyOptions()).isNull();
+    }
+
+    @Test
+    void should_apply_http_timeouts() {
+        environment.setProperty(PREFIX + ".http.connectTimeout", "1234");
+        environment.setProperty(PREFIX + ".http.idleTimeout", "5678");
+
+        var options = TracingQueryConfigurationProvider.from(environment, PREFIX).getHttpOptions();
+        assertThat(options.getConnectTimeout()).isEqualTo(1234);
+        assertThat(options.getIdleTimeout()).isEqualTo(5678);
+    }
+
+    @Test
+    void should_isolate_settings_by_prefix() {
+        environment.setProperty(PREFIX + ".url", "http://tempo-prod:3200");
+        environment.setProperty("apim.tracing.tempo.url", "http://tempo-staging:3200");
+
+        assertThat(TracingQueryConfigurationProvider.from(environment, PREFIX).getUrl()).isEqualTo("http://tempo-prod:3200");
+        assertThat(TracingQueryConfigurationProvider.from(environment, "apim.tracing.tempo").getUrl())
+            .isEqualTo("http://tempo-staging:3200");
+    }
+}

--- a/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/query/tempo/TempoHttpClientTest.java
+++ b/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/query/tempo/TempoHttpClientTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.opentelemetry.query.tempo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.gravitee.node.api.configuration.Configuration;
+import io.gravitee.node.opentelemetry.query.tempo.TempoHttpClient.TempoClientException;
+import io.gravitee.node.vertx.client.http.VertxHttpClientFactory;
+import io.gravitee.node.vertx.client.http.VertxHttpClientOptions;
+import io.gravitee.node.vertx.client.ssl.SslOptions;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.junit5.VertxExtension;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * @author GraviteeSource Team
+ */
+@ExtendWith(VertxExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class TempoHttpClientTest {
+
+    private Vertx vertx;
+    private HttpServer server;
+    private TempoHttpClient client;
+    private final Queue<RecordedRequest> recorded = new ConcurrentLinkedQueue<>();
+    private volatile Consumer<HttpServerRequest> stubHandler = req -> req.response().setStatusCode(200).end("{}");
+
+    @BeforeEach
+    void start_server() throws InterruptedException {
+        vertx = Vertx.vertx();
+        server = vertx.createHttpServer();
+        server.requestHandler(req -> {
+            recorded.add(new RecordedRequest(req.method().name(), req.uri(), copyHeaders(req)));
+            stubHandler.accept(req);
+        });
+        server.listen(0, "127.0.0.1").toCompletionStage().toCompletableFuture().join();
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("X-Scope-OrgID", "tenant-1");
+        headers.put("Authorization", "Bearer secret");
+        client = new TempoHttpClient(buildHttpClient(server.actualPort()), headers);
+    }
+
+    @AfterEach
+    void tear_down() {
+        if (client != null) {
+            client.close();
+        }
+        if (server != null) {
+            server.close().toCompletionStage().toCompletableFuture().join();
+        }
+        if (vertx != null) {
+            vertx.close().toCompletionStage().toCompletableFuture().join();
+        }
+    }
+
+    @Test
+    void should_decode_a_successful_get_trace_response() {
+        stubHandler =
+            req ->
+                req
+                    .response()
+                    .putHeader("Content-Type", "application/json")
+                    .end(
+                        "{\"batches\":[{\"resource\":{\"attributes\":[{\"key\":\"service.name\",\"value\":{\"stringValue\":\"gateway\"}}]}," +
+                        "\"scopeSpans\":[{\"scope\":{\"name\":\"scope\"},\"spans\":[]}]}]}"
+                    );
+
+        TempoTraceResponse response = client.getTrace("abc-123").blockingGet();
+
+        assertThat(response).isNotNull();
+        assertThat(response.batches()).hasSize(1);
+        assertThat(response.batches().get(0).resource().attributes())
+            .singleElement()
+            .satisfies(kv -> assertThat(kv.value().asString()).isEqualTo("gateway"));
+    }
+
+    @Test
+    void should_send_static_headers_and_default_accept_on_each_request() {
+        stubHandler = req -> req.response().end("{}");
+
+        client.getTrace("abc-123").blockingGet();
+
+        assertThat(recorded)
+            .singleElement()
+            .satisfies(r -> {
+                assertThat(r.headers().get("Accept")).isEqualTo("application/json");
+                assertThat(r.headers().get("X-Scope-OrgID")).isEqualTo("tenant-1");
+                assertThat(r.headers().get("Authorization")).isEqualTo("Bearer secret");
+            });
+    }
+
+    @Test
+    void should_url_encode_the_traceql_query_and_path_segments() {
+        stubHandler = req -> req.response().end("{\"traces\":[]}");
+
+        String traceQL = "{ span.http.method = \"GET\" } | select(span.http.target)";
+        client.searchTracesTraceQL(traceQL, 10, 1700000000L, 1700000060L).blockingGet();
+
+        assertThat(recorded)
+            .singleElement()
+            .satisfies(r -> {
+                assertThat(r.uri()).startsWith("/api/search?q=");
+                assertThat(r.uri()).contains("limit=10");
+                assertThat(r.uri()).contains("start=1700000000");
+                assertThat(r.uri()).contains("end=1700000060");
+                // The encoded query carries the raw TraceQL even though it contains spaces, quotes and braces.
+                assertThat(
+                    java.net.URLDecoder.decode(
+                        r.uri().substring(r.uri().indexOf("q=") + 2, r.uri().indexOf("&")),
+                        java.nio.charset.StandardCharsets.UTF_8
+                    )
+                )
+                    .isEqualTo(traceQL);
+            });
+    }
+
+    @Test
+    void should_url_encode_the_trace_id() {
+        stubHandler = req -> req.response().end("{\"batches\":[]}");
+
+        client.getTrace("abc/with weird?chars").blockingGet();
+
+        assertThat(recorded).singleElement().satisfies(r -> assertThat(r.uri()).isEqualTo("/api/traces/abc%2Fwith+weird%3Fchars"));
+    }
+
+    @Test
+    void should_raise_tempo_client_exception_on_4xx() {
+        stubHandler = req -> req.response().setStatusCode(404).end("not found");
+
+        assertThatThrownBy(() -> client.getTrace("abc-123").blockingGet())
+            .isInstanceOf(TempoClientException.class)
+            .hasMessageContaining("404");
+    }
+
+    @Test
+    void should_raise_tempo_client_exception_on_5xx() {
+        stubHandler = req -> req.response().setStatusCode(500).end("internal error");
+
+        assertThatThrownBy(() -> client.getTrace("abc-123").blockingGet())
+            .isInstanceOf(TempoClientException.class)
+            .hasMessageContaining("500");
+    }
+
+    private io.vertx.rxjava3.core.http.HttpClient buildHttpClient(int port) {
+        return VertxHttpClientFactory
+            .builder()
+            .vertx(io.vertx.rxjava3.core.Vertx.newInstance(vertx))
+            .nodeConfiguration(staticConfiguration())
+            .defaultTarget("http://127.0.0.1:" + port)
+            .name("tempo-http-client-test")
+            .sslOptions(SslOptions.builder().build())
+            .httpOptions(VertxHttpClientOptions.builder().connectTimeout(2000).idleTimeout(5000).build())
+            .build()
+            .createHttpClient();
+    }
+
+    private static Configuration staticConfiguration() {
+        return new Configuration() {
+            @Override
+            public boolean containsProperty(String key) {
+                return false;
+            }
+
+            @Override
+            public String getProperty(String key) {
+                return null;
+            }
+
+            @Override
+            public String getProperty(String key, String defaultValue) {
+                return defaultValue;
+            }
+
+            @Override
+            public <T> T getProperty(String key, Class<T> targetType) {
+                return null;
+            }
+
+            @Override
+            public <T> T getProperty(String key, Class<T> targetType, T defaultValue) {
+                return defaultValue;
+            }
+        };
+    }
+
+    private static Map<String, List<String>> copyHeaders(HttpServerRequest req) {
+        Map<String, List<String>> copy = new HashMap<>();
+        req.headers().forEach(h -> copy.computeIfAbsent(h.getKey(), k -> new java.util.ArrayList<>()).add(h.getValue()));
+        return copy;
+    }
+
+    private record RecordedRequest(String method, String uri, Map<String, List<String>> headerMultimap) {
+        Map<String, String> headers() {
+            Map<String, String> flat = new HashMap<>();
+            headerMultimap.forEach((k, v) -> flat.put(k, v.get(0)));
+            return flat;
+        }
+    }
+}

--- a/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/query/tempo/TempoTracingQueryServiceTest.java
+++ b/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/query/tempo/TempoTracingQueryServiceTest.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.opentelemetry.query.tempo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.node.api.opentelemetry.query.model.Trace;
+import io.gravitee.node.api.opentelemetry.query.model.TraceSearchCriteria;
+import io.gravitee.node.api.opentelemetry.query.model.TraceSpan;
+import io.reactivex.rxjava3.core.Single;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class TempoTracingQueryServiceTest {
+
+    @Mock
+    TempoHttpClient tempoClient;
+
+    @InjectMocks
+    TempoTracingQueryService underTest;
+
+    @Test
+    void should_emit_empty_list_when_tempo_returns_no_traces() {
+        when(tempoClient.searchTracesTraceQL(any(), any(), any(), any())).thenReturn(Single.just(new TempoSearchResponse(null)));
+
+        List<Trace> traces = underTest.searchTraces(new TraceSearchCriteria(Map.of(), 20, null, null)).blockingGet();
+
+        assertThat(traces).isEmpty();
+    }
+
+    @Test
+    void should_route_resource_attributes_under_resource_prefix() {
+        when(tempoClient.searchTracesTraceQL(any(), any(), any(), any())).thenReturn(Single.just(new TempoSearchResponse(List.of())));
+
+        Map<String, String> tags = new LinkedHashMap<>();
+        tags.put("service.name", "gateway");
+        tags.put("http.method", "GET");
+        underTest.searchTraces(new TraceSearchCriteria(tags, 20, null, null)).blockingGet();
+
+        ArgumentCaptor<String> queryCaptor = ArgumentCaptor.forClass(String.class);
+        verify(tempoClient, times(2)).searchTracesTraceQL(queryCaptor.capture(), any(), any(), any());
+        String primaryQuery = queryCaptor.getAllValues().get(0);
+        assertThat(primaryQuery).contains("resource.service.name = \"gateway\"");
+        assertThat(primaryQuery).contains("span.http.method = \"GET\"");
+    }
+
+    @Test
+    void should_run_both_primary_and_error_passes() {
+        when(tempoClient.searchTracesTraceQL(any(), any(), any(), any())).thenReturn(Single.just(new TempoSearchResponse(List.of())));
+
+        underTest.searchTraces(new TraceSearchCriteria(Map.of(), 20, null, null)).blockingGet();
+
+        ArgumentCaptor<String> queryCaptor = ArgumentCaptor.forClass(String.class);
+        verify(tempoClient, times(2)).searchTracesTraceQL(queryCaptor.capture(), any(), any(), any());
+        assertThat(queryCaptor.getAllValues().get(0)).doesNotContain("status = error");
+        assertThat(queryCaptor.getAllValues().get(1)).contains("status = error");
+    }
+
+    @Test
+    void should_flag_traces_returned_by_the_error_pass() {
+        TempoSearchResponse primary = new TempoSearchResponse(List.of(traceResult("aaa"), traceResult("bbb")));
+        TempoSearchResponse errors = new TempoSearchResponse(List.of(traceResult("bbb")));
+        when(tempoClient.searchTracesTraceQL(any(), any(), any(), any())).thenReturn(Single.just(primary)).thenReturn(Single.just(errors));
+
+        List<Trace> traces = underTest.searchTraces(new TraceSearchCriteria(Map.of(), 20, null, null)).blockingGet();
+
+        assertThat(traces).hasSize(2);
+        assertThat(traces.get(0).hasError()).isFalse();
+        assertThat(traces.get(1).hasError()).isTrue();
+    }
+
+    @Test
+    void should_treat_traces_as_unflagged_when_error_pass_fails() {
+        // Older Tempo builds reject `status = error`; the list must still load with hasError=false.
+        TempoSearchResponse primary = new TempoSearchResponse(List.of(traceResult("aaa")));
+        when(tempoClient.searchTracesTraceQL(any(), any(), any(), any()))
+            .thenReturn(Single.just(primary))
+            .thenReturn(Single.error(new RuntimeException("intrinsic not supported")));
+
+        List<Trace> traces = underTest.searchTraces(new TraceSearchCriteria(Map.of(), 20, null, null)).blockingGet();
+
+        assertThat(traces).hasSize(1);
+        assertThat(traces.get(0).hasError()).isFalse();
+    }
+
+    @Test
+    void should_default_start_to_seven_days_before_end_when_only_end_is_set() {
+        when(tempoClient.searchTracesTraceQL(any(), any(), any(), any())).thenReturn(Single.just(new TempoSearchResponse(List.of())));
+
+        Instant end = Instant.parse("2026-04-29T12:00:00Z");
+        underTest.searchTraces(new TraceSearchCriteria(Map.of(), 20, null, end)).blockingGet();
+
+        ArgumentCaptor<Long> startCaptor = ArgumentCaptor.forClass(Long.class);
+        verify(tempoClient, times(2)).searchTracesTraceQL(any(), any(), startCaptor.capture(), eq(end.getEpochSecond()));
+        long expectedStart = end.getEpochSecond() - 7L * 24 * 3600;
+        assertThat(startCaptor.getValue()).isEqualTo(expectedStart);
+    }
+
+    @Test
+    void should_pass_root_trace_name_through_as_root_operation() {
+        TempoSearchResponse.TraceResult result = new TempoSearchResponse.TraceResult(
+            "abc",
+            "gateway",
+            "GET /proxy",
+            Instant.parse("2026-04-29T12:00:00Z").toEpochMilli() * 1_000_000L,
+            42L
+        );
+        when(tempoClient.searchTracesTraceQL(any(), any(), any(), any())).thenReturn(Single.just(new TempoSearchResponse(List.of(result))));
+
+        List<Trace> traces = underTest.searchTraces(new TraceSearchCriteria(Map.of(), 20, null, null)).blockingGet();
+
+        assertThat(traces)
+            .singleElement()
+            .satisfies(t -> {
+                assertThat(t.rootService()).isEqualTo("gateway");
+                assertThat(t.rootOperation()).isEqualTo("GET /proxy");
+            });
+    }
+
+    @Test
+    void should_return_empty_when_response_has_no_batches() {
+        when(tempoClient.getTrace("missing")).thenReturn(Single.just(new TempoTraceResponse(null)));
+
+        Optional<Trace> result = underTest.getTrace("missing").blockingGet() == null
+            ? Optional.empty()
+            : Optional.of(underTest.getTrace("missing").blockingGet());
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void should_return_empty_when_response_is_null() {
+        when(tempoClient.getTrace("missing")).thenReturn(Single.just(new TempoTraceResponse(null)));
+
+        assertThat(underTest.getTrace("missing").blockingGet()).isNull();
+    }
+
+    @Test
+    void should_normalise_numeric_status_codes() {
+        TempoTraceResponse response = singleBatch(
+            "gateway",
+            spanWithStatus("trace", "span-1", null, "GET", "0"),
+            spanWithStatus("trace", "span-2", "span-1", "child", "1"),
+            spanWithStatus("trace", "span-3", "span-1", "boom", "2")
+        );
+        when(tempoClient.getTrace("trace")).thenReturn(Single.just(response));
+
+        Trace trace = underTest.getTrace("trace").blockingGet();
+
+        assertThat(trace).isNotNull();
+        assertThat(trace.spans()).hasSize(3);
+        assertThat(statusOf(trace, "span-1")).isEqualTo("UNSET");
+        assertThat(statusOf(trace, "span-2")).isEqualTo("OK");
+        assertThat(statusOf(trace, "span-3")).isEqualTo("ERROR");
+        assertThat(trace.hasError()).isTrue();
+    }
+
+    @Test
+    void should_normalise_proto_enum_status_codes() {
+        TempoTraceResponse response = singleBatch(
+            "gateway",
+            spanWithStatus("trace", "span-1", null, "GET", "STATUS_CODE_UNSET"),
+            spanWithStatus("trace", "span-2", "span-1", "child", "STATUS_CODE_OK"),
+            spanWithStatus("trace", "span-3", "span-1", "boom", "STATUS_CODE_ERROR")
+        );
+        when(tempoClient.getTrace("trace")).thenReturn(Single.just(response));
+
+        Trace trace = underTest.getTrace("trace").blockingGet();
+
+        assertThat(statusOf(trace, "span-1")).isEqualTo("UNSET");
+        assertThat(statusOf(trace, "span-2")).isEqualTo("OK");
+        assertThat(statusOf(trace, "span-3")).isEqualTo("ERROR");
+    }
+
+    @Test
+    void should_use_root_span_name_for_root_operation() {
+        TempoTraceResponse response = singleBatch(
+            "gateway",
+            spanWithStatus("trace", "root", null, "GET /proxy", "0"),
+            spanWithStatus("trace", "child", "root", "callout", "0")
+        );
+        when(tempoClient.getTrace("trace")).thenReturn(Single.just(response));
+
+        Trace trace = underTest.getTrace("trace").blockingGet();
+
+        assertThat(trace).isNotNull();
+        assertThat(trace.rootService()).isEqualTo("gateway");
+        assertThat(trace.rootOperation()).isEqualTo("GET /proxy");
+    }
+
+    @Test
+    void should_propagate_close_to_http_client() {
+        underTest.close();
+        verify(tempoClient).close();
+    }
+
+    @Test
+    void should_return_mutable_collections_so_callers_can_post_process() {
+        TempoTraceResponse response = singleBatch("gateway", spanWithStatus("trace", "root", null, "GET /proxy", "0"));
+        when(tempoClient.getTrace("trace")).thenReturn(Single.just(response));
+
+        Trace trace = underTest.getTrace("trace").blockingGet();
+        assertThat(trace).isNotNull();
+
+        // Adding to spans / attributes / events must not throw.
+        trace.spans().add(null);
+        trace.spans().get(0).attributes().put("custom", "value");
+        trace.spans().get(0).children().add(null);
+        trace.spans().get(0).events().add(null);
+    }
+
+    // ----- helpers ---------------------------------------------------------
+
+    private static TempoSearchResponse.TraceResult traceResult(String id) {
+        return new TempoSearchResponse.TraceResult(id, "gateway", "GET /", 1_700_000_000_000_000_000L, 10L);
+    }
+
+    private static TempoTraceResponse.Value strVal(String value) {
+        return new TempoTraceResponse.Value(value, null, null, null);
+    }
+
+    private static TempoTraceResponse.Span spanWithStatus(
+        String traceId,
+        String spanId,
+        String parentSpanId,
+        String name,
+        String statusCode
+    ) {
+        return new TempoTraceResponse.Span(
+            traceId,
+            spanId,
+            parentSpanId,
+            name,
+            "1700000000000000000",
+            "1700000001000000000",
+            List.of(),
+            new TempoTraceResponse.Status(statusCode, null),
+            List.of()
+        );
+    }
+
+    private static TempoTraceResponse singleBatch(String serviceName, TempoTraceResponse.Span... spans) {
+        return new TempoTraceResponse(
+            List.of(
+                new TempoTraceResponse.ResourceSpans(
+                    new TempoTraceResponse.Resource(List.of(new TempoTraceResponse.KeyValue("service.name", strVal(serviceName)))),
+                    List.of(new TempoTraceResponse.ScopeSpans(new TempoTraceResponse.Scope("scope"), List.of(spans)))
+                )
+            )
+        );
+    }
+
+    private static String statusOf(Trace trace, String spanId) {
+        return trace
+            .spans()
+            .stream()
+            .filter(s -> s.spanId().equals(spanId))
+            .map(TraceSpan::attributes)
+            .map(a -> a.get("otel.status_code"))
+            .findFirst()
+            .orElse(null);
+    }
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

Add a generic tracing query service to fetch traces. Right now, only a Tempo implementation is available but it could be enhanced later. 

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `9.0.0-feat-add-tracing-tempo-query-service-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/9.0.0-feat-add-tracing-tempo-query-service-SNAPSHOT/gravitee-node-9.0.0-feat-add-tracing-tempo-query-service-SNAPSHOT.zip)
  <!-- Version placeholder end -->
