### PR TITLE
feat: add support for multitenancy in TracingQueryService and Tempo impl

### DIFF
--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/query/TracingQueryService.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/query/TracingQueryService.java
@@ -17,6 +17,7 @@ package io.gravitee.node.api.opentelemetry.query;
 
 import io.gravitee.node.api.opentelemetry.query.model.Trace;
 import io.gravitee.node.api.opentelemetry.query.model.TraceSearchCriteria;
+import io.gravitee.node.api.opentelemetry.query.model.TracingQueryContext;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 import java.util.List;
@@ -24,24 +25,30 @@ import java.util.List;
 /**
  * Backend-agnostic port for querying stored traces. Implementations adapt this contract to a specific tracing backend
  * (Grafana Tempo today; Jaeger / direct OTLP could follow).
+ * <p>
+ * Both methods take a {@link TracingQueryContext} so implementations can scope a request — Tempo uses it to set the
+ * {@code X-Scope-OrgID} header for multi-tenant deployments, single-tenant backends just ignore it. Pass
+ * {@link TracingQueryContext#EMPTY} when no per-call context applies.
  *
  * @author GraviteeSource Team
  */
 public interface TracingQueryService {
     /**
-     * List traces matching the given filter. The returned {@link Trace} entries carry summary fields only; {@code spans} is
-     * always empty — call {@link #getTrace(String)} to fetch a trace's spans.
+     * List traces matching the given filter. The returned {@link Trace} entries carry summary fields only;
+     * {@code spans} is always empty — call {@link #getTrace(TracingQueryContext, String)} to fetch a trace's spans.
      *
+     * @param context per-call context (tenant for multi-tenant backends; pass {@link TracingQueryContext#EMPTY} otherwise)
      * @param criteria filter (tags, time window, limit)
      * @return list of matching traces; emits an empty list when no trace matches
      */
-    Single<List<Trace>> searchTraces(TraceSearchCriteria criteria);
+    Single<List<Trace>> searchTraces(TracingQueryContext context, TraceSearchCriteria criteria);
 
     /**
      * Fetch a single trace by id, including its full span tree.
      *
+     * @param context per-call context (tenant for multi-tenant backends; pass {@link TracingQueryContext#EMPTY} otherwise)
      * @param traceId the trace identifier
      * @return the trace; completes empty when the backend has no trace for that id
      */
-    Maybe<Trace> getTrace(String traceId);
+    Maybe<Trace> getTrace(TracingQueryContext context, String traceId);
 }

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/query/model/TraceSearchCriteria.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/query/model/TraceSearchCriteria.java
@@ -20,20 +20,22 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Filter passed to {@link io.gravitee.node.api.opentelemetry.query.TracingQueryService#searchTraces(TraceSearchCriteria)}.
+ * Filter passed to {@link io.gravitee.node.api.opentelemetry.query.TracingQueryService#searchTraces(TracingQueryContext, TraceSearchCriteria)}.
  * <p>
- * {@code tags} is a structured key/value filter — the backend decides where each key lands (resource vs. span attribute) and
- * how it is encoded into the backend query language.
+ * {@code attributeFilters} is a structured key/value filter on span attributes — the backend decides where each
+ * key lands (resource vs. span attribute) and how it is encoded into the backend query language. Resource-side
+ * filters travel separately via {@link TracingQueryContext#resourceAttributeFilters()} so the caller can be
+ * explicit about which side of the OTel data model each filter applies to.
  *
  * @author GraviteeSource Team
  */
-public record TraceSearchCriteria(Map<String, String> tags, Integer limit, Instant start, Instant end) {
+public record TraceSearchCriteria(Map<String, String> attributeFilters, Integer limit, Instant start, Instant end) {
     public TraceSearchCriteria {
         if (limit == null || limit <= 0) {
             limit = 20;
         }
-        if (tags == null) {
-            tags = new HashMap<>();
+        if (attributeFilters == null) {
+            attributeFilters = new HashMap<>();
         }
     }
 }

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/query/model/TracingQueryContext.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/query/model/TracingQueryContext.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.api.opentelemetry.query.model;
+
+import java.util.Map;
+
+/**
+ * Per-request context passed to a {@link io.gravitee.node.api.opentelemetry.query.TracingQueryService} call.
+ * <p>
+ * Carries two scoping knobs, both backend-agnostic:
+ * <ul>
+ *   <li>{@code tenant} — backend-level tenant identity. Tempo turns it into {@code X-Scope-OrgID}; backends
+ *       without multi-tenancy ignore it.</li>
+ *   <li>{@code resourceAttributeFilters} — soft scoping nested inside the tenant. Each entry is injected as an
+ *       equality clause on an OTel resource attribute. Tempo emits TraceQL
+ *       {@code resource.<key> = "<value>"} clauses joined with {@code &&}; callers can use any attribute key
+ *       (e.g. {@code gravitee.environment.id}, {@code service.namespace}, {@code cloud.region}). Empty map
+ *       means no extra scoping.</li>
+ * </ul>
+ * The record is left open for future per-call knobs (e.g. correlation id, caller-supplied auth headers) without
+ * forcing a signature change.
+ *
+ * @author GraviteeSource Team
+ */
+public record TracingQueryContext(String tenant, Map<String, String> resourceAttributeFilters) {
+    public TracingQueryContext {
+        // Defensive copy + null-safety so callers can pass null without the consumers having to null-check.
+        resourceAttributeFilters = resourceAttributeFilters == null ? Map.of() : Map.copyOf(resourceAttributeFilters);
+    }
+
+    /** Empty context — used by callers that need neither tenancy nor any resource-attribute scoping. */
+    public static final TracingQueryContext EMPTY = new TracingQueryContext(null, Map.of());
+
+    public static TracingQueryContext forTenant(String tenant) {
+        return new TracingQueryContext(tenant, Map.of());
+    }
+
+    public static TracingQueryContext of(String tenant, Map<String, String> resourceAttributeFilters) {
+        return new TracingQueryContext(tenant, resourceAttributeFilters);
+    }
+}

--- a/gravitee-node-opentelemetry/README.adoc
+++ b/gravitee-node-opentelemetry/README.adoc
@@ -2,7 +2,7 @@
 
 == Description
 
-The *Gravitee Node OpenTelemtry* module offers the capabilities to create Tracer based on OpenTelemetry implementation. This Tracer could be then used to create start/end spans for any request objets.
+The *Gravitee Node OpenTelemetry* module offers the capabilities to create Tracer based on OpenTelemetry implementation. This Tracer could be then used to create start/end spans for any request objets.
 
 == Configuration
 
@@ -36,6 +36,12 @@ All the exporter configurations are located under the `services.opentelemetry.ex
 |endpoint
 |http://localhost:4317
 |Sets the OTLP endpoint to send telemetry data. If unset, defaults to http://localhost:4317. If protocol is `http` or `http/protobuf` the version and signal will be appended to the path (e.g. v1/traces or v1/metrics).
+
+**Using `https://` will apply SSL settings**
+
+|logsEndpoint
+|http://localhost:3100/otlp/v1/logs
+|Sets the OTLP HTTP endpoint for log records. If unset, defaults to http://localhost:3100/otlp/v1/logs
 
 **Using `https://` will apply SSL settings**
 
@@ -144,6 +150,7 @@ services:
       - deployment.environment.name: production
     exporter:
       endpoint: http://localhost:4317
+      logsEndpoint: http://localhost:3100/otlp/v1/logs
       protocol: grpc
       compression: none
       headers:
@@ -177,18 +184,44 @@ The contract lives in `gravitee-node-api` under
 [source,java]
 ----
 public interface TracingQueryService {
-    Single<List<Trace>> searchTraces(TraceSearchCriteria criteria);
-    Maybe<Trace> getTrace(String traceId);
+    Single<List<Trace>> searchTraces(TracingQueryContext context, TraceSearchCriteria criteria);
+    Maybe<Trace> getTrace(TracingQueryContext context, String traceId);
 }
 ----
 
-`Trace`, `TraceSpan`, `TraceSpanEvent` and `TraceSearchCriteria` are records under
-`io.gravitee.node.api.opentelemetry.query.model`. The records themselves are immutable, but the
+`Trace`, `TraceSpan`, `TraceSpanEvent`, `TraceSearchCriteria` and `TracingQueryContext` are records
+under `io.gravitee.node.api.opentelemetry.query.model`. The records themselves are immutable, but the
 collections they expose (`Trace.spans`, `TraceSpan.attributes`/`events`/`children`,
 `TraceSpanEvent.attributes`, `TraceSearchCriteria.tags`) are deliberately mutable: callers can rebuild
 or augment them — for example to apply product-specific overrides on top of what the Tempo adapter
 returns — without hitting `UnsupportedOperationException`. The API is reactive (RxJava 3) so it
 composes naturally with the Vert.x HTTP client used by the Tempo adapter.
+
+`TracingQueryContext` is the per-call request context. It carries two scoping knobs, both backend-
+agnostic:
+
+* `tenant` — backend-level tenant identity. Tempo turns it into `X-Scope-OrgID`; backends without
+  multi-tenancy ignore it.
+* `resourceAttributeFilters` — `Map<String, String>` of resource-attribute filters. Each entry is
+  injected as a query clause `resource.<key> = "<value>"`. The caller chooses the keys (e.g.
+  `gravitee.environment.id` for APIM, `deployment.environment.name` for OTel-standard pipelines,
+  `cloud.region` for geo-scoping). Producers must emit matching resource attributes — typically via
+  `services.opentelemetry.extraAttributes` — for the filter to find spans.
+
+Constructors / helpers:
+
+[source,java]
+----
+TracingQueryContext.EMPTY                                          // no tenant, no filters
+TracingQueryContext.forTenant("acme")                              // tenant only
+TracingQueryContext.of("acme", Map.of("gravitee.environment.id",
+                                       "production"))              // both
+----
+
+The module deliberately doesn't define product-specific attribute key constants — APIM (or any other
+consumer) keeps the mapping from its own concepts (`envId`, etc.) to OTel attribute keys on its
+side. The record is left open for future per-call knobs so new requirements (e.g. correlation id)
+won't force another signature change.
 
 `TraceSearchCriteria` is structured (`Map<String,String> tags` + `Instant start`/`end` +
 `Integer limit`); the implementation decides how to translate keys into the backend query
@@ -210,6 +243,14 @@ The Tempo adapter returns Tempo's data as-is. In particular:
   the primary search response. Older Tempo builds that don't support the `status` intrinsic are
   handled gracefully — the second pass is wrapped in `onErrorReturnItem(Set.of())` so the list
   still loads with `hasError=false` instead of failing.
+* Each entry in `context.resourceAttributeFilters()` is prepended to both the primary and the error
+  TraceQL pass as `resource.<key> = "<value>"` clauses, joined with `&&` and the rest of the
+  criteria tags. `getTrace(context, traceId)` has no equivalent query-side filter (Tempo's
+  `/api/traces/{id}` takes no query DSL), so the match is enforced post-fetch — the trace is
+  returned only when at least one of its resource batches carries **all** the requested
+  attributes. "At least one batch" is intentional: traces touching external services may include
+  batches without the consumer-side resource attributes (e.g. Gravitee-emitted env), and those
+  shouldn't block the match.
 
 Product-specific overrides (e.g. preferring an inbound HTTP server span's `http.target` +
 `http.method` over `rootTraceName` when an internal policy mutates `http.route`) are deliberately
@@ -243,6 +284,16 @@ public TracingQueryService tempoTracingQueryService(
     var configuration = TracingQueryConfigurationProvider.from(environment, "apim.tracing.tempo");
     return TempoTracingQueryServiceFactory.create(vertx, nodeConfiguration, configuration);
 }
+
+// Calling the service:
+//   no scoping:    service.searchTraces(TracingQueryContext.EMPTY, criteria)
+//   tenant only:   service.searchTraces(TracingQueryContext.forTenant(orgId), criteria)
+//   tenant + env:  service.searchTraces(
+//                      TracingQueryContext.of(orgId, Map.of("gravitee.environment.id", envId)),
+//                      criteria)
+//
+// Producers must set the matching attributes on the resource
+// (services.opentelemetry.extraAttributes) for the filter to find spans.
 ----
 
 ==== General
@@ -258,9 +309,14 @@ this host. `https://` triggers TLS using the SSL settings below.
 
 ==== Headers
 
-Static headers added to every Tempo request. Useful for `X-Scope-OrgID` on multi-tenant Tempo
-deployments (Grafana Cloud) and for `Authorization` when Tempo is behind an auth-enforcing
-reverse proxy.
+Static headers added to every Tempo request. Useful for `Authorization` when Tempo is behind an
+auth-enforcing reverse proxy, and for `X-Scope-OrgID` on single-tenant Tempo deployments where the
+tenant id is fixed.
+
+For multi-tenant deployments where the tenant varies per request, prefer
+`TracingQueryContext.forTenant(...)` over a static header — a per-call tenant overrides the static
+`X-Scope-OrgID` when present, so each call hits the right tenant scope without rebuilding the
+service.
 
 |===
 |Parameter |Default |Description

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/query/tempo/TempoHttpClient.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/query/tempo/TempoHttpClient.java
@@ -34,6 +34,9 @@ import lombok.CustomLog;
 @CustomLog
 public class TempoHttpClient implements AutoCloseable {
 
+    /** Tempo's multi-tenancy header — set per-call when a {@code TracingQueryContext.tenant()} is provided. */
+    static final String X_SCOPE_ORG_ID = "X-Scope-OrgID";
+
     private final HttpClient httpClient;
     private final Map<String, String> staticHeaders;
     private final ObjectMapper objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
@@ -43,11 +46,17 @@ public class TempoHttpClient implements AutoCloseable {
         this.staticHeaders = staticHeaders == null ? Map.of() : Map.copyOf(staticHeaders);
     }
 
-    public Single<TempoTraceResponse> getTrace(final String traceId) {
-        return executeGet("/api/traces/" + URLEncoder.encode(traceId, StandardCharsets.UTF_8), TempoTraceResponse.class);
+    public Single<TempoTraceResponse> getTrace(final String traceId, final String tenant) {
+        return executeGet("/api/traces/" + URLEncoder.encode(traceId, StandardCharsets.UTF_8), tenant, TempoTraceResponse.class);
     }
 
-    public Single<TempoSearchResponse> searchTracesTraceQL(final String traceQL, final Integer limit, final Long start, final Long end) {
+    public Single<TempoSearchResponse> searchTracesTraceQL(
+        final String traceQL,
+        final Integer limit,
+        final Long start,
+        final Long end,
+        final String tenant
+    ) {
         StringBuilder uri = new StringBuilder("/api/search");
         String separator = "?";
 
@@ -67,7 +76,7 @@ public class TempoHttpClient implements AutoCloseable {
             uri.append(separator).append("end=").append(end);
         }
 
-        return executeGet(uri.toString(), TempoSearchResponse.class);
+        return executeGet(uri.toString(), tenant, TempoSearchResponse.class);
     }
 
     /**
@@ -79,12 +88,17 @@ public class TempoHttpClient implements AutoCloseable {
         httpClient.close().subscribe();
     }
 
-    private <T> Single<T> executeGet(final String requestUri, final Class<T> responseType) {
+    private <T> Single<T> executeGet(final String requestUri, final String tenant, final Class<T> responseType) {
         return httpClient
             .rxRequest(HttpMethod.GET, requestUri)
             .map(req -> {
                 req.putHeader("Accept", "application/json");
                 staticHeaders.forEach(req::putHeader);
+                // A per-call tenant overrides any X-Scope-OrgID baked into staticHeaders so callers running in a
+                // multi-tenant deployment can target individual tenants without rebuilding the client.
+                if (tenant != null && !tenant.isEmpty()) {
+                    req.putHeader(X_SCOPE_ORG_ID, tenant);
+                }
                 return req;
             })
             .flatMap(req -> req.rxSend())

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/query/tempo/TempoTracingQueryService.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/query/tempo/TempoTracingQueryService.java
@@ -20,6 +20,7 @@ import io.gravitee.node.api.opentelemetry.query.model.Trace;
 import io.gravitee.node.api.opentelemetry.query.model.TraceSearchCriteria;
 import io.gravitee.node.api.opentelemetry.query.model.TraceSpan;
 import io.gravitee.node.api.opentelemetry.query.model.TraceSpanEvent;
+import io.gravitee.node.api.opentelemetry.query.model.TracingQueryContext;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 import java.time.Instant;
@@ -54,9 +55,10 @@ public class TempoTracingQueryService implements TracingQueryService, AutoClosea
     }
 
     @Override
-    public Single<List<Trace>> searchTraces(TraceSearchCriteria criteria) {
-        String traceQL = buildTraceQL(criteria.tags(), false);
-        String errorTraceQL = buildTraceQL(criteria.tags(), true);
+    public Single<List<Trace>> searchTraces(TracingQueryContext context, TraceSearchCriteria criteria) {
+        Map<String, String> resourceFilters = context != null ? context.resourceAttributeFilters() : Map.of();
+        String traceQL = buildTraceQL(criteria.attributeFilters(), resourceFilters, false);
+        String errorTraceQL = buildTraceQL(criteria.attributeFilters(), resourceFilters, true);
         Long start = criteria.start() != null ? criteria.start().getEpochSecond() : null;
         Long end = criteria.end() != null ? criteria.end().getEpochSecond() : null;
         if (start == null && end != null) {
@@ -64,12 +66,13 @@ public class TempoTracingQueryService implements TracingQueryService, AutoClosea
         }
         Long startParam = start;
         Long endParam = end;
+        String tenant = context != null ? context.tenant() : null;
 
-        Single<TempoSearchResponse> primary = tempoClient.searchTracesTraceQL(traceQL, criteria.limit(), startParam, endParam);
+        Single<TempoSearchResponse> primary = tempoClient.searchTracesTraceQL(traceQL, criteria.limit(), startParam, endParam, tenant);
         // Older Tempo builds may not support the `status = error` intrinsic; fall back to an empty error set rather than
         // failing the whole list — the status column then renders as "unknown" instead of breaking the page.
         Single<Set<String>> errorIds = tempoClient
-            .searchTracesTraceQL(errorTraceQL, criteria.limit(), startParam, endParam)
+            .searchTracesTraceQL(errorTraceQL, criteria.limit(), startParam, endParam, tenant)
             .map(TempoTracingQueryService::extractTraceIds)
             .onErrorReturnItem(Set.of());
 
@@ -77,15 +80,54 @@ public class TempoTracingQueryService implements TracingQueryService, AutoClosea
     }
 
     @Override
-    public Maybe<Trace> getTrace(String traceId) {
+    public Maybe<Trace> getTrace(TracingQueryContext context, String traceId) {
+        String tenant = context != null ? context.tenant() : null;
+        Map<String, String> resourceFilters = context != null ? context.resourceAttributeFilters() : Map.of();
         return tempoClient
-            .getTrace(traceId)
+            .getTrace(traceId, tenant)
             .flatMapMaybe(response -> {
                 if (response == null || response.batches() == null || response.batches().isEmpty()) {
                     return Maybe.empty();
                 }
+                // Defence in depth: Tempo's /api/traces/{id} has no query DSL, so resource-attribute scoping has
+                // to happen post-fetch. If no batch's resource carries all the requested attribute filters, treat
+                // it as "not found" — a caller scoped to env A must not see env B's trace just because they know
+                // its id. "At least one batch matches all filters" is intentional: traces touching external
+                // services may include batches without the Gravitee-emitted attributes, and those shouldn't
+                // block the match.
+                if (!resourceFilters.isEmpty() && !traceMatchesResourceFilters(response, resourceFilters)) {
+                    return Maybe.empty();
+                }
                 return Maybe.just(convertToTrace(traceId, response));
             });
+    }
+
+    private static boolean traceMatchesResourceFilters(TempoTraceResponse response, Map<String, String> filters) {
+        for (TempoTraceResponse.ResourceSpans batch : response.batches()) {
+            if (batch.resource() == null || batch.resource().attributes() == null) {
+                continue;
+            }
+            if (batchSatisfies(batch.resource().attributes(), filters)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean batchSatisfies(List<TempoTraceResponse.KeyValue> attributes, Map<String, String> filters) {
+        for (Map.Entry<String, String> entry : filters.entrySet()) {
+            boolean matched = false;
+            for (TempoTraceResponse.KeyValue kv : attributes) {
+                if (entry.getKey().equals(kv.key()) && kv.value() != null && entry.getValue().equals(kv.value().asString())) {
+                    matched = true;
+                    break;
+                }
+            }
+            if (!matched) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static Set<String> extractTraceIds(TempoSearchResponse response) {
@@ -196,9 +238,9 @@ public class TempoTracingQueryService implements TracingQueryService, AutoClosea
         List<TraceSpanEvent> events = convertEvents(span.events());
 
         return TraceSpan.of(
-            span.traceId(),
-            span.spanId(),
-            span.parentSpanId(),
+            hexEncodeIfBase64(span.traceId()),
+            hexEncodeIfBase64(span.spanId()),
+            hexEncodeIfBase64(span.parentSpanId()),
             span.name(),
             serviceName,
             startTime,
@@ -206,6 +248,28 @@ public class TempoTracingQueryService implements TracingQueryService, AutoClosea
             attrs,
             events
         );
+    }
+
+    /**
+     * Tempo's {@code /api/traces/{id}} returns OTLP/JSON where 8-byte / 16-byte span and trace IDs are encoded as
+     * base64. Most consumers (Elasticsearch-backed indexes, OTel tooling, distributed-tracing UIs) expect IDs in the
+     * conventional lowercase-hex form. Decode and re-encode so callers comparing IDs across backends see the same
+     * representation. Returns the input unchanged when it doesn't decode cleanly to 8 or 16 bytes — covers the
+     * unusual case where a Tempo build already hands back hex strings.
+     */
+    private static String hexEncodeIfBase64(String maybeBase64) {
+        if (maybeBase64 == null || maybeBase64.isEmpty()) {
+            return maybeBase64;
+        }
+        try {
+            byte[] bytes = java.util.Base64.getDecoder().decode(maybeBase64);
+            if (bytes.length != 8 && bytes.length != 16) {
+                return maybeBase64;
+            }
+            return java.util.HexFormat.of().formatHex(bytes);
+        } catch (IllegalArgumentException notBase64) {
+            return maybeBase64;
+        }
     }
 
     private List<TraceSpanEvent> convertEvents(List<TempoTraceResponse.Event> rawEvents) {
@@ -234,29 +298,59 @@ public class TempoTracingQueryService implements TracingQueryService, AutoClosea
     }
 
     /**
-     * Turn a structured tag filter into TraceQL. {@code service.*} and {@code telemetry.*} keys go on the resource, everything
-     * else on the span. Multiple keys are joined with {@code &&}. When {@code errorsOnly} is true a {@code status = error}
-     * intrinsic is added so only traces with at least one errored span match.
+     * Turn a structured attribute filter + caller-provided resource-attribute filters into TraceQL.
+     * <ul>
+     *   <li>{@code resourceFilters} entries are emitted as {@code resource.<key> = "<value>"} clauses; the caller
+     *       has already decided the key belongs on the resource (e.g. tenant-specific scoping attributes).</li>
+     *   <li>{@code attributeFilters} keys prefixed with {@code service.} or {@code telemetry.} go on the resource,
+     *       everything else on the span.</li>
+     *   <li>Multiple clauses are joined with {@code &&}.</li>
+     *   <li>When {@code errorsOnly} is true, a {@code status = error} intrinsic is added so only traces with at
+     *       least one errored span match.</li>
+     * </ul>
      */
-    private String buildTraceQL(Map<String, String> tags, boolean errorsOnly) {
+    private String buildTraceQL(Map<String, String> attributeFilters, Map<String, String> resourceFilters, boolean errorsOnly) {
         StringBuilder sb = new StringBuilder("{ ");
-        boolean hasTag = tags != null && !tags.isEmpty();
-        if (hasTag) {
-            boolean first = true;
-            for (Map.Entry<String, String> entry : tags.entrySet()) {
-                if (!first) sb.append(" && ");
+        boolean hasClause = false;
+        if (resourceFilters != null) {
+            for (Map.Entry<String, String> entry : resourceFilters.entrySet()) {
+                if (hasClause) sb.append(" && ");
+                appendClause(sb, "resource.", entry.getKey(), entry.getValue());
+                hasClause = true;
+            }
+        }
+        if (attributeFilters != null && !attributeFilters.isEmpty()) {
+            for (Map.Entry<String, String> entry : attributeFilters.entrySet()) {
+                if (hasClause) sb.append(" && ");
                 String key = entry.getKey();
                 String prefix = isResourceAttribute(key) ? "resource." : "span.";
-                sb.append(prefix).append(key).append(" = \"").append(entry.getValue()).append("\"");
-                first = false;
+                appendClause(sb, prefix, key, entry.getValue());
+                hasClause = true;
             }
         }
         if (errorsOnly) {
-            if (hasTag) sb.append(" && ");
+            if (hasClause) sb.append(" && ");
             sb.append("status = error");
         }
         sb.append(" }");
         return sb.toString();
+    }
+
+    private static void appendClause(StringBuilder sb, String prefix, String key, String value) {
+        sb.append(prefix).append(key).append(" = \"").append(escapeTraceQLValue(value)).append("\"");
+    }
+
+    /**
+     * Escapes backslashes and double quotes in a TraceQL string literal so the resulting query parses cleanly.
+     * Today's callers pass UUIDs / opaque identifiers without special characters, but a value flowing in from
+     * outside this module (operator config, future user-supplied attribute filter) could carry either — without
+     * escaping, the produced TraceQL would be syntactically invalid.
+     */
+    private static String escapeTraceQLValue(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
     }
 
     private boolean isResourceAttribute(String key) {

--- a/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/query/tempo/TempoHttpClientTest.java
+++ b/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/query/tempo/TempoHttpClientTest.java
@@ -64,7 +64,6 @@ class TempoHttpClientTest {
         server.listen(0, "127.0.0.1").toCompletionStage().toCompletableFuture().join();
 
         Map<String, String> headers = new HashMap<>();
-        headers.put("X-Scope-OrgID", "tenant-1");
         headers.put("Authorization", "Bearer secret");
         client = new TempoHttpClient(buildHttpClient(server.actualPort()), headers);
     }
@@ -94,7 +93,7 @@ class TempoHttpClientTest {
                         "\"scopeSpans\":[{\"scope\":{\"name\":\"scope\"},\"spans\":[]}]}]}"
                     );
 
-        TempoTraceResponse response = client.getTrace("abc-123").blockingGet();
+        TempoTraceResponse response = client.getTrace("abc-123", null).blockingGet();
 
         assertThat(response).isNotNull();
         assertThat(response.batches()).hasSize(1);
@@ -107,15 +106,26 @@ class TempoHttpClientTest {
     void should_send_static_headers_and_default_accept_on_each_request() {
         stubHandler = req -> req.response().end("{}");
 
-        client.getTrace("abc-123").blockingGet();
+        client.getTrace("abc-123", null).blockingGet();
 
         assertThat(recorded)
             .singleElement()
             .satisfies(r -> {
                 assertThat(r.headers().get("Accept")).isEqualTo("application/json");
-                assertThat(r.headers().get("X-Scope-OrgID")).isEqualTo("tenant-1");
                 assertThat(r.headers().get("Authorization")).isEqualTo("Bearer secret");
+                // No tenant supplied, no X-Scope-OrgID — single-tenant Tempo ignores the header anyway.
+                assertThat(r.headers().get("X-Scope-OrgID")).isNull();
             });
+    }
+
+    @Test
+    void should_set_x_scope_org_id_header_when_tenant_is_provided() {
+        stubHandler = req -> req.response().end("{}");
+
+        client.getTrace("abc-123", "acme").blockingGet();
+        client.searchTracesTraceQL("{}", 10, 1700000000L, 1700000060L, "acme").blockingGet();
+
+        assertThat(recorded).hasSize(2).allSatisfy(r -> assertThat(r.headers().get("X-Scope-OrgID")).isEqualTo("acme"));
     }
 
     @Test
@@ -123,7 +133,7 @@ class TempoHttpClientTest {
         stubHandler = req -> req.response().end("{\"traces\":[]}");
 
         String traceQL = "{ span.http.method = \"GET\" } | select(span.http.target)";
-        client.searchTracesTraceQL(traceQL, 10, 1700000000L, 1700000060L).blockingGet();
+        client.searchTracesTraceQL(traceQL, 10, 1700000000L, 1700000060L, null).blockingGet();
 
         assertThat(recorded)
             .singleElement()
@@ -147,7 +157,7 @@ class TempoHttpClientTest {
     void should_url_encode_the_trace_id() {
         stubHandler = req -> req.response().end("{\"batches\":[]}");
 
-        client.getTrace("abc/with weird?chars").blockingGet();
+        client.getTrace("abc/with weird?chars", null).blockingGet();
 
         assertThat(recorded).singleElement().satisfies(r -> assertThat(r.uri()).isEqualTo("/api/traces/abc%2Fwith+weird%3Fchars"));
     }
@@ -156,7 +166,7 @@ class TempoHttpClientTest {
     void should_raise_tempo_client_exception_on_4xx() {
         stubHandler = req -> req.response().setStatusCode(404).end("not found");
 
-        assertThatThrownBy(() -> client.getTrace("abc-123").blockingGet())
+        assertThatThrownBy(() -> client.getTrace("abc-123", null).blockingGet())
             .isInstanceOf(TempoClientException.class)
             .hasMessageContaining("404");
     }
@@ -165,7 +175,7 @@ class TempoHttpClientTest {
     void should_raise_tempo_client_exception_on_5xx() {
         stubHandler = req -> req.response().setStatusCode(500).end("internal error");
 
-        assertThatThrownBy(() -> client.getTrace("abc-123").blockingGet())
+        assertThatThrownBy(() -> client.getTrace("abc-123", null).blockingGet())
             .isInstanceOf(TempoClientException.class)
             .hasMessageContaining("500");
     }

--- a/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/query/tempo/TempoTracingQueryServiceTest.java
+++ b/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/query/tempo/TempoTracingQueryServiceTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 import io.gravitee.node.api.opentelemetry.query.model.Trace;
 import io.gravitee.node.api.opentelemetry.query.model.TraceSearchCriteria;
 import io.gravitee.node.api.opentelemetry.query.model.TraceSpan;
+import io.gravitee.node.api.opentelemetry.query.model.TracingQueryContext;
 import io.reactivex.rxjava3.core.Single;
 import java.time.Instant;
 import java.util.LinkedHashMap;
@@ -55,24 +56,27 @@ class TempoTracingQueryServiceTest {
 
     @Test
     void should_emit_empty_list_when_tempo_returns_no_traces() {
-        when(tempoClient.searchTracesTraceQL(any(), any(), any(), any())).thenReturn(Single.just(new TempoSearchResponse(null)));
+        when(tempoClient.searchTracesTraceQL(any(), any(), any(), any(), any())).thenReturn(Single.just(new TempoSearchResponse(null)));
 
-        List<Trace> traces = underTest.searchTraces(new TraceSearchCriteria(Map.of(), 20, null, null)).blockingGet();
+        List<Trace> traces = underTest
+            .searchTraces(TracingQueryContext.EMPTY, new TraceSearchCriteria(Map.of(), 20, null, null))
+            .blockingGet();
 
         assertThat(traces).isEmpty();
     }
 
     @Test
     void should_route_resource_attributes_under_resource_prefix() {
-        when(tempoClient.searchTracesTraceQL(any(), any(), any(), any())).thenReturn(Single.just(new TempoSearchResponse(List.of())));
+        when(tempoClient.searchTracesTraceQL(any(), any(), any(), any(), any()))
+            .thenReturn(Single.just(new TempoSearchResponse(List.of())));
 
-        Map<String, String> tags = new LinkedHashMap<>();
-        tags.put("service.name", "gateway");
-        tags.put("http.method", "GET");
-        underTest.searchTraces(new TraceSearchCriteria(tags, 20, null, null)).blockingGet();
+        Map<String, String> attributeFilters = new LinkedHashMap<>();
+        attributeFilters.put("service.name", "gateway");
+        attributeFilters.put("http.method", "GET");
+        underTest.searchTraces(TracingQueryContext.EMPTY, new TraceSearchCriteria(attributeFilters, 20, null, null)).blockingGet();
 
         ArgumentCaptor<String> queryCaptor = ArgumentCaptor.forClass(String.class);
-        verify(tempoClient, times(2)).searchTracesTraceQL(queryCaptor.capture(), any(), any(), any());
+        verify(tempoClient, times(2)).searchTracesTraceQL(queryCaptor.capture(), any(), any(), any(), any());
         String primaryQuery = queryCaptor.getAllValues().get(0);
         assertThat(primaryQuery).contains("resource.service.name = \"gateway\"");
         assertThat(primaryQuery).contains("span.http.method = \"GET\"");
@@ -80,12 +84,13 @@ class TempoTracingQueryServiceTest {
 
     @Test
     void should_run_both_primary_and_error_passes() {
-        when(tempoClient.searchTracesTraceQL(any(), any(), any(), any())).thenReturn(Single.just(new TempoSearchResponse(List.of())));
+        when(tempoClient.searchTracesTraceQL(any(), any(), any(), any(), any()))
+            .thenReturn(Single.just(new TempoSearchResponse(List.of())));
 
-        underTest.searchTraces(new TraceSearchCriteria(Map.of(), 20, null, null)).blockingGet();
+        underTest.searchTraces(TracingQueryContext.EMPTY, new TraceSearchCriteria(Map.of(), 20, null, null)).blockingGet();
 
         ArgumentCaptor<String> queryCaptor = ArgumentCaptor.forClass(String.class);
-        verify(tempoClient, times(2)).searchTracesTraceQL(queryCaptor.capture(), any(), any(), any());
+        verify(tempoClient, times(2)).searchTracesTraceQL(queryCaptor.capture(), any(), any(), any(), any());
         assertThat(queryCaptor.getAllValues().get(0)).doesNotContain("status = error");
         assertThat(queryCaptor.getAllValues().get(1)).contains("status = error");
     }
@@ -94,9 +99,13 @@ class TempoTracingQueryServiceTest {
     void should_flag_traces_returned_by_the_error_pass() {
         TempoSearchResponse primary = new TempoSearchResponse(List.of(traceResult("aaa"), traceResult("bbb")));
         TempoSearchResponse errors = new TempoSearchResponse(List.of(traceResult("bbb")));
-        when(tempoClient.searchTracesTraceQL(any(), any(), any(), any())).thenReturn(Single.just(primary)).thenReturn(Single.just(errors));
+        when(tempoClient.searchTracesTraceQL(any(), any(), any(), any(), any()))
+            .thenReturn(Single.just(primary))
+            .thenReturn(Single.just(errors));
 
-        List<Trace> traces = underTest.searchTraces(new TraceSearchCriteria(Map.of(), 20, null, null)).blockingGet();
+        List<Trace> traces = underTest
+            .searchTraces(TracingQueryContext.EMPTY, new TraceSearchCriteria(Map.of(), 20, null, null))
+            .blockingGet();
 
         assertThat(traces).hasSize(2);
         assertThat(traces.get(0).hasError()).isFalse();
@@ -107,11 +116,13 @@ class TempoTracingQueryServiceTest {
     void should_treat_traces_as_unflagged_when_error_pass_fails() {
         // Older Tempo builds reject `status = error`; the list must still load with hasError=false.
         TempoSearchResponse primary = new TempoSearchResponse(List.of(traceResult("aaa")));
-        when(tempoClient.searchTracesTraceQL(any(), any(), any(), any()))
+        when(tempoClient.searchTracesTraceQL(any(), any(), any(), any(), any()))
             .thenReturn(Single.just(primary))
             .thenReturn(Single.error(new RuntimeException("intrinsic not supported")));
 
-        List<Trace> traces = underTest.searchTraces(new TraceSearchCriteria(Map.of(), 20, null, null)).blockingGet();
+        List<Trace> traces = underTest
+            .searchTraces(TracingQueryContext.EMPTY, new TraceSearchCriteria(Map.of(), 20, null, null))
+            .blockingGet();
 
         assertThat(traces).hasSize(1);
         assertThat(traces.get(0).hasError()).isFalse();
@@ -119,13 +130,14 @@ class TempoTracingQueryServiceTest {
 
     @Test
     void should_default_start_to_seven_days_before_end_when_only_end_is_set() {
-        when(tempoClient.searchTracesTraceQL(any(), any(), any(), any())).thenReturn(Single.just(new TempoSearchResponse(List.of())));
+        when(tempoClient.searchTracesTraceQL(any(), any(), any(), any(), any()))
+            .thenReturn(Single.just(new TempoSearchResponse(List.of())));
 
         Instant end = Instant.parse("2026-04-29T12:00:00Z");
-        underTest.searchTraces(new TraceSearchCriteria(Map.of(), 20, null, end)).blockingGet();
+        underTest.searchTraces(TracingQueryContext.EMPTY, new TraceSearchCriteria(Map.of(), 20, null, end)).blockingGet();
 
         ArgumentCaptor<Long> startCaptor = ArgumentCaptor.forClass(Long.class);
-        verify(tempoClient, times(2)).searchTracesTraceQL(any(), any(), startCaptor.capture(), eq(end.getEpochSecond()));
+        verify(tempoClient, times(2)).searchTracesTraceQL(any(), any(), startCaptor.capture(), eq(end.getEpochSecond()), any());
         long expectedStart = end.getEpochSecond() - 7L * 24 * 3600;
         assertThat(startCaptor.getValue()).isEqualTo(expectedStart);
     }
@@ -139,9 +151,12 @@ class TempoTracingQueryServiceTest {
             Instant.parse("2026-04-29T12:00:00Z").toEpochMilli() * 1_000_000L,
             42L
         );
-        when(tempoClient.searchTracesTraceQL(any(), any(), any(), any())).thenReturn(Single.just(new TempoSearchResponse(List.of(result))));
+        when(tempoClient.searchTracesTraceQL(any(), any(), any(), any(), any()))
+            .thenReturn(Single.just(new TempoSearchResponse(List.of(result))));
 
-        List<Trace> traces = underTest.searchTraces(new TraceSearchCriteria(Map.of(), 20, null, null)).blockingGet();
+        List<Trace> traces = underTest
+            .searchTraces(TracingQueryContext.EMPTY, new TraceSearchCriteria(Map.of(), 20, null, null))
+            .blockingGet();
 
         assertThat(traces)
             .singleElement()
@@ -153,20 +168,20 @@ class TempoTracingQueryServiceTest {
 
     @Test
     void should_return_empty_when_response_has_no_batches() {
-        when(tempoClient.getTrace("missing")).thenReturn(Single.just(new TempoTraceResponse(null)));
+        when(tempoClient.getTrace(eq("missing"), any())).thenReturn(Single.just(new TempoTraceResponse(null)));
 
-        Optional<Trace> result = underTest.getTrace("missing").blockingGet() == null
+        Optional<Trace> result = underTest.getTrace(TracingQueryContext.EMPTY, "missing").blockingGet() == null
             ? Optional.empty()
-            : Optional.of(underTest.getTrace("missing").blockingGet());
+            : Optional.of(underTest.getTrace(TracingQueryContext.EMPTY, "missing").blockingGet());
 
         assertThat(result).isEmpty();
     }
 
     @Test
     void should_return_empty_when_response_is_null() {
-        when(tempoClient.getTrace("missing")).thenReturn(Single.just(new TempoTraceResponse(null)));
+        when(tempoClient.getTrace(eq("missing"), any())).thenReturn(Single.just(new TempoTraceResponse(null)));
 
-        assertThat(underTest.getTrace("missing").blockingGet()).isNull();
+        assertThat(underTest.getTrace(TracingQueryContext.EMPTY, "missing").blockingGet()).isNull();
     }
 
     @Test
@@ -177,9 +192,9 @@ class TempoTracingQueryServiceTest {
             spanWithStatus("trace", "span-2", "span-1", "child", "1"),
             spanWithStatus("trace", "span-3", "span-1", "boom", "2")
         );
-        when(tempoClient.getTrace("trace")).thenReturn(Single.just(response));
+        when(tempoClient.getTrace(eq("trace"), any())).thenReturn(Single.just(response));
 
-        Trace trace = underTest.getTrace("trace").blockingGet();
+        Trace trace = underTest.getTrace(TracingQueryContext.EMPTY, "trace").blockingGet();
 
         assertThat(trace).isNotNull();
         assertThat(trace.spans()).hasSize(3);
@@ -197,9 +212,9 @@ class TempoTracingQueryServiceTest {
             spanWithStatus("trace", "span-2", "span-1", "child", "STATUS_CODE_OK"),
             spanWithStatus("trace", "span-3", "span-1", "boom", "STATUS_CODE_ERROR")
         );
-        when(tempoClient.getTrace("trace")).thenReturn(Single.just(response));
+        when(tempoClient.getTrace(eq("trace"), any())).thenReturn(Single.just(response));
 
-        Trace trace = underTest.getTrace("trace").blockingGet();
+        Trace trace = underTest.getTrace(TracingQueryContext.EMPTY, "trace").blockingGet();
 
         assertThat(statusOf(trace, "span-1")).isEqualTo("UNSET");
         assertThat(statusOf(trace, "span-2")).isEqualTo("OK");
@@ -213,13 +228,192 @@ class TempoTracingQueryServiceTest {
             spanWithStatus("trace", "root", null, "GET /proxy", "0"),
             spanWithStatus("trace", "child", "root", "callout", "0")
         );
-        when(tempoClient.getTrace("trace")).thenReturn(Single.just(response));
+        when(tempoClient.getTrace(eq("trace"), any())).thenReturn(Single.just(response));
 
-        Trace trace = underTest.getTrace("trace").blockingGet();
+        Trace trace = underTest.getTrace(TracingQueryContext.EMPTY, "trace").blockingGet();
 
         assertThat(trace).isNotNull();
         assertThat(trace.rootService()).isEqualTo("gateway");
         assertThat(trace.rootOperation()).isEqualTo("GET /proxy");
+    }
+
+    @Test
+    void should_forward_context_tenant_to_http_client_on_search_and_get() {
+        when(tempoClient.searchTracesTraceQL(any(), any(), any(), any(), any()))
+            .thenReturn(Single.just(new TempoSearchResponse(List.of())));
+        when(tempoClient.getTrace(eq("trace"), any())).thenReturn(Single.just(new TempoTraceResponse(List.of())));
+
+        underTest.searchTraces(TracingQueryContext.forTenant("acme"), new TraceSearchCriteria(Map.of(), 20, null, null)).blockingGet();
+        underTest.getTrace(TracingQueryContext.forTenant("acme"), "trace").blockingGet();
+
+        ArgumentCaptor<String> searchTenantCaptor = ArgumentCaptor.forClass(String.class);
+        verify(tempoClient, times(2)).searchTracesTraceQL(any(), any(), any(), any(), searchTenantCaptor.capture());
+        assertThat(searchTenantCaptor.getAllValues()).containsExactly("acme", "acme");
+
+        ArgumentCaptor<String> getTenantCaptor = ArgumentCaptor.forClass(String.class);
+        verify(tempoClient).getTrace(eq("trace"), getTenantCaptor.capture());
+        assertThat(getTenantCaptor.getValue()).isEqualTo("acme");
+    }
+
+    @Test
+    void should_pass_null_tenant_when_context_is_empty() {
+        when(tempoClient.searchTracesTraceQL(any(), any(), any(), any(), any()))
+            .thenReturn(Single.just(new TempoSearchResponse(List.of())));
+
+        underTest.searchTraces(TracingQueryContext.EMPTY, new TraceSearchCriteria(Map.of(), 20, null, null)).blockingGet();
+
+        ArgumentCaptor<String> tenantCaptor = ArgumentCaptor.forClass(String.class);
+        verify(tempoClient, times(2)).searchTracesTraceQL(any(), any(), any(), any(), tenantCaptor.capture());
+        assertThat(tenantCaptor.getAllValues()).containsOnlyNulls();
+    }
+
+    @Test
+    void should_inject_resource_attribute_filters_into_traceql_when_set() {
+        when(tempoClient.searchTracesTraceQL(any(), any(), any(), any(), any()))
+            .thenReturn(Single.just(new TempoSearchResponse(List.of())));
+
+        underTest
+            .searchTraces(
+                TracingQueryContext.of("acme", Map.of("gravitee.environment.id", "production")),
+                new TraceSearchCriteria(Map.of("http.method", "GET"), 20, null, null)
+            )
+            .blockingGet();
+
+        ArgumentCaptor<String> queryCaptor = ArgumentCaptor.forClass(String.class);
+        verify(tempoClient, times(2)).searchTracesTraceQL(queryCaptor.capture(), any(), any(), any(), any());
+        String primary = queryCaptor.getAllValues().get(0);
+        // Resource-attribute clauses come first so the caller-driven scope is always present, even when no
+        // attribute filters are passed.
+        assertThat(primary).contains("resource.gravitee.environment.id = \"production\"");
+        assertThat(primary).contains("span.http.method = \"GET\"");
+    }
+
+    @Test
+    void should_combine_multiple_resource_attribute_filters_with_and() {
+        when(tempoClient.searchTracesTraceQL(any(), any(), any(), any(), any()))
+            .thenReturn(Single.just(new TempoSearchResponse(List.of())));
+
+        // Use a LinkedHashMap so the clause order in the assertion is stable.
+        Map<String, String> filters = new LinkedHashMap<>();
+        filters.put("gravitee.environment.id", "production");
+        filters.put("cloud.region", "eu-west-1");
+        underTest.searchTraces(TracingQueryContext.of("acme", filters), new TraceSearchCriteria(Map.of(), 20, null, null)).blockingGet();
+
+        ArgumentCaptor<String> queryCaptor = ArgumentCaptor.forClass(String.class);
+        verify(tempoClient, times(2)).searchTracesTraceQL(queryCaptor.capture(), any(), any(), any(), any());
+        String primary = queryCaptor.getAllValues().get(0);
+        assertThat(primary).contains("resource.gravitee.environment.id = \"production\"");
+        assertThat(primary).contains("resource.cloud.region = \"eu-west-1\"");
+        assertThat(primary).contains(" && ");
+    }
+
+    @Test
+    void should_omit_resource_attribute_clauses_when_map_is_empty() {
+        when(tempoClient.searchTracesTraceQL(any(), any(), any(), any(), any()))
+            .thenReturn(Single.just(new TempoSearchResponse(List.of())));
+
+        underTest.searchTraces(TracingQueryContext.forTenant("acme"), new TraceSearchCriteria(Map.of(), 20, null, null)).blockingGet();
+
+        ArgumentCaptor<String> queryCaptor = ArgumentCaptor.forClass(String.class);
+        verify(tempoClient, times(2)).searchTracesTraceQL(queryCaptor.capture(), any(), any(), any(), any());
+        assertThat(queryCaptor.getAllValues().get(0)).doesNotContain("resource.");
+    }
+
+    @Test
+    void should_treat_get_trace_as_not_found_when_resource_attribute_does_not_match() {
+        // Trace exists in Tempo but its resource attribute says env = staging — caller asking for production must
+        // see Maybe.empty(), not the staging trace.
+        TempoTraceResponse response = singleBatchWithEnv("gateway", "staging", spanWithStatus("trace", "root", null, "GET /", "0"));
+        when(tempoClient.getTrace(eq("trace"), any())).thenReturn(Single.just(response));
+
+        Trace trace = underTest
+            .getTrace(TracingQueryContext.of("acme", Map.of("gravitee.environment.id", "production")), "trace")
+            .blockingGet();
+
+        assertThat(trace).isNull();
+    }
+
+    @Test
+    void should_return_get_trace_when_all_resource_attributes_match_some_batch() {
+        TempoTraceResponse response = singleBatchWithEnv("gateway", "production", spanWithStatus("trace", "root", null, "GET /", "0"));
+        when(tempoClient.getTrace(eq("trace"), any())).thenReturn(Single.just(response));
+
+        Trace trace = underTest
+            .getTrace(TracingQueryContext.of("acme", Map.of("gravitee.environment.id", "production")), "trace")
+            .blockingGet();
+
+        assertThat(trace).isNotNull();
+        assertThat(trace.traceId()).isEqualTo("trace");
+    }
+
+    @Test
+    void should_return_get_trace_when_at_least_one_batch_satisfies_all_filters() {
+        // Two batches: one Gravitee-emitted with env=production, one external service with no env attribute. The
+        // "any batch satisfies all filters" semantic must accept this trace — external service spans don't carry
+        // Gravitee resource attributes and shouldn't block the match.
+        TempoTraceResponse.ResourceSpans gateway = new TempoTraceResponse.ResourceSpans(
+            new TempoTraceResponse.Resource(
+                List.of(
+                    new TempoTraceResponse.KeyValue("service.name", strVal("gateway")),
+                    new TempoTraceResponse.KeyValue("gravitee.environment.id", strVal("production"))
+                )
+            ),
+            List.of(
+                new TempoTraceResponse.ScopeSpans(
+                    new TempoTraceResponse.Scope("scope"),
+                    List.of(spanWithStatus("trace", "root", null, "GET /", "0"))
+                )
+            )
+        );
+        TempoTraceResponse.ResourceSpans external = new TempoTraceResponse.ResourceSpans(
+            new TempoTraceResponse.Resource(List.of(new TempoTraceResponse.KeyValue("service.name", strVal("upstream")))),
+            List.of(
+                new TempoTraceResponse.ScopeSpans(
+                    new TempoTraceResponse.Scope("scope"),
+                    List.of(spanWithStatus("trace", "child", "root", "POST /", "0"))
+                )
+            )
+        );
+        when(tempoClient.getTrace(eq("trace"), any())).thenReturn(Single.just(new TempoTraceResponse(List.of(gateway, external))));
+
+        Trace trace = underTest
+            .getTrace(TracingQueryContext.of("acme", Map.of("gravitee.environment.id", "production")), "trace")
+            .blockingGet();
+
+        assertThat(trace).isNotNull();
+    }
+
+    @Test
+    void should_hex_encode_base64_ids_returned_by_tempo() {
+        // Tempo's /api/traces/{id} returns OTLP/JSON with base64-encoded binary IDs. Callers (and the matching ES
+        // tracing repository) expect hex. Decode the known 16-byte trace id and 8-byte span id and re-encode.
+        // base64 "hLz5Lr5Nzm0HBLlwpyH7ig==" decodes to the 16 bytes for trace id "84bcf92ebe4dce6d0704b970a721fb8a".
+        // base64 "dBR0f2vpGxg=" decodes to the 8 bytes for span id "7414747f6be91b18".
+        // base64 "cudkhg0tvEo=" decodes to the 8 bytes for parent span id "72e764860d2dbc4a".
+        TempoTraceResponse.Span span = new TempoTraceResponse.Span(
+            "hLz5Lr5Nzm0HBLlwpyH7ig==",
+            "dBR0f2vpGxg=",
+            "cudkhg0tvEo=",
+            "Request phase",
+            "1700000000000000000",
+            "1700000001000000000",
+            List.of(),
+            new TempoTraceResponse.Status("0", null),
+            List.of()
+        );
+        TempoTraceResponse response = singleBatch("gateway", span);
+        when(tempoClient.getTrace(eq("trace"), any())).thenReturn(Single.just(response));
+
+        Trace trace = underTest.getTrace(TracingQueryContext.EMPTY, "trace").blockingGet();
+
+        assertThat(trace).isNotNull();
+        assertThat(trace.spans())
+            .singleElement()
+            .satisfies(s -> {
+                assertThat(s.traceId()).isEqualTo("84bcf92ebe4dce6d0704b970a721fb8a");
+                assertThat(s.spanId()).isEqualTo("7414747f6be91b18");
+                assertThat(s.parentSpanId()).isEqualTo("72e764860d2dbc4a");
+            });
     }
 
     @Test
@@ -231,9 +425,9 @@ class TempoTracingQueryServiceTest {
     @Test
     void should_return_mutable_collections_so_callers_can_post_process() {
         TempoTraceResponse response = singleBatch("gateway", spanWithStatus("trace", "root", null, "GET /proxy", "0"));
-        when(tempoClient.getTrace("trace")).thenReturn(Single.just(response));
+        when(tempoClient.getTrace(eq("trace"), any())).thenReturn(Single.just(response));
 
-        Trace trace = underTest.getTrace("trace").blockingGet();
+        Trace trace = underTest.getTrace(TracingQueryContext.EMPTY, "trace").blockingGet();
         assertThat(trace).isNotNull();
 
         // Adding to spans / attributes / events must not throw.
@@ -241,6 +435,28 @@ class TempoTracingQueryServiceTest {
         trace.spans().get(0).attributes().put("custom", "value");
         trace.spans().get(0).children().add(null);
         trace.spans().get(0).events().add(null);
+    }
+
+    @Test
+    void should_escape_quotes_and_backslashes_in_attribute_filter_values() {
+        // Values flowing into TraceQL clauses must escape " and \ — without escaping, a value carrying either
+        // breaks the query syntactically. Pin both the span-attribute and the resource-attribute paths.
+        when(tempoClient.searchTracesTraceQL(any(), any(), any(), any(), any()))
+            .thenReturn(Single.just(new TempoSearchResponse(List.of())));
+
+        Map<String, String> attributeFilters = new LinkedHashMap<>();
+        attributeFilters.put("http.url", "https://api.example.com/\"with-quote\"");
+        Map<String, String> resourceFilters = new LinkedHashMap<>();
+        resourceFilters.put("deployment.path", "C:\\logs\\trace");
+        underTest
+            .searchTraces(TracingQueryContext.of(null, resourceFilters), new TraceSearchCriteria(attributeFilters, 20, null, null))
+            .blockingGet();
+
+        ArgumentCaptor<String> queryCaptor = ArgumentCaptor.forClass(String.class);
+        verify(tempoClient, times(2)).searchTracesTraceQL(queryCaptor.capture(), any(), any(), any(), any());
+        String primary = queryCaptor.getAllValues().get(0);
+        assertThat(primary).contains("span.http.url = \"https://api.example.com/\\\"with-quote\\\"\"");
+        assertThat(primary).contains("resource.deployment.path = \"C:\\\\logs\\\\trace\"");
     }
 
     // ----- helpers ---------------------------------------------------------
@@ -278,6 +494,22 @@ class TempoTracingQueryServiceTest {
             List.of(
                 new TempoTraceResponse.ResourceSpans(
                     new TempoTraceResponse.Resource(List.of(new TempoTraceResponse.KeyValue("service.name", strVal(serviceName)))),
+                    List.of(new TempoTraceResponse.ScopeSpans(new TempoTraceResponse.Scope("scope"), List.of(spans)))
+                )
+            )
+        );
+    }
+
+    private static TempoTraceResponse singleBatchWithEnv(String serviceName, String environment, TempoTraceResponse.Span... spans) {
+        return new TempoTraceResponse(
+            List.of(
+                new TempoTraceResponse.ResourceSpans(
+                    new TempoTraceResponse.Resource(
+                        List.of(
+                            new TempoTraceResponse.KeyValue("service.name", strVal(serviceName)),
+                            new TempoTraceResponse.KeyValue("gravitee.environment.id", strVal(environment))
+                        )
+                    ),
                     List.of(new TempoTraceResponse.ScopeSpans(new TempoTraceResponse.Scope("scope"), List.of(spans)))
                 )
             )


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

This PR adds support for multitenancy in TracingQueryService and the Tempo implementation. A new context is provided to define the tenant id and additional resource attributes that can be used to restrict the data returned by the service.
A small fix has also been done on the Tempo impl to format IDs in the conventional lowercase-hex form.

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `9.0.0-feat-add-multitenancy-support-tempo-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/9.0.0-feat-add-multitenancy-support-tempo-SNAPSHOT/gravitee-node-9.0.0-feat-add-multitenancy-support-tempo-SNAPSHOT.zip)
  <!-- Version placeholder end -->
