### PR TITLE
fix(deps) Updating versions to fix vulnerabilities

### DIFF
--- a/gravitee-node-secrets/gravitee-secret-provider-mock/pom.xml
+++ b/gravitee-node-secrets/gravitee-secret-provider-mock/pom.xml
@@ -40,22 +40,27 @@
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-logging</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.gravitee.secret</groupId>
             <artifactId>gravitee-secret-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.gravitee.plugin</groupId>
             <artifactId>gravitee-plugin-core</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.reactivex.rxjava3</groupId>
             <artifactId>rxjava</artifactId>
+            <scope>provided</scope>
         </dependency>
         <!-- tests -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -57,14 +57,14 @@
     </modules>
 
     <properties>
-        <gravitee-bom.version>8.3.41</gravitee-bom.version>
+        <gravitee-bom.version>8.3.56</gravitee-bom.version>
         <gravitee-common.version>4.6.0</gravitee-common.version>
         <gravitee-plugin.version>4.2.1</gravitee-plugin.version>
         <gravitee-reporter-api.version>1.33.0</gravitee-reporter-api.version>
         <gravitee-kubernetes.version>3.5.2</gravitee-kubernetes.version>
         <gravitee-secret-api.version>1.0.0</gravitee-secret-api.version>
         <snakeyaml.version>2.0</snakeyaml.version>
-        <hazelcast.version>5.5.0</hazelcast.version>
+        <hazelcast.version>5.7.0</hazelcast.version>
         <gravitee-alert-api.version>1.9.1</gravitee-alert-api.version>
         <protobuf-java.version>3.25.5</protobuf-java.version>
         <opentelemetry.version>1.39.0</opentelemetry.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13243

## Description

Bumping up gravitee-apim to stable versions in order to fix for vulnerability GHSA 72hv-8253 57qq
## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `8.0.4-fix-apim-13243-master-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/8.0.4-fix-apim-13243-master-SNAPSHOT/gravitee-node-8.0.4-fix-apim-13243-master-SNAPSHOT.zip)
  <!-- Version placeholder end -->
