### PR TITLE
fix(ssl): null-safe hostnameVerificationAlgorithm in TCP client factory

### DIFF
--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/redis/VertxRedisClientFactory.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/redis/VertxRedisClientFactory.java
@@ -188,7 +188,7 @@ public class VertxRedisClientFactory {
 
         var sslOptions = SslOptionsMapper.INSTANCE.map(sourceSslOptions);
         netClientOptions.setTrustAll(sslOptions.isTrustAll());
-        netClientOptions.setHostnameVerificationAlgorithm(resolveHostnameVerificationAlgorithm(sslOptions));
+        netClientOptions.setHostnameVerificationAlgorithm(sslOptions.effectiveHostnameVerificationAlgorithm());
 
         if (sslOptions.getTlsProtocols() != null && !sslOptions.getTlsProtocols().isEmpty()) {
             netClientOptions.setEnabledSecureTransportProtocols(sslOptions.getTlsProtocols());
@@ -211,25 +211,6 @@ public class VertxRedisClientFactory {
         }
 
         sslOptions.keyStore().flatMap(KeyStore::keyCertOptions).ifPresent(netClientOptions::setKeyCertOptions);
-    }
-
-    /**
-     * Pick the hostname verification algorithm to apply on the Vert.x
-     * {@code NetClientOptions}. Precedence:
-     * <ol>
-     *   <li>{@code SslOptions.hostnameVerificationAlgorithm} if set and not
-     *       {@code "NONE"} — used verbatim, supports {@code HTTPS},
-     *       {@code LDAPS}, etc.</li>
-     *   <li>Otherwise {@code SslOptions.hostnameVerifier} — {@code true} →
-     *       {@code "HTTPS"}, {@code false} → {@code ""} (disabled).</li>
-     * </ol>
-     */
-    static String resolveHostnameVerificationAlgorithm(io.gravitee.node.vertx.client.ssl.SslOptions sslOptions) {
-        String algo = sslOptions.getHostnameVerificationAlgorithm();
-        if (algo != null && !algo.isEmpty() && !"NONE".equalsIgnoreCase(algo)) {
-            return algo;
-        }
-        return sslOptions.isHostnameVerifier() ? "HTTPS" : "";
     }
 
     /**

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/ssl/SslOptions.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/ssl/SslOptions.java
@@ -24,6 +24,8 @@ public class SslOptions implements Serializable {
     private static final long serialVersionUID = 5578794192878572915L;
 
     private boolean trustAll;
+
+    @Builder.Default
     private boolean hostnameVerifier = true;
 
     @Builder.Default
@@ -47,5 +49,29 @@ public class SslOptions implements Serializable {
 
     public Optional<KeyStore> keyStore() {
         return Optional.ofNullable(keyStore);
+    }
+
+    /**
+     * Hostname verification algorithm to apply on the Vert.x
+     * {@code NetClientOptions}. Precedence:
+     * <ol>
+     *   <li>{@link #hostnameVerificationAlgorithm} if set and not
+     *       {@code "NONE"} — used verbatim, supports {@code HTTPS},
+     *       {@code LDAPS}, etc.</li>
+     *   <li>Otherwise {@link #hostnameVerifier} — {@code true} →
+     *       {@code "HTTPS"}, {@code false} → {@code ""} (disabled).</li>
+     * </ol>
+     * Never returns {@code null}, so it is safe to pass directly to
+     * {@code NetClientOptions#setHostnameVerificationAlgorithm}.
+     */
+    public String effectiveHostnameVerificationAlgorithm() {
+        if (
+            hostnameVerificationAlgorithm != null &&
+            !hostnameVerificationAlgorithm.isEmpty() &&
+            !"NONE".equalsIgnoreCase(hostnameVerificationAlgorithm)
+        ) {
+            return hostnameVerificationAlgorithm;
+        }
+        return hostnameVerifier ? "HTTPS" : "";
     }
 }

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/tcp/VertxTcpClientFactory.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/tcp/VertxTcpClientFactory.java
@@ -119,7 +119,7 @@ public class VertxTcpClientFactory {
         }
 
         String hostnameVerificationAlgorithm = sslOptions.getHostnameVerificationAlgorithm();
