### PR TITLE
fix(deps): bump gravitee-plugin-common-configurations to 1.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <gravitee-bom.version>9.0.0-alpha.2</gravitee-bom.version>
         <gravitee-common.version>4.6.0</gravitee-common.version>
         <gravitee-plugin.version>4.2.1</gravitee-plugin.version>
-        <gravitee-plugin-common-configurations.version>1.2.1</gravitee-plugin-common-configurations.version>
+        <gravitee-plugin-common-configurations.version>1.2.3</gravitee-plugin-common-configurations.version>
         <gravitee-reporter-api.version>1.33.0</gravitee-reporter-api.version>
         <gravitee-kubernetes.version>3.5.2</gravitee-kubernetes.version>
         <gravitee-secret-api.version>1.0.0</gravitee-secret-api.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

bump gravitee-plugin-common-configurations to 1.2.3 


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `9.0.0-bump-plugin-config-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/9.0.0-bump-plugin-config-SNAPSHOT/gravitee-node-9.0.0-bump-plugin-config-SNAPSHOT.zip)
  <!-- Version placeholder end -->
