### PR TITLE
feat(redis,ssl): honour hostname algorithm and multi-cert PEM via shared SSL types

### DIFF
--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/redis/VertxRedisClientFactory.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/redis/VertxRedisClientFactory.java
@@ -188,7 +188,7 @@ public class VertxRedisClientFactory {
 
         var sslOptions = SslOptionsMapper.INSTANCE.map(sourceSslOptions);
         netClientOptions.setTrustAll(sslOptions.isTrustAll());
-        netClientOptions.setHostnameVerificationAlgorithm(sslOptions.isHostnameVerifier() ? "HTTPS" : "");
+        netClientOptions.setHostnameVerificationAlgorithm(resolveHostnameVerificationAlgorithm(sslOptions));
 
         if (sslOptions.getTlsProtocols() != null && !sslOptions.getTlsProtocols().isEmpty()) {
             netClientOptions.setEnabledSecureTransportProtocols(sslOptions.getTlsProtocols());
@@ -211,6 +211,25 @@ public class VertxRedisClientFactory {
         }
 
         sslOptions.keyStore().flatMap(KeyStore::keyCertOptions).ifPresent(netClientOptions::setKeyCertOptions);
+    }
+
+    /**
+     * Pick the hostname verification algorithm to apply on the Vert.x
+     * {@code NetClientOptions}. Precedence:
+     * <ol>
+     *   <li>{@code SslOptions.hostnameVerificationAlgorithm} if set and not
+     *       {@code "NONE"} — used verbatim, supports {@code HTTPS},
+     *       {@code LDAPS}, etc.</li>
+     *   <li>Otherwise {@code SslOptions.hostnameVerifier} — {@code true} →
+     *       {@code "HTTPS"}, {@code false} → {@code ""} (disabled).</li>
+     * </ol>
+     */
+    static String resolveHostnameVerificationAlgorithm(io.gravitee.node.vertx.client.ssl.SslOptions sslOptions) {
+        String algo = sslOptions.getHostnameVerificationAlgorithm();
+        if (algo != null && !algo.isEmpty() && !"NONE".equalsIgnoreCase(algo)) {
+            return algo;
+        }
+        return sslOptions.isHostnameVerifier() ? "HTTPS" : "";
     }
 
     /**

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/ssl/pem/PEMKeyStore.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/ssl/pem/PEMKeyStore.java
@@ -20,6 +20,7 @@ import io.gravitee.node.vertx.client.ssl.KeyStoreType;
 import io.vertx.core.net.KeyCertOptions;
 import io.vertx.core.net.PemKeyCertOptions;
 import java.io.Serial;
+import java.util.List;
 import java.util.Optional;
 import lombok.Builder;
 import lombok.Data;
@@ -39,22 +40,47 @@ public class PEMKeyStore extends KeyStore {
     private String keyContent;
     private String certPath;
     private String certContent;
+    private List<String> certPaths;
+    private List<String> keyPaths;
 
     public PEMKeyStore() {
         super(KeyStoreType.PEM);
     }
 
     public PEMKeyStore(String keyPath, String keyContent, String certPath, String certContent) {
+        this(keyPath, keyContent, certPath, certContent, null, null);
+    }
+
+    public PEMKeyStore(
+        String keyPath,
+        String keyContent,
+        String certPath,
+        String certContent,
+        List<String> certPaths,
+        List<String> keyPaths
+    ) {
         super(KeyStoreType.PEM);
         this.keyPath = keyPath;
         this.keyContent = keyContent;
         this.certPath = certPath;
         this.certContent = certContent;
+        this.certPaths = certPaths;
+        this.keyPaths = keyPaths;
     }
 
     @Override
     public Optional<KeyCertOptions> keyCertOptions() {
         final PemKeyCertOptions pemKeyCertOptions = new PemKeyCertOptions();
+
+        if (certPaths != null && !certPaths.isEmpty()) {
+            if (keyPaths == null || keyPaths.size() != certPaths.size()) {
+                throw new KeyStoreCertOptionsException("PEM certPaths and keyPaths must have the same size");
+            }
+            for (int i = 0; i < certPaths.size(); i++) {
+                pemKeyCertOptions.addCertPath(certPaths.get(i)).addKeyPath(keyPaths.get(i));
+            }
+            return Optional.of(pemKeyCertOptions);
+        }
 
         if (getCertPath() != null && !getCertPath().isEmpty()) {
             pemKeyCertOptions.setCertPath(getCertPath());

--- a/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/client/redis/VertxRedisClientFactoryTest.java
+++ b/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/client/redis/VertxRedisClientFactoryTest.java
@@ -394,4 +394,58 @@ class VertxRedisClientFactoryTest {
             assertThat(factory.sharedClientCount()).isZero();
         }
     }
+
+    @Nested
+    class HostnameAlgorithmResolution {
+
+        @Test
+        void shouldUseExplicitAlgorithmWhenProvided() {
+            var ssl = io.gravitee.node.vertx.client.ssl.SslOptions
+                .builder()
+                .hostnameVerifier(true)
+                .hostnameVerificationAlgorithm("LDAPS")
+                .build();
+            assertThat(VertxRedisClientFactory.resolveHostnameVerificationAlgorithm(ssl)).isEqualTo("LDAPS");
+        }
+
+        @Test
+        void shouldFallBackToHttpsWhenAlgorithmNoneAndVerifierTrue() {
+            var ssl = io.gravitee.node.vertx.client.ssl.SslOptions
+                .builder()
+                .hostnameVerifier(true)
+                .hostnameVerificationAlgorithm("NONE")
+                .build();
+            assertThat(VertxRedisClientFactory.resolveHostnameVerificationAlgorithm(ssl)).isEqualTo("HTTPS");
+        }
+
+        @Test
+        void shouldFallBackToEmptyWhenAlgorithmNoneAndVerifierFalse() {
+            var ssl = io.gravitee.node.vertx.client.ssl.SslOptions
+                .builder()
+                .hostnameVerifier(false)
+                .hostnameVerificationAlgorithm("NONE")
+                .build();
+            assertThat(VertxRedisClientFactory.resolveHostnameVerificationAlgorithm(ssl)).isEmpty();
+        }
+
+        @Test
+        void shouldFallBackToHttpsWhenAlgorithmNullAndVerifierTrue() {
+            var ssl = io.gravitee.node.vertx.client.ssl.SslOptions.builder().hostnameVerifier(true).build();
+            // hostnameVerificationAlgorithm builder-default is "NONE" — explicit-null only via setter.
+            ssl.setHostnameVerificationAlgorithm(null);
+            assertThat(VertxRedisClientFactory.resolveHostnameVerificationAlgorithm(ssl)).isEqualTo("HTTPS");
+        }
+
+        @Test
+        void explicitAlgorithmTakesPrecedenceOverVerifierFalse() {
+            // Verifier=false would normally disable verification, but an explicit
+            // algorithm string opts the operator into algorithm-driven verification.
+            var ssl = io.gravitee.node.vertx.client.ssl.SslOptions
+                .builder()
+                .hostnameVerifier(false)
+                .hostnameVerificationAlgorithm("HTTPS")
+                .build();
+            assertThat(VertxRedisClientFactory.resolveHostnameVerificationAlgorithm(ssl)).isEqualTo("HTTPS");
+        }
+    }
 }

--- a/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/client/ssl/pem/PEMKeyStoreTest.java
+++ b/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/client/ssl/pem/PEMKeyStoreTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.vertx.client.ssl.pem;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.gravitee.node.vertx.client.ssl.KeyStore;
+import io.vertx.core.net.PemKeyCertOptions;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PEMKeyStoreTest {
+
+    @Test
+    void shouldBuildKeyCertOptionsFromMultiCertList() {
+        var keyStore = PEMKeyStore.builder().certPaths(List.of("cert1.pem", "cert2.pem")).keyPaths(List.of("key1.pem", "key2.pem")).build();
+
+        var keyCertOptions = (PemKeyCertOptions) keyStore.keyCertOptions().orElseThrow();
+
+        assertThat(keyCertOptions.getCertPaths()).containsExactly("cert1.pem", "cert2.pem");
+        assertThat(keyCertOptions.getKeyPaths()).containsExactly("key1.pem", "key2.pem");
+    }
+
+    @Test
+    void shouldPreferMultiCertListOverSingleCertFields() {
+        var keyStore = PEMKeyStore
+            .builder()
+            .certPath("ignored.pem")
+            .keyPath("ignored-key.pem")
+            .certPaths(List.of("cert1.pem"))
+            .keyPaths(List.of("key1.pem"))
+            .build();
+
+        var keyCertOptions = (PemKeyCertOptions) keyStore.keyCertOptions().orElseThrow();
+
+        assertThat(keyCertOptions.getCertPaths()).containsExactly("cert1.pem").doesNotContain("ignored.pem");
+        assertThat(keyCertOptions.getKeyPaths()).containsExactly("key1.pem").doesNotContain("ignored-key.pem");
+    }
+
+    @Test
+    void shouldFallBackToSingleCertWhenListsAreNull() {
+        var keyStore = PEMKeyStore.builder().certPath("cert.pem").keyPath("key.pem").build();
+
+        var keyCertOptions = (PemKeyCertOptions) keyStore.keyCertOptions().orElseThrow();
+
+        assertThat(keyCertOptions.getCertPath()).isEqualTo("cert.pem");
+        assertThat(keyCertOptions.getKeyPath()).isEqualTo("key.pem");
+    }
+
+    @Test
+    void shouldRejectMismatchedCertAndKeyListSizes() {
+        var keyStore = PEMKeyStore.builder().certPaths(List.of("cert1.pem", "cert2.pem")).keyPaths(List.of("key1.pem")).build();
+
+        assertThatThrownBy(keyStore::keyCertOptions)
+            .isInstanceOf(KeyStore.KeyStoreCertOptionsException.class)
+            .hasMessageContaining("must have the same size");
+    }
+}


### PR DESCRIPTION
## Summary

- **`PEMKeyStore`**: add `certPaths: List<String>` + `keyPaths: List<String>`. `keyCertOptions()` iterates the lists when populated (with size-mismatch guard), falls back to the single-cert path otherwise.
- **`VertxRedisClientFactory.configureSsl`**: replace the boolean-only `setHostnameVerificationAlgorithm("HTTPS"|"")` mapping with `resolveHostnameVerificationAlgorithm(...)`. Precedence:
  1. `SslOptions.hostnameVerificationAlgorithm` if set and non-`NONE` → applied verbatim (supports `LDAPS`).
  2. Otherwise `SslOptions.hostnameVerifier` boolean → `HTTPS` if true, `""` if false.

## Why

The Redis rate-limit / distributed-sync migration in APIM ([gravitee-io/gravitee-api-management#16408](https://github.com/gravitee-io/gravitee-api-management/pull/16408)) routes through `VertxRedisClientFactory` and the shared `common-configurations.SslOptions`. Two documented YAML knobs were about to silently break:

- `hostnameVerificationAlgorithm: LDAPS` → reduced to a boolean, factory hardcoded HTTPS.
- `keystore.certificates[0..n]` → only `[0]` survived single-cert `PEMKeyStore`.

Both customer-visible. Companion change in [gravitee-io/gravitee-plugin-common-configurations#20](https://github.com/gravitee-io/gravitee-plugin-common-configurations/pull/20) surfaces the fields on the shared types; this PR wires them through `node-vertx.PEMKeyStore.keyCertOptions()` and `VertxRedisClientFactory.configureSsl`. MapStruct field-name mapping carries the data across (no explicit `@Mapping` annotations needed).

## Compatibility

- `node-vertx.PEMKeyStore` already had a 4-arg public constructor and a `@Builder` — added a 6-arg overload, kept the 4-arg as delegating.
- `VertxRedisClientFactory.configureSsl`: existing boolean-only callers (where `hostnameVerificationAlgorithm` is `null` / `NONE`) get identical behavior. Only callers that set the field opt into algorithm-driven verification.

## Depends on / blocks

- Companion: [gravitee-io/gravitee-plugin-common-configurations#20](https://github.com/gravitee-io/gravitee-plugin-common-configurations/pull/20) — surfaces the new fields on shared `SslOptions` / `PEMKeyStore`.
- End consumer: [gravitee-io/gravitee-api-management#16408](https://github.com/gravitee-io/gravitee-api-management/pull/16408)
- Fix for: [APIM-13779](https://gravitee.atlassian.net/browse/APIM-13779)
- Epic: [APIM-13553](https://gravitee.atlassian.net/browse/APIM-13553)

## Test plan

- [x] New `PEMKeyStoreTest` (4 cases): multi-cert list, list precedence over single-cert, single-cert fallback when lists null, mismatched-size guard.
- [x] New `VertxRedisClientFactoryTest$HostnameAlgorithmResolution` (5 cases): explicit algorithm, `NONE` fallback (verifier true/false), null algorithm, explicit algorithm overrides verifier=false.
- [x] All existing tests pass (33/33).
- [ ] CI green after common-configurations PR merges + releases.

[APIM-13779]: https://gravitee.atlassian.net/browse/APIM-13779
[APIM-13553]: https://gravitee.atlassian.net/browse/APIM-13553
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `9.0.0-wbabyte-APIM-13779-redis-hostname-multi-cert-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/9.0.0-wbabyte-APIM-13779-redis-hostname-multi-cert-SNAPSHOT/gravitee-node-9.0.0-wbabyte-APIM-13779-redis-hostname-multi-cert-SNAPSHOT.zip)
  <!-- Version placeholder end -->