-        if ("NONE".equals(hostnameVerificationAlgorithm)) {
+        if (hostnameVerificationAlgorithm == null || "NONE".equalsIgnoreCase(hostnameVerificationAlgorithm)) {
             clientOptions.setHostnameVerificationAlgorithm("");
         } else {
             clientOptions.setHostnameVerificationAlgorithm(hostnameVerificationAlgorithm);

--- a/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/client/redis/VertxRedisClientFactoryTest.java
+++ b/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/client/redis/VertxRedisClientFactoryTest.java
@@ -405,7 +405,7 @@ class VertxRedisClientFactoryTest {
                 .hostnameVerifier(true)
                 .hostnameVerificationAlgorithm("LDAPS")
                 .build();
-            assertThat(VertxRedisClientFactory.resolveHostnameVerificationAlgorithm(ssl)).isEqualTo("LDAPS");
+            assertThat(ssl.effectiveHostnameVerificationAlgorithm()).isEqualTo("LDAPS");
         }
 
         @Test
@@ -415,7 +415,7 @@ class VertxRedisClientFactoryTest {
                 .hostnameVerifier(true)
                 .hostnameVerificationAlgorithm("NONE")
                 .build();
-            assertThat(VertxRedisClientFactory.resolveHostnameVerificationAlgorithm(ssl)).isEqualTo("HTTPS");
+            assertThat(ssl.effectiveHostnameVerificationAlgorithm()).isEqualTo("HTTPS");
         }
 
         @Test
@@ -425,7 +425,7 @@ class VertxRedisClientFactoryTest {
                 .hostnameVerifier(false)
                 .hostnameVerificationAlgorithm("NONE")
                 .build();
-            assertThat(VertxRedisClientFactory.resolveHostnameVerificationAlgorithm(ssl)).isEmpty();
+            assertThat(ssl.effectiveHostnameVerificationAlgorithm()).isEmpty();
         }
 
         @Test
@@ -433,7 +433,7 @@ class VertxRedisClientFactoryTest {
             var ssl = io.gravitee.node.vertx.client.ssl.SslOptions.builder().hostnameVerifier(true).build();
             // hostnameVerificationAlgorithm builder-default is "NONE" — explicit-null only via setter.
             ssl.setHostnameVerificationAlgorithm(null);
-            assertThat(VertxRedisClientFactory.resolveHostnameVerificationAlgorithm(ssl)).isEqualTo("HTTPS");
+            assertThat(ssl.effectiveHostnameVerificationAlgorithm()).isEqualTo("HTTPS");
         }
 
         @Test
@@ -445,7 +445,7 @@ class VertxRedisClientFactoryTest {
                 .hostnameVerifier(false)
                 .hostnameVerificationAlgorithm("HTTPS")
                 .build();
-            assertThat(VertxRedisClientFactory.resolveHostnameVerificationAlgorithm(ssl)).isEqualTo("HTTPS");
+            assertThat(ssl.effectiveHostnameVerificationAlgorithm()).isEqualTo("HTTPS");
         }
     }
 }

--- a/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/client/tcp/VertxTcpClientFactoryTest.java
+++ b/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/client/tcp/VertxTcpClientFactoryTest.java
@@ -69,6 +69,22 @@ class VertxTcpClientFactoryTest {
         assertThat(tcpClient).isNotNull();
     }
 
+    @Test
+    void should_build_client_when_hostnameVerificationAlgorithm_is_null() throws Exception {
+        // Reproduces the regression from apim TCP proxy endpoint tests: SslOptions
+        // populated via mapper/setter ends up with hostnameVerificationAlgorithm=null
+        // (Lombok's @Builder.Default does not apply to @NoArgsConstructor + setter
+        // population). The factory must treat null/NONE as verification-disabled
+        // instead of passing null straight to Vert.x.
+        final SslOptions sslOptions = new SslOptions();
+        sslOptions.setHostnameVerificationAlgorithm(null);
+
+        final var vertxTcpClientFactoryBuilder = builder().sslOptions(sslOptions);
+        final var tcpClient = vertxTcpClientFactoryBuilder.build().createTcpClient();
+
+        assertThat(tcpClient).isNotNull();
+    }
+
     @Nested
     class PEM {
 


### PR DESCRIPTION
## Summary

`VertxTcpClientFactory.configureSslClientOption` was passing `SslOptions.hostnameVerificationAlgorithm` verbatim to Vert.x's `NetClientOptions.setHostnameVerificationAlgorithm`, which throws NPE when the field is null. Lombok's `@Builder.Default = \"NONE\"` does not apply when `SslOptions` is populated via the no-args constructor + setters (or via a mapper that does the same), so the field is null in those code paths.

This regressed the apim `TcpProxyEndpointConnectorTest#should_connect_to_backend` after the alpha.10 bump (see [apim PR #16408](https://github.com/gravitee-io/gravitee-api-management/pull/16408) CI failure).

The Redis factory was already null-safe via a private `resolveHostnameVerificationAlgorithm` helper introduced in #556. This PR promotes that helper to `SslOptions.effectiveHostnameVerificationAlgorithm()` so the contract (explicit algorithm wins, else fall back to the legacy `hostnameVerifier` boolean) lives next to the field, and both factories route through it.

## Why

* APIM-13779 needs the algorithm + multi-cert fields to be safe to set or leave null on every consuming factory, not just the Redis one.
* Putting the contract on `SslOptions` is what `gravitee-plugin-common-configurations#20` already documents in its Javadoc — \"interpreted in the consuming layer\". This PR makes that interpretation a single explicit method.

## Changes

- `SslOptions.effectiveHostnameVerificationAlgorithm()` — new, never returns null. Documents the precedence: explicit non-`NONE` algorithm → use it; otherwise `hostnameVerifier ? \"HTTPS\" : \"\"`.
- `VertxTcpClientFactory.configureSslClientOption` — calls the new method; removes the broken null-on-null path.
- `VertxRedisClientFactory` — replaces the private static helper with a delegate to the new method; behavior unchanged.
- `VertxRedisClientFactoryTest` — five existing precedence tests now call `ssl.effectiveHostnameVerificationAlgorithm()` directly (the helper they targeted is gone).
- `VertxTcpClientFactoryTest#should_build_client_when_hostnameVerificationAlgorithm_is_null` — new regression test reproducing the apim breakage via no-args + explicit-null setter.

## Compatibility

Purely additive on the public API (`SslOptions` gains a method). No behavior change for callers who already set `hostnameVerificationAlgorithm` explicitly.

## Depends on / blocks

- Blocks: [apim #16408](https://github.com/gravitee-io/gravitee-api-management/pull/16408) — needs alpha.11 bump once this releases.
- Companion (already merged): #556 — added the algorithm/multi-cert fields wired through Redis.
- Touches: [gravitee-plugin-common-configurations #20](https://github.com/gravitee-io/gravitee-plugin-common-configurations/pull/20) — same Javadoc contract on the source-side `SslOptions`.

## Test plan

- [x] Local: 175/175 `gravitee-node-vertx` tests pass.
- [x] New: `VertxTcpClientFactoryTest#should_build_client_when_hostnameVerificationAlgorithm_is_null`.
- [x] Existing precedence tests retargeted to the new method (5 cases — explicit algorithm, NONE+verifier-true, NONE+verifier-false, null+verifier-true, explicit-vs-verifier-false).
- [ ] CI green.
- [ ] After merge + alpha.11 release, retry apim PR #16408 CI.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `9.0.0-wba-fix-tcp-hostname-null-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/9.0.0-wba-fix-tcp-hostname-null-SNAPSHOT/gravitee-node-9.0.0-wba-fix-tcp-hostname-null-SNAPSHOT.zip)
  <!-- Version placeholder end -->
