### PR TITLE
feat/APIM-13569: payload data masking

### DIFF
--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/TracerFactory.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/TracerFactory.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.node.api.opentelemetry;
 
+import io.gravitee.node.api.opentelemetry.redaction.PayloadMaskingConfig;
 import io.gravitee.node.api.opentelemetry.redaction.RedactionConfig;
 import java.util.List;
 import java.util.Map;
@@ -66,6 +67,50 @@ public interface TracerFactory {
         final List<InstrumenterTracerFactory> instrumenterTracerFactories,
         final Map<String, String> additionalResourceAttributes,
         final RedactionConfig redactionConfig
+    ) {
+        return createTracer(
+            id,
+            serviceName,
+            serviceNamespace,
+            version,
+            instrumenterTracerFactories,
+            additionalResourceAttributes,
+            redactionConfig,
+            PayloadMaskingConfig.EMPTY
+        );
+    }
+
+    default Tracer createTracer(
+        final String id,
+        final String serviceName,
+        final String serviceNamespace,
+        final String version,
+        final List<InstrumenterTracerFactory> instrumenterTracerFactories,
+        final RedactionConfig redactionConfig,
+        final PayloadMaskingConfig payloadMaskingConfig
+    ) {
+        return createTracer(
+            id,
+            serviceName,
+            serviceNamespace,
+            version,
+            instrumenterTracerFactories,
+            null,
+            redactionConfig,
+            payloadMaskingConfig
+        );
+    }
+
+    @SuppressWarnings("java:S107") // 8 params required: service identity (4) + factories + attrs + redaction + payload masking
+    default Tracer createTracer(
+        final String id,
+        final String serviceName,
+        final String serviceNamespace,
+        final String version,
+        final List<InstrumenterTracerFactory> instrumenterTracerFactories,
+        final Map<String, String> additionalResourceAttributes,
+        final RedactionConfig redactionConfig,
+        final PayloadMaskingConfig payloadMaskingConfig
     ) {
         return createTracer(id, serviceName, serviceNamespace, version, instrumenterTracerFactories, additionalResourceAttributes);
     }

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/redaction/PayloadFormat.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/redaction/PayloadFormat.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.api.opentelemetry.redaction;
+
+/**
+ * The format of the payload body to be masked.
+ * <p>
+ * {@code AUTO} instructs the masking engine to detect the format at runtime from the
+ * {@code payload.format} span-event attribute, falling back to a heuristic inspection
+ * of the body string (leading {@code '{'} / {@code '['} → JSON, leading {@code '<'} → XML).
+ */
+public enum PayloadFormat {
+    JSON,
+    XML,
+    AUTO,
+}

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/redaction/PayloadMaskingConfig.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/redaction/PayloadMaskingConfig.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.api.opentelemetry.redaction;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * An ordered, immutable collection of {@link PayloadMaskingRule} entries used to mask sensitive
+ * fields in request/response payload bodies before export via OTLP.
+ *
+ * <p>Mirrors {@link RedactionConfig} in structure so both configs can be active simultaneously
+ * without interference. Global (gravitee.yml) rules are the base; per-API rules are appended via
+ * {@link #mergeWith(PayloadMaskingConfig)}.
+ *
+ * @param rules              ordered list of masking rules; never null, never contains nulls
+ * @param defaultReplacement fallback replacement string used by rules whose strategy is
+ *                           {@link MaskingStrategy#DEFAULT}
+ */
+public record PayloadMaskingConfig(List<PayloadMaskingRule> rules, String defaultReplacement) {
+    public static final PayloadMaskingConfig EMPTY = new PayloadMaskingConfig(List.of());
+
+    public PayloadMaskingConfig {
+        rules = (rules == null) ? List.of() : List.copyOf(rules);
+        defaultReplacement =
+            (defaultReplacement == null || defaultReplacement.isBlank()) ? RedactionRule.DEFAULT_REPLACEMENT : defaultReplacement;
+    }
+
+    public PayloadMaskingConfig(List<PayloadMaskingRule> rules) {
+        this(rules, RedactionRule.DEFAULT_REPLACEMENT);
+    }
+
+    public boolean hasRules() {
+        return !rules.isEmpty();
+    }
+
+    /**
+     * Returns a new config whose rules are this config's rules followed by {@code other}'s rules.
+     * Global (YAML) config should call this with the per-API config as argument so global rules
+     * are evaluated first.
+     */
+    public PayloadMaskingConfig mergeWith(PayloadMaskingConfig other) {
+        if (other == null || !other.hasRules()) return this;
+        if (!this.hasRules()) return other;
+        List<PayloadMaskingRule> combined = new ArrayList<>(this.rules());
+        combined.addAll(other.rules());
+        return new PayloadMaskingConfig(combined, this.defaultReplacement());
+    }
+}

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/redaction/PayloadMaskingRule.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/redaction/PayloadMaskingRule.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.api.opentelemetry.redaction;
+
+import java.util.Objects;
+
+/**
+ * An immutable rule that masks a specific field within a structured payload body.
+ *
+ * <p>Unlike {@link RedactionRule}, which matches OTel span/log <em>attribute keys</em> by name
+ * pattern, this rule targets <em>field values</em> inside the body using a path expression:
+ * <ul>
+ *   <li>JSONPath — e.g. {@code $.creditCard.number}, {@code $.items[*].payment.cvv}</li>
+ *   <li>XPath — e.g. {@code /order/payment/cvv}</li>
+ * </ul>
+ *
+ * @param path            JSONPath or XPath expression identifying the field(s) to mask (required)
+ * @param maskingStrategy how to mask the matched value; defaults to {@link MaskingStrategy#DEFAULT}
+ * @param phase           which traffic direction this rule applies to; defaults to {@link PayloadPhase#BOTH}
+ * @param format          body format expected by this rule; defaults to {@link PayloadFormat#AUTO}
+ */
+public record PayloadMaskingRule(String path, MaskingStrategy maskingStrategy, PayloadPhase phase, PayloadFormat format) {
+    public PayloadMaskingRule {
+        Objects.requireNonNull(path, "path must not be null");
+        maskingStrategy = (maskingStrategy == null) ? MaskingStrategy.DEFAULT : maskingStrategy;
+        phase = (phase == null) ? PayloadPhase.BOTH : phase;
+        format = (format == null) ? PayloadFormat.AUTO : format;
+    }
+
+    public PayloadMaskingRule(String path) {
+        this(path, MaskingStrategy.DEFAULT, PayloadPhase.BOTH, PayloadFormat.AUTO);
+    }
+
+    public PayloadMaskingRule(String path, MaskingStrategy maskingStrategy) {
+        this(path, maskingStrategy, PayloadPhase.BOTH, PayloadFormat.AUTO);
+    }
+
+    public PayloadMaskingRule(String path, MaskingStrategy maskingStrategy, PayloadPhase phase) {
+        this(path, maskingStrategy, phase, PayloadFormat.AUTO);
+    }
+}

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/redaction/PayloadPhase.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/redaction/PayloadPhase.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.api.opentelemetry.redaction;
+
+/**
+ * The traffic direction a {@link PayloadMaskingRule} applies to.
+ * <p>
+ * {@code BOTH} matches both request and response payload events.
+ */
+public enum PayloadPhase {
+    REQUEST,
+    RESPONSE,
+    BOTH,
+}

--- a/gravitee-node-opentelemetry/pom.xml
+++ b/gravitee-node-opentelemetry/pom.xml
@@ -75,6 +75,12 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
 
+        <!-- JSONPath -->
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+        </dependency>
+
         <!-- Spring -->
         <dependency>
             <groupId>org.springframework</groupId>

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/OpenTelemetryFactory.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/OpenTelemetryFactory.java
@@ -20,6 +20,7 @@ import io.gravitee.node.api.opentelemetry.Logger;
 import io.gravitee.node.api.opentelemetry.LoggerFactory;
 import io.gravitee.node.api.opentelemetry.Tracer;
 import io.gravitee.node.api.opentelemetry.TracerFactory;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadMaskingConfig;
 import io.gravitee.node.api.opentelemetry.redaction.RedactionConfig;
 import io.gravitee.node.opentelemetry.configuration.OpenTelemetryConfiguration;
 import io.gravitee.node.opentelemetry.exporter.SpanExporterFactory;
@@ -116,6 +117,29 @@ public class OpenTelemetryFactory implements TracerFactory, LoggerFactory {
         final Map<String, String> additionalResourceAttributes,
         final RedactionConfig redactionConfig
     ) {
+        return createTracer(
+            serviceInstanceId,
+            serviceName,
+            serviceNamespace,
+            serviceVersion,
+            instrumenterTracerFactories,
+            additionalResourceAttributes,
+            redactionConfig,
+            PayloadMaskingConfig.EMPTY
+        );
+    }
+
+    @Override
+    public Tracer createTracer(
+        final String serviceInstanceId,
+        final String serviceName,
+        final String serviceNamespace,
+        final String serviceVersion,
+        final List<InstrumenterTracerFactory> instrumenterTracerFactories,
+        final Map<String, String> additionalResourceAttributes,
+        final RedactionConfig redactionConfig,
+        final PayloadMaskingConfig payloadMaskingConfig
+    ) {
         if (configuration.isTracesEnabled()) {
             Resource resource = createResource(
                 serviceInstanceId,
@@ -126,11 +150,12 @@ public class OpenTelemetryFactory implements TracerFactory, LoggerFactory {
             );
 
             // YAML rules are the base; any product-supplied rules are merged on top.
-            // Products that pass RedactionConfig.EMPTY (or nothing) automatically benefit
-            // from operator-configured YAML rules without any code change in APIM or AM.
-            RedactionConfig effectiveConfig = configuration.getRedactionConfig().mergeWith(redactionConfig);
+            // Products that pass RedactionConfig.EMPTY / PayloadMaskingConfig.EMPTY (or nothing)
+            // automatically benefit from operator-configured YAML rules without any code change.
+            RedactionConfig effectiveRedaction = configuration.getRedactionConfig().mergeWith(redactionConfig);
+            PayloadMaskingConfig effectivePayload = configuration.getPayloadMaskingConfig().mergeWith(payloadMaskingConfig);
             SpanExporter exporter = spanExporterFactory.getSpanExporter();
-            if (effectiveConfig.hasRules()) {
+            if (effectiveRedaction.hasRules() || effectivePayload.hasRules()) {
                 // Create the exporter once and reuse its compiled rules to redact resource
                 // attributes (service.instance.id, hostname, ip, …) upfront so the already-clean
                 // values are baked into the SdkTracerProvider. Resource attrs live in
@@ -138,7 +163,7 @@ public class OpenTelemetryFactory implements TracerFactory, LoggerFactory {
                 // to per-span redaction inside the exporter.
                 // @SuppressWarnings: lifecycle is transferred to BatchSpanProcessor below.
                 @SuppressWarnings("resource")
-                RedactSpanExporter redactExporter = new RedactSpanExporter(exporter, effectiveConfig);
+                RedactSpanExporter redactExporter = new RedactSpanExporter(exporter, effectiveRedaction, effectivePayload);
                 resource = redactExporter.redactResource(resource);
                 exporter = redactExporter;
             }

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/configuration/OpenTelemetryConfiguration.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/configuration/OpenTelemetryConfiguration.java
@@ -17,6 +17,10 @@ package io.gravitee.node.opentelemetry.configuration;
 
 import io.gravitee.common.util.EnvironmentUtils;
 import io.gravitee.node.api.opentelemetry.redaction.MaskingStrategy;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadFormat;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadMaskingConfig;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadMaskingRule;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadPhase;
 import io.gravitee.node.api.opentelemetry.redaction.RedactionConfig;
 import io.gravitee.node.api.opentelemetry.redaction.RedactionRule;
 import io.opentelemetry.api.common.AttributeKey;
@@ -239,6 +243,47 @@ public class OpenTelemetryConfiguration {
             "services.opentelemetry.redactionDefaultReplacement"
         );
         return redactionConfig = rules.isEmpty() ? RedactionConfig.EMPTY : new RedactionConfig(rules, defaultReplacement);
+    }
+
+    @Getter(AccessLevel.NONE)
+    private PayloadMaskingConfig payloadMaskingConfig;
+
+    public PayloadMaskingConfig getPayloadMaskingConfig() {
+        if (payloadMaskingConfig != null) {
+            return payloadMaskingConfig;
+        }
+        Map<String, Object> allRuleProperties = EnvironmentUtils.getPropertiesStartingWith(
+            environment,
+            "services.opentelemetry.payloadMasking.rules"
+        );
+        if (allRuleProperties.isEmpty()) {
+            payloadMaskingConfig = PayloadMaskingConfig.EMPTY;
+            return payloadMaskingConfig;
+        }
+        List<PayloadMaskingRule> rules = new ArrayList<>();
+        int ruleIndex = 0;
+        while (true) {
+            String rulePrefix = "services.opentelemetry.payloadMasking.rules[" + ruleIndex + "].";
+            String path = getString(allRuleProperties, rulePrefix + "path");
+            if (path == null) break;
+            rules.add(buildPayloadRule(allRuleProperties, rulePrefix, path));
+            ruleIndex++;
+        }
+        String defaultReplacement = getString(
+            EnvironmentUtils.getPropertiesStartingWith(environment, "services.opentelemetry.payloadMasking.defaultReplacement"),
+            "services.opentelemetry.payloadMasking.defaultReplacement"
+        );
+        payloadMaskingConfig = rules.isEmpty() ? PayloadMaskingConfig.EMPTY : new PayloadMaskingConfig(rules, defaultReplacement);
+        return payloadMaskingConfig;
+    }
+
+    private PayloadMaskingRule buildPayloadRule(Map<String, Object> ruleProperties, String rulePrefix, String path) {
+        MaskingStrategy strategy = buildMaskingStrategy(ruleProperties, rulePrefix);
+        String phaseStr = getString(ruleProperties, rulePrefix + "phase");
+        PayloadPhase phase = phaseStr != null ? PayloadPhase.valueOf(phaseStr.toUpperCase()) : PayloadPhase.BOTH;
+        String formatStr = getString(ruleProperties, rulePrefix + "format");
+        PayloadFormat format = formatStr != null ? PayloadFormat.valueOf(formatStr.toUpperCase()) : PayloadFormat.AUTO;
+        return new PayloadMaskingRule(path, strategy, phase, format);
     }
 
     private RedactionRule buildRule(Map<String, Object> ruleProperties, String rulePrefix, String pattern) {

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/redact/CompiledPayloadMaskingRule.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/redact/CompiledPayloadMaskingRule.java
@@ -30,14 +30,14 @@ import io.gravitee.node.api.opentelemetry.redaction.PayloadPhase;
  */
 final class CompiledPayloadMaskingRule {
 
-    // null when format is XML (or AUTO — resolved at redact time)
-    final JsonPath compiledJsonPath;
-    // raw XPath expression; null when format is JSON
-    final String rawXPath;
-    final MaskingStrategy maskingStrategy;
-    final String effectiveReplacement;
-    final PayloadPhase phase;
-    final PayloadFormat format;
+    // null when format is XML, or when JsonPath.compile() fails for AUTO/JSON rules
+    private final JsonPath compiledJsonPath;
+    // raw XPath expression; always set for XML and AUTO formats
+    private final String rawXPath;
+    private final MaskingStrategy maskingStrategy;
+    private final String effectiveReplacement;
+    private final PayloadPhase phase;
+    private final PayloadFormat format;
 
     CompiledPayloadMaskingRule(PayloadMaskingRule rule, String configDefaultReplacement) {
         this.maskingStrategy = rule.maskingStrategy();
@@ -54,10 +54,28 @@ final class CompiledPayloadMaskingRule {
             this.rawXPath = rule.path();
         } else {
             // JSON or AUTO: compile as JsonPath. AUTO rules also run through XML redactor if body is XML.
-            this.compiledJsonPath = JsonPath.compile(rule.path());
+            JsonPath compiled;
+            try {
+                compiled = JsonPath.compile(rule.path());
+            } catch (Exception e) {
+                compiled = null; // invalid JsonPath expression — rule will be skipped at redact time
+            }
+            this.compiledJsonPath = compiled;
             // Keep the raw path for XPath evaluation when AUTO detects XML at runtime.
             this.rawXPath = rule.path();
         }
+    }
+
+    JsonPath compiledJsonPath() {
+        return compiledJsonPath;
+    }
+
+    String rawXPath() {
+        return rawXPath;
+    }
+
+    PayloadFormat format() {
+        return format;
     }
 
     boolean appliesToPhase(PayloadPhase requestedPhase) {

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/redact/CompiledPayloadMaskingRule.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/redact/CompiledPayloadMaskingRule.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.opentelemetry.exporter.redact;
+
+import com.jayway.jsonpath.JsonPath;
+import io.gravitee.node.api.opentelemetry.redaction.FullMaskingStrategy;
+import io.gravitee.node.api.opentelemetry.redaction.MaskingStrategy;
+import io.gravitee.node.api.opentelemetry.redaction.PartialMaskingStrategy;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadFormat;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadMaskingRule;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadPhase;
+
+/**
+ * A pre-compiled form of a {@link PayloadMaskingRule} used at export time.
+ * Path expressions are compiled once at deploy time — not per request — to avoid
+ * repeated parse overhead on the hot path.
+ */
+final class CompiledPayloadMaskingRule {
+
+    // null when format is XML (or AUTO — resolved at redact time)
+    final JsonPath compiledJsonPath;
+    // raw XPath expression; null when format is JSON
+    final String rawXPath;
+    final MaskingStrategy maskingStrategy;
+    final String effectiveReplacement;
+    final PayloadPhase phase;
+    final PayloadFormat format;
+
+    CompiledPayloadMaskingRule(PayloadMaskingRule rule, String configDefaultReplacement) {
+        this.maskingStrategy = rule.maskingStrategy();
+        this.phase = rule.phase();
+        this.format = rule.format();
+        this.effectiveReplacement =
+            switch (rule.maskingStrategy()) {
+                case FullMaskingStrategy full -> (full == MaskingStrategy.DEFAULT) ? configDefaultReplacement : full.replacement();
+                case PartialMaskingStrategy ignored -> null; // computed per value
+            };
+
+        if (rule.format() == PayloadFormat.XML) {
+            this.compiledJsonPath = null;
+            this.rawXPath = rule.path();
+        } else {
+            // JSON or AUTO: compile as JsonPath. AUTO rules also run through XML redactor if body is XML.
+            this.compiledJsonPath = JsonPath.compile(rule.path());
+            // Keep the raw path for XPath evaluation when AUTO detects XML at runtime.
+            this.rawXPath = rule.path();
+        }
+    }
+
+    boolean appliesToPhase(PayloadPhase requestedPhase) {
+        return this.phase == PayloadPhase.BOTH || this.phase == requestedPhase;
+    }
+
+    String applyMask(String value) {
+        return switch (maskingStrategy) {
+            case FullMaskingStrategy ignored -> effectiveReplacement;
+            case PartialMaskingStrategy partial -> {
+                String maskChar = partial.maskChar();
+                if (value == null) yield maskChar;
+                int prefix = partial.prefixLength();
+                int suffix = partial.suffixLength();
+                if (value.length() <= prefix + suffix) yield maskChar.repeat(value.length());
+                yield value.substring(0, prefix) +
+                maskChar.repeat(value.length() - prefix - suffix) +
+                value.substring(value.length() - suffix);
+            }
+        };
+    }
+}

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/redact/JsonPathPayloadRedactor.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/redact/JsonPathPayloadRedactor.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.opentelemetry.exporter.redact;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.Option;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadPhase;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Applies {@link CompiledPayloadMaskingRule} entries to a JSON body string using Jayway JsonPath.
+ *
+ * <p>Fail-open: any parse error returns the original body unchanged — the span is never dropped.
+ * Thread-safe and stateless (no mutable instance fields).
+ */
+final class JsonPathPayloadRedactor {
+
+    private static final Logger log = LoggerFactory.getLogger(JsonPathPayloadRedactor.class);
+
+    // SUPPRESS_EXCEPTIONS: missing paths are silently skipped (no PathNotFoundException).
+    // DEFAULT_PATH_LEAF_TO_NULL intentionally excluded — it would create null fields for non-existent paths.
+    private static final Configuration JSONPATH_CONFIG = Configuration.builder().options(Option.SUPPRESS_EXCEPTIONS).build();
+
+    /**
+     * Applies all rules that match {@code phase} to {@code json} and returns the masked result.
+     * Returns {@code json} unchanged if no rule matches or if the body cannot be parsed.
+     */
+    String redact(String json, List<CompiledPayloadMaskingRule> rules, PayloadPhase phase) {
+        if (json == null || json.isBlank() || rules.isEmpty()) {
+            return json;
+        }
+        DocumentContext ctx;
+        try {
+            ctx = com.jayway.jsonpath.JsonPath.using(JSONPATH_CONFIG).parse(json);
+        } catch (Exception e) {
+            log.warn("PayloadMasking: failed to parse JSON body — returning original body unchanged. Cause: {}", e.getMessage());
+            return json;
+        }
+
+        boolean anyApplied = false;
+        for (CompiledPayloadMaskingRule rule : rules) {
+            if (!rule.appliesToPhase(phase) || rule.compiledJsonPath == null) {
+                continue;
+            }
+            try {
+                boolean[] matched = { false };
+                ctx.map(
+                    rule.compiledJsonPath,
+                    (value, cfg) -> {
+                        if (value == null) return null;
+                        matched[0] = true;
+                        return rule.applyMask(value.toString());
+                    }
+                );
+                anyApplied |= matched[0];
+            } catch (Exception e) {
+                log.warn(
+                    "PayloadMasking: failed to apply JSONPath '{}' — skipping rule. Cause: {}",
+                    rule.compiledJsonPath.getPath(),
+                    e.getMessage()
+                );
+            }
+        }
+        if (!anyApplied) {
+            return json;
+        }
+        try {
+            return ctx.jsonString();
+        } catch (Exception e) {
+            log.warn("PayloadMasking: failed to serialize masked JSON — returning original body unchanged. Cause: {}", e.getMessage());
+            return json;
+        }
+    }
+}

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/redact/JsonPathPayloadRedactor.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/redact/JsonPathPayloadRedactor.java
@@ -20,8 +20,7 @@ import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.Option;
 import io.gravitee.node.api.opentelemetry.redaction.PayloadPhase;
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.CustomLog;
 
 /**
  * Applies {@link CompiledPayloadMaskingRule} entries to a JSON body string using Jayway JsonPath.
@@ -29,9 +28,8 @@ import org.slf4j.LoggerFactory;
  * <p>Fail-open: any parse error returns the original body unchanged — the span is never dropped.
  * Thread-safe and stateless (no mutable instance fields).
  */
+@CustomLog
 final class JsonPathPayloadRedactor {
-
-    private static final Logger log = LoggerFactory.getLogger(JsonPathPayloadRedactor.class);
 
     // SUPPRESS_EXCEPTIONS: missing paths are silently skipped (no PathNotFoundException).
     // DEFAULT_PATH_LEAF_TO_NULL intentionally excluded — it would create null fields for non-existent paths.
@@ -55,13 +53,13 @@ final class JsonPathPayloadRedactor {
 
         boolean anyApplied = false;
         for (CompiledPayloadMaskingRule rule : rules) {
-            if (!rule.appliesToPhase(phase) || rule.compiledJsonPath == null) {
+            if (!rule.appliesToPhase(phase) || rule.compiledJsonPath() == null) {
                 continue;
             }
             try {
                 boolean[] matched = { false };
                 ctx.map(
-                    rule.compiledJsonPath,
+                    rule.compiledJsonPath(),
                     (value, cfg) -> {
                         if (value == null) return null;
                         matched[0] = true;
@@ -72,7 +70,7 @@ final class JsonPathPayloadRedactor {
             } catch (Exception e) {
                 log.warn(
                     "PayloadMasking: failed to apply JSONPath '{}' — skipping rule. Cause: {}",
-                    rule.compiledJsonPath.getPath(),
+                    rule.compiledJsonPath().getPath(),
                     e.getMessage()
                 );
             }

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/redact/PayloadFieldRedactor.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/redact/PayloadFieldRedactor.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.opentelemetry.exporter.redact;
+
+import io.gravitee.node.api.opentelemetry.redaction.PayloadFormat;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadMaskingConfig;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadPhase;
+import java.util.List;
+
+/**
+ * Dispatcher that routes a payload body to {@link JsonPathPayloadRedactor} or
+ * {@link XPathPayloadRedactor} based on the resolved {@link PayloadFormat}.
+ *
+ * <p>Format resolution order for rules whose format is {@link PayloadFormat#AUTO}:
+ * <ol>
+ *   <li>The {@code eventFormat} attribute from the span event ({@code "JSON"} / {@code "XML"}).</li>
+ *   <li>Body heuristic: stripped body starting with {@code {} or {@code [} → JSON;
+ *       starting with {@code <} → XML.</li>
+ * </ol>
+ *
+ * <p>Thread-safe. Holds no mutable state after construction.
+ */
+final class PayloadFieldRedactor {
+
+    private final JsonPathPayloadRedactor jsonRedactor = new JsonPathPayloadRedactor();
+    private final XPathPayloadRedactor xmlRedactor = new XPathPayloadRedactor();
+
+    private final List<CompiledPayloadMaskingRule> jsonRules;
+    private final List<CompiledPayloadMaskingRule> xmlRules;
+    private final List<CompiledPayloadMaskingRule> autoRules;
+
+    PayloadFieldRedactor(PayloadMaskingConfig config) {
+        String defaultReplacement = config.defaultReplacement();
+        List<CompiledPayloadMaskingRule> compiled = config
+            .rules()
+            .stream()
+            .map(rule -> new CompiledPayloadMaskingRule(rule, defaultReplacement))
+            .toList();
+
+        this.jsonRules = compiled.stream().filter(r -> r.format == PayloadFormat.JSON).toList();
+        this.xmlRules = compiled.stream().filter(r -> r.format == PayloadFormat.XML).toList();
+        this.autoRules = compiled.stream().filter(r -> r.format == PayloadFormat.AUTO).toList();
+    }
+
+    /**
+     * Masks sensitive fields in {@code body} using rules that apply to {@code phase}.
+     *
+     * @param body        the raw payload body string from the span event's {@code payload.body} attribute
+     * @param eventFormat the {@code payload.format} span-event attribute value (may be null → triggers AUTO heuristic)
+     * @param phase       {@code REQUEST} or {@code RESPONSE} from the {@code payload.phase} attribute
+     * @return the masked body, or {@code body} unchanged if no rules match
+     */
+    String redact(String body, String eventFormat, PayloadPhase phase) {
+        if (body == null || body.isBlank()) {
+            return body;
+        }
+
+        PayloadFormat resolved = resolveFormat(eventFormat, body);
+
+        return switch (resolved) {
+            case JSON -> {
+                String result = jsonRedactor.redact(body, jsonRules, phase);
+                // Also apply AUTO rules as JSON
+                yield autoRules.isEmpty() ? result : jsonRedactor.redact(result, autoRules, phase);
+            }
+            case XML -> {
+                String result = xmlRedactor.redact(body, xmlRules, phase);
+                // Also apply AUTO rules as XML
+                yield autoRules.isEmpty() ? result : xmlRedactor.redact(result, autoRules, phase);
+            }
+            case AUTO -> body; // unrecognised format — fail-open, do not mask
+        };
+    }
+
+    private static PayloadFormat resolveFormat(String eventFormat, String body) {
+        if (eventFormat != null) {
+            if ("JSON".equalsIgnoreCase(eventFormat)) return PayloadFormat.JSON;
+            if ("XML".equalsIgnoreCase(eventFormat)) return PayloadFormat.XML;
+        }
+        // Body heuristic
+        String stripped = body.stripLeading();
+        if (!stripped.isEmpty()) {
+            char first = stripped.charAt(0);
+            if (first == '{' || first == '[') return PayloadFormat.JSON;
+            if (first == '<') return PayloadFormat.XML;
+        }
+        return PayloadFormat.AUTO; // unrecognised
+    }
+}

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/redact/PayloadFieldRedactor.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/redact/PayloadFieldRedactor.java
@@ -19,6 +19,7 @@ import io.gravitee.node.api.opentelemetry.redaction.PayloadFormat;
 import io.gravitee.node.api.opentelemetry.redaction.PayloadMaskingConfig;
 import io.gravitee.node.api.opentelemetry.redaction.PayloadPhase;
 import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * Dispatcher that routes a payload body to {@link JsonPathPayloadRedactor} or
@@ -38,9 +39,10 @@ final class PayloadFieldRedactor {
     private final JsonPathPayloadRedactor jsonRedactor = new JsonPathPayloadRedactor();
     private final XPathPayloadRedactor xmlRedactor = new XPathPayloadRedactor();
 
-    private final List<CompiledPayloadMaskingRule> jsonRules;
-    private final List<CompiledPayloadMaskingRule> xmlRules;
-    private final List<CompiledPayloadMaskingRule> autoRules;
+    // JSON-format rules merged with AUTO rules (both applied when body is JSON)
+    private final List<CompiledPayloadMaskingRule> effectiveJsonRules;
+    // XML-format rules merged with AUTO rules (both applied when body is XML)
+    private final List<CompiledPayloadMaskingRule> effectiveXmlRules;
 
     PayloadFieldRedactor(PayloadMaskingConfig config) {
         String defaultReplacement = config.defaultReplacement();
@@ -50,9 +52,13 @@ final class PayloadFieldRedactor {
             .map(rule -> new CompiledPayloadMaskingRule(rule, defaultReplacement))
             .toList();
 
-        this.jsonRules = compiled.stream().filter(r -> r.format == PayloadFormat.JSON).toList();
-        this.xmlRules = compiled.stream().filter(r -> r.format == PayloadFormat.XML).toList();
-        this.autoRules = compiled.stream().filter(r -> r.format == PayloadFormat.AUTO).toList();
+        List<CompiledPayloadMaskingRule> jsonRules = compiled.stream().filter(r -> r.format() == PayloadFormat.JSON).toList();
+        List<CompiledPayloadMaskingRule> xmlRules = compiled.stream().filter(r -> r.format() == PayloadFormat.XML).toList();
+        List<CompiledPayloadMaskingRule> autoRules = compiled.stream().filter(r -> r.format() == PayloadFormat.AUTO).toList();
+
+        // Pre-merge so each body is parsed only once per format
+        this.effectiveJsonRules = autoRules.isEmpty() ? jsonRules : Stream.concat(jsonRules.stream(), autoRules.stream()).toList();
+        this.effectiveXmlRules = autoRules.isEmpty() ? xmlRules : Stream.concat(xmlRules.stream(), autoRules.stream()).toList();
     }
 
     /**
@@ -71,16 +77,8 @@ final class PayloadFieldRedactor {
         PayloadFormat resolved = resolveFormat(eventFormat, body);
 
         return switch (resolved) {
-            case JSON -> {
-                String result = jsonRedactor.redact(body, jsonRules, phase);
-                // Also apply AUTO rules as JSON
-                yield autoRules.isEmpty() ? result : jsonRedactor.redact(result, autoRules, phase);
-            }
-            case XML -> {
-                String result = xmlRedactor.redact(body, xmlRules, phase);
-                // Also apply AUTO rules as XML
-                yield autoRules.isEmpty() ? result : xmlRedactor.redact(result, autoRules, phase);
-            }
+            case JSON -> jsonRedactor.redact(body, effectiveJsonRules, phase);
+            case XML -> xmlRedactor.redact(body, effectiveXmlRules, phase);
             case AUTO -> body; // unrecognised format — fail-open, do not mask
         };
     }

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/redact/RedactSpanExporter.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/redact/RedactSpanExporter.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.node.opentelemetry.exporter.redact;
 
+import io.gravitee.node.api.opentelemetry.redaction.PayloadMaskingConfig;
 import io.gravitee.node.api.opentelemetry.redaction.RedactionConfig;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.common.CompletableResultCode;
@@ -32,8 +33,12 @@ public final class RedactSpanExporter implements SpanExporter {
     private final SpanAttributeRedactor redactor;
 
     public RedactSpanExporter(SpanExporter delegate, RedactionConfig config) {
+        this(delegate, config, PayloadMaskingConfig.EMPTY);
+    }
+
+    public RedactSpanExporter(SpanExporter delegate, RedactionConfig config, PayloadMaskingConfig payloadMaskingConfig) {
         this.delegate = delegate;
-        this.redactor = new SpanAttributeRedactor(config);
+        this.redactor = new SpanAttributeRedactor(config, payloadMaskingConfig);
     }
 
     /** Redacts resource attributes at tracer-creation time. Returns the original if no rule matches. */

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/redact/SpanAttributeRedactor.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/redact/SpanAttributeRedactor.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.node.opentelemetry.exporter.redact;
 
+import io.gravitee.node.api.opentelemetry.redaction.PayloadMaskingConfig;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadPhase;
 import io.gravitee.node.api.opentelemetry.redaction.RedactionConfig;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -22,18 +24,32 @@ import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.sdk.trace.data.EventData;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import lombok.CustomLog;
 
+@CustomLog
 final class SpanAttributeRedactor {
 
+    private static final String PAYLOAD_EVENT_NAME = "payload";
+    private static final AttributeKey<String> PAYLOAD_BODY = AttributeKey.stringKey("payload.body");
+    private static final AttributeKey<String> PAYLOAD_FORMAT = AttributeKey.stringKey("payload.format");
+    private static final AttributeKey<String> PAYLOAD_PHASE = AttributeKey.stringKey("payload.phase");
+
     private final List<CompiledRedactionRule> rules;
+    private final PayloadFieldRedactor payloadRedactor;
 
     SpanAttributeRedactor(RedactionConfig config) {
-        String defaultReplacement = config.defaultReplacement();
-        this.rules = config.rules().stream().map(rule -> new CompiledRedactionRule(rule, defaultReplacement)).toList();
+        this(config, PayloadMaskingConfig.EMPTY);
+    }
+
+    SpanAttributeRedactor(RedactionConfig redactionConfig, PayloadMaskingConfig payloadMaskingConfig) {
+        String defaultReplacement = redactionConfig.defaultReplacement();
+        this.rules = redactionConfig.rules().stream().map(rule -> new CompiledRedactionRule(rule, defaultReplacement)).toList();
+        this.payloadRedactor = payloadMaskingConfig.hasRules() ? new PayloadFieldRedactor(payloadMaskingConfig) : null;
     }
 
     boolean hasRules() {
-        return !rules.isEmpty();
+        return !rules.isEmpty() || payloadRedactor != null;
     }
 
     List<EventData> redactEvents(List<EventData> events) {
@@ -44,6 +60,7 @@ final class SpanAttributeRedactor {
         for (int i = 0; i < events.size(); i++) {
             EventData original = events.get(i);
             Attributes redactedAttrs = redact(original.getAttributes());
+            redactedAttrs = redactPayloadBody(original.getName(), redactedAttrs);
             if (redactedAttrs != original.getAttributes() && result == null) {
                 result = new ArrayList<>(events.size());
                 for (int j = 0; j < i; j++) {
@@ -59,6 +76,41 @@ final class SpanAttributeRedactor {
             }
         }
         return result != null ? result : events;
+    }
+
+    private Attributes redactPayloadBody(String eventName, Attributes attrs) {
+        if (payloadRedactor == null || !PAYLOAD_EVENT_NAME.equals(eventName)) {
+            return attrs;
+        }
+        Map<AttributeKey<?>, Object> attrMap = attrs.asMap();
+        String body = (String) attrMap.get(PAYLOAD_BODY);
+        if (body == null) {
+            return attrs;
+        }
+        String format = (String) attrMap.get(PAYLOAD_FORMAT);
+        String phaseStr = (String) attrMap.get(PAYLOAD_PHASE);
+        PayloadPhase phase;
+        if (phaseStr == null || "REQUEST".equalsIgnoreCase(phaseStr)) {
+            phase = PayloadPhase.REQUEST;
+        } else if ("RESPONSE".equalsIgnoreCase(phaseStr)) {
+            phase = PayloadPhase.RESPONSE;
+        } else {
+            log.warn("PayloadMasking: unrecognised payload.phase value '{}' — defaulting to REQUEST", phaseStr);
+            phase = PayloadPhase.REQUEST;
+        }
+        String maskedBody = payloadRedactor.redact(body, format, phase);
+        if (maskedBody == body) { //NOSONAR S1698: intentional reference equality — fast-path when body is unchanged
+            return attrs;
+        }
+        AttributesBuilder builder = Attributes.builder();
+        attrMap.forEach((key, value) -> {
+            if (PAYLOAD_BODY.equals(key)) {
+                builder.put(PAYLOAD_BODY, maskedBody);
+            } else {
+                putRaw(builder, key, value);
+            }
+        });
+        return builder.build();
     }
 
     Attributes redact(Attributes original) {

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/redact/XPathPayloadRedactor.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/redact/XPathPayloadRedactor.java
@@ -21,14 +21,14 @@ import java.io.StringWriter;
 import java.util.List;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.CustomLog;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 
@@ -39,9 +39,8 @@ import org.xml.sax.InputSource;
  * per invocation from the thread-safe {@link XPathFactory#newInstance()} singleton.
  * Fail-open: any parse / evaluation error returns the original body unchanged.
  */
+@CustomLog
 final class XPathPayloadRedactor {
-
-    private static final Logger log = LoggerFactory.getLogger(XPathPayloadRedactor.class);
 
     // XPathFactory.newInstance() IS thread-safe per the JAXP spec.
     private static final XPathFactory XPATH_FACTORY = XPathFactory.newInstance();
@@ -67,7 +66,10 @@ final class XPathPayloadRedactor {
 
         org.w3c.dom.Document doc;
         try {
-            DocumentBuilder builder = DOC_BUILDER_FACTORY.newDocumentBuilder();
+            DocumentBuilder builder;
+            synchronized (DOC_BUILDER_FACTORY) {
+                builder = DOC_BUILDER_FACTORY.newDocumentBuilder();
+            }
             doc = builder.parse(new InputSource(new StringReader(xml)));
         } catch (Exception e) {
             log.warn("PayloadMasking: failed to parse XML body — returning original body unchanged. Cause: {}", e.getMessage());
@@ -76,12 +78,12 @@ final class XPathPayloadRedactor {
 
         boolean anyApplied = false;
         for (CompiledPayloadMaskingRule rule : rules) {
-            if (!rule.appliesToPhase(phase) || rule.rawXPath == null) {
+            if (!rule.appliesToPhase(phase) || rule.rawXPath() == null) {
                 continue;
             }
             try {
                 // XPathExpression is NOT thread-safe — compile fresh per call.
-                javax.xml.xpath.XPathExpression expr = XPATH_FACTORY.newXPath().compile(rule.rawXPath);
+                javax.xml.xpath.XPathExpression expr = XPATH_FACTORY.newXPath().compile(rule.rawXPath());
                 NodeList nodes = (NodeList) expr.evaluate(doc, XPathConstants.NODESET);
                 for (int i = 0; i < nodes.getLength(); i++) {
                     org.w3c.dom.Node node = nodes.item(i);
@@ -89,7 +91,7 @@ final class XPathPayloadRedactor {
                     anyApplied = true;
                 }
             } catch (Exception e) {
-                log.warn("PayloadMasking: failed to apply XPath '{}' — skipping rule. Cause: {}", rule.rawXPath, e.getMessage());
+                log.warn("PayloadMasking: failed to apply XPath '{}' — skipping rule. Cause: {}", rule.rawXPath(), e.getMessage());
             }
         }
 
@@ -99,6 +101,7 @@ final class XPathPayloadRedactor {
 
         try {
             Transformer transformer = TRANSFORMER_FACTORY.newTransformer();
+            transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
             StringWriter writer = new StringWriter();
             transformer.transform(new DOMSource(doc), new StreamResult(writer));
             return writer.toString();

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/redact/XPathPayloadRedactor.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/redact/XPathPayloadRedactor.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.opentelemetry.exporter.redact;
+
+import io.gravitee.node.api.opentelemetry.redaction.PayloadPhase;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.List;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+/**
+ * Applies {@link CompiledPayloadMaskingRule} entries to an XML body string using javax.xml.xpath.
+ *
+ * <p>{@link javax.xml.xpath.XPathExpression} is NOT thread-safe; a fresh expression is compiled
+ * per invocation from the thread-safe {@link XPathFactory#newInstance()} singleton.
+ * Fail-open: any parse / evaluation error returns the original body unchanged.
+ */
+final class XPathPayloadRedactor {
+
+    private static final Logger log = LoggerFactory.getLogger(XPathPayloadRedactor.class);
+
+    // XPathFactory.newInstance() IS thread-safe per the JAXP spec.
+    private static final XPathFactory XPATH_FACTORY = XPathFactory.newInstance();
+
+    // DocumentBuilderFactory and TransformerFactory are also thread-safe for newInstance().
+    private static final DocumentBuilderFactory DOC_BUILDER_FACTORY;
+    private static final TransformerFactory TRANSFORMER_FACTORY;
+
+    static {
+        DOC_BUILDER_FACTORY = DocumentBuilderFactory.newInstance();
+        DOC_BUILDER_FACTORY.setNamespaceAware(false);
+        TRANSFORMER_FACTORY = TransformerFactory.newInstance();
+    }
+
+    /**
+     * Applies all rules that match {@code phase} to {@code xml} and returns the masked result.
+     * Returns {@code xml} unchanged if no rule matches or the body cannot be parsed.
+     */
+    String redact(String xml, List<CompiledPayloadMaskingRule> rules, PayloadPhase phase) {
+        if (xml == null || xml.isBlank() || rules.isEmpty()) {
+            return xml;
+        }
+
+        org.w3c.dom.Document doc;
+        try {
+            DocumentBuilder builder = DOC_BUILDER_FACTORY.newDocumentBuilder();
+            doc = builder.parse(new InputSource(new StringReader(xml)));
+        } catch (Exception e) {
+            log.warn("PayloadMasking: failed to parse XML body — returning original body unchanged. Cause: {}", e.getMessage());
+            return xml;
+        }
+
+        boolean anyApplied = false;
+        for (CompiledPayloadMaskingRule rule : rules) {
+            if (!rule.appliesToPhase(phase) || rule.rawXPath == null) {
+                continue;
+            }
+            try {
+                // XPathExpression is NOT thread-safe — compile fresh per call.
+                javax.xml.xpath.XPathExpression expr = XPATH_FACTORY.newXPath().compile(rule.rawXPath);
+                NodeList nodes = (NodeList) expr.evaluate(doc, XPathConstants.NODESET);
+                for (int i = 0; i < nodes.getLength(); i++) {
+                    org.w3c.dom.Node node = nodes.item(i);
+                    node.setTextContent(rule.applyMask(node.getTextContent()));
+                    anyApplied = true;
+                }
+            } catch (Exception e) {
+                log.warn("PayloadMasking: failed to apply XPath '{}' — skipping rule. Cause: {}", rule.rawXPath, e.getMessage());
+            }
+        }
+
+        if (!anyApplied) {
+            return xml;
+        }
+
+        try {
+            Transformer transformer = TRANSFORMER_FACTORY.newTransformer();
+            StringWriter writer = new StringWriter();
+            transformer.transform(new DOMSource(doc), new StreamResult(writer));
+            return writer.toString();
+        } catch (Exception e) {
+            log.warn("PayloadMasking: failed to serialize masked XML — returning original body unchanged. Cause: {}", e.getMessage());
+            return xml;
+        }
+    }
+}

--- a/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/configuration/OpenTelemetryConfigurationTest.java
+++ b/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/configuration/OpenTelemetryConfigurationTest.java
@@ -5,6 +5,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.gravitee.node.api.opentelemetry.redaction.FullMaskingStrategy;
 import io.gravitee.node.api.opentelemetry.redaction.MaskingStrategy;
 import io.gravitee.node.api.opentelemetry.redaction.PartialMaskingStrategy;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadFormat;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadMaskingConfig;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadMaskingRule;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadPhase;
 import io.gravitee.node.api.opentelemetry.redaction.RedactionConfig;
 import io.gravitee.node.api.opentelemetry.redaction.RedactionRule;
 import io.opentelemetry.api.common.AttributeKey;
@@ -246,6 +250,81 @@ class OpenTelemetryConfigurationTest {
             RedactionConfig merged = yamlConfig.mergeWith(productConfig);
 
             assertThat(merged.defaultReplacement()).isEqualTo("[YAML_DEFAULT]");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // getPayloadMaskingConfig
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class GetPayloadMaskingConfig {
+
+        @Test
+        void returns_empty_config_when_no_rules_defined() {
+            assertThat(underTest.getPayloadMaskingConfig()).isSameAs(PayloadMaskingConfig.EMPTY);
+        }
+
+        @Test
+        void reads_single_full_mask_rule_with_defaults() {
+            environment.setProperty("services.opentelemetry.payloadMasking.rules[0].path", "$.password");
+            environment.setProperty("services.opentelemetry.payloadMasking.rules[0].maskingStrategy.type", "FULL");
+
+            PayloadMaskingConfig config = underTest.getPayloadMaskingConfig();
+
+            assertThat(config.rules()).hasSize(1);
+            PayloadMaskingRule rule = config.rules().get(0);
+            assertThat(rule.path()).isEqualTo("$.password");
+            assertThat(rule.phase()).isEqualTo(PayloadPhase.BOTH);
+            assertThat(rule.format()).isEqualTo(PayloadFormat.AUTO);
+        }
+
+        @Test
+        void reads_phase_and_format_explicitly() {
+            environment.setProperty("services.opentelemetry.payloadMasking.rules[0].path", "//cvv");
+            environment.setProperty("services.opentelemetry.payloadMasking.rules[0].phase", "REQUEST");
+            environment.setProperty("services.opentelemetry.payloadMasking.rules[0].format", "XML");
+
+            PayloadMaskingConfig config = underTest.getPayloadMaskingConfig();
+
+            PayloadMaskingRule rule = config.rules().get(0);
+            assertThat(rule.phase()).isEqualTo(PayloadPhase.REQUEST);
+            assertThat(rule.format()).isEqualTo(PayloadFormat.XML);
+        }
+
+        @Test
+        void reads_partial_mask_rule() {
+            environment.setProperty("services.opentelemetry.payloadMasking.rules[0].path", "$.card.number");
+            environment.setProperty("services.opentelemetry.payloadMasking.rules[0].maskingStrategy.type", "PARTIAL");
+            environment.setProperty("services.opentelemetry.payloadMasking.rules[0].maskingStrategy.prefixLength", "0");
+            environment.setProperty("services.opentelemetry.payloadMasking.rules[0].maskingStrategy.suffixLength", "4");
+            environment.setProperty("services.opentelemetry.payloadMasking.rules[0].maskingStrategy.replacement", "X");
+
+            PayloadMaskingConfig config = underTest.getPayloadMaskingConfig();
+
+            assertThat(config.rules().get(0).maskingStrategy()).isInstanceOf(PartialMaskingStrategy.class);
+            PartialMaskingStrategy partial = (PartialMaskingStrategy) config.rules().get(0).maskingStrategy();
+            assertThat(partial.suffixLength()).isEqualTo(4);
+            assertThat(partial.maskChar()).isEqualTo("X");
+        }
+
+        @Test
+        void reads_multiple_rules_in_order() {
+            environment.setProperty("services.opentelemetry.payloadMasking.rules[0].path", "$.password");
+            environment.setProperty("services.opentelemetry.payloadMasking.rules[1].path", "//cvv");
+
+            PayloadMaskingConfig config = underTest.getPayloadMaskingConfig();
+
+            assertThat(config.rules()).hasSize(2);
+            assertThat(config.rules().get(0).path()).isEqualTo("$.password");
+            assertThat(config.rules().get(1).path()).isEqualTo("//cvv");
+        }
+
+        @Test
+        void result_is_cached_across_calls() {
+            environment.setProperty("services.opentelemetry.payloadMasking.rules[0].path", "$.password");
+
+            assertThat(underTest.getPayloadMaskingConfig()).isSameAs(underTest.getPayloadMaskingConfig());
         }
     }
 }

--- a/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/exporter/redact/JsonPathPayloadRedactorTest.java
+++ b/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/exporter/redact/JsonPathPayloadRedactorTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.opentelemetry.exporter.redact;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.node.api.opentelemetry.redaction.MaskingStrategy;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadFormat;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadMaskingRule;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadPhase;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class JsonPathPayloadRedactorTest {
+
+    private static final String DEFAULT_REPLACEMENT = "[REDACTED]";
+    private final JsonPathPayloadRedactor redactor = new JsonPathPayloadRedactor();
+
+    private CompiledPayloadMaskingRule compiled(String path) {
+        return new CompiledPayloadMaskingRule(new PayloadMaskingRule(path), DEFAULT_REPLACEMENT);
+    }
+
+    private CompiledPayloadMaskingRule compiled(String path, MaskingStrategy strategy) {
+        return new CompiledPayloadMaskingRule(new PayloadMaskingRule(path, strategy), DEFAULT_REPLACEMENT);
+    }
+
+    private CompiledPayloadMaskingRule compiledForPhase(String path, PayloadPhase phase) {
+        return new CompiledPayloadMaskingRule(
+            new PayloadMaskingRule(path, MaskingStrategy.DEFAULT, phase, PayloadFormat.JSON),
+            DEFAULT_REPLACEMENT
+        );
+    }
+
+    @Test
+    void should_mask_top_level_field() {
+        String json = "{\"password\":\"secret\",\"user\":\"alice\"}";
+        String result = redactor.redact(json, List.of(compiled("$.password")), PayloadPhase.REQUEST);
+        assertThat(result).contains("\"password\":\"[REDACTED]\"").contains("\"user\":\"alice\"");
+    }
+
+    @Test
+    void should_mask_nested_field() {
+        String json = "{\"card\":{\"number\":\"4111111111111111\",\"cvv\":\"123\"}}";
+        String result = redactor.redact(json, List.of(compiled("$.card.cvv")), PayloadPhase.REQUEST);
+        assertThat(result).contains("\"cvv\":\"[REDACTED]\"").contains("\"number\":\"4111111111111111\"");
+    }
+
+    @Test
+    void should_mask_all_elements_in_array() {
+        String json = "{\"items\":[{\"payment\":{\"cvv\":\"111\"}},{\"payment\":{\"cvv\":\"222\"}}]}";
+        String result = redactor.redact(json, List.of(compiled("$.items[*].payment.cvv")), PayloadPhase.REQUEST);
+        assertThat(result).doesNotContain("111").doesNotContain("222").contains("[REDACTED]");
+    }
+
+    @Test
+    void should_apply_partial_masking_strategy() {
+        String json = "{\"card\":\"4111111111111111\"}";
+        MaskingStrategy partial = MaskingStrategy.partialMask(4, 4);
+        String result = redactor.redact(json, List.of(compiled("$.card", partial)), PayloadPhase.REQUEST);
+        assertThat(result).contains("4111").contains("1111").doesNotContain("4111111111111111");
+    }
+
+    @Test
+    void should_return_original_when_path_does_not_match() {
+        String json = "{\"user\":\"alice\"}";
+        String result = redactor.redact(json, List.of(compiled("$.password")), PayloadPhase.REQUEST);
+        assertThat(result).isSameAs(json);
+    }
+
+    @Test
+    void should_return_original_when_rules_list_is_empty() {
+        String json = "{\"password\":\"secret\"}";
+        String result = redactor.redact(json, List.of(), PayloadPhase.REQUEST);
+        assertThat(result).isSameAs(json);
+    }
+
+    @Test
+    void should_return_original_on_malformed_json_fail_open() {
+        String notJson = "not-json-at-all";
+        String result = redactor.redact(notJson, List.of(compiled("$.password")), PayloadPhase.REQUEST);
+        assertThat(result).isSameAs(notJson);
+    }
+
+    @Test
+    void should_skip_rule_that_does_not_apply_to_phase() {
+        String json = "{\"password\":\"secret\"}";
+        CompiledPayloadMaskingRule requestOnlyRule = compiledForPhase("$.password", PayloadPhase.REQUEST);
+        String result = redactor.redact(json, List.of(requestOnlyRule), PayloadPhase.RESPONSE);
+        assertThat(result).isSameAs(json);
+    }
+
+    @Test
+    void should_mask_when_phase_is_both() {
+        String json = "{\"password\":\"secret\"}";
+        CompiledPayloadMaskingRule bothRule = compiledForPhase("$.password", PayloadPhase.BOTH);
+        String result = redactor.redact(json, List.of(bothRule), PayloadPhase.RESPONSE);
+        assertThat(result).contains("[REDACTED]");
+    }
+
+    @Test
+    void should_return_original_when_body_is_blank() {
+        String result = redactor.redact("   ", List.of(compiled("$.password")), PayloadPhase.REQUEST);
+        assertThat(result).isEqualTo("   ");
+    }
+}

--- a/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/exporter/redact/PayloadFieldRedactorTest.java
+++ b/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/exporter/redact/PayloadFieldRedactorTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.opentelemetry.exporter.redact;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.node.api.opentelemetry.redaction.MaskingStrategy;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadFormat;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadMaskingConfig;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadMaskingRule;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadPhase;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PayloadFieldRedactorTest {
+
+    private static PayloadFieldRedactor redactorWith(PayloadMaskingRule... rules) {
+        return new PayloadFieldRedactor(new PayloadMaskingConfig(List.of(rules)));
+    }
+
+    @Test
+    void should_use_eventFormat_JSON_hint_and_apply_jsonpath_rule() {
+        PayloadFieldRedactor redactor = redactorWith(
+            new PayloadMaskingRule("$.password", MaskingStrategy.DEFAULT, PayloadPhase.BOTH, PayloadFormat.AUTO)
+        );
+        String result = redactor.redact("{\"password\":\"secret\"}", "JSON", PayloadPhase.REQUEST);
+        assertThat(result).contains("[REDACTED]").doesNotContain("secret");
+    }
+
+    @Test
+    void should_use_eventFormat_XML_hint_and_apply_xpath_rule() {
+        PayloadFieldRedactor redactor = redactorWith(
+            new PayloadMaskingRule("//cvv", MaskingStrategy.DEFAULT, PayloadPhase.BOTH, PayloadFormat.AUTO)
+        );
+        String result = redactor.redact("<order><cvv>123</cvv></order>", "XML", PayloadPhase.REQUEST);
+        assertThat(result).contains("[REDACTED]").doesNotContain("123");
+    }
+
+    @Test
+    void should_detect_json_by_body_heuristic_when_no_event_format() {
+        PayloadFieldRedactor redactor = redactorWith(
+            new PayloadMaskingRule("$.password", MaskingStrategy.DEFAULT, PayloadPhase.BOTH, PayloadFormat.AUTO)
+        );
+        String result = redactor.redact("{\"password\":\"secret\"}", null, PayloadPhase.REQUEST);
+        assertThat(result).contains("[REDACTED]");
+    }
+
+    @Test
+    void should_detect_xml_by_body_heuristic_when_no_event_format() {
+        PayloadFieldRedactor redactor = redactorWith(
+            new PayloadMaskingRule("//cvv", MaskingStrategy.DEFAULT, PayloadPhase.BOTH, PayloadFormat.AUTO)
+        );
+        String result = redactor.redact("<order><cvv>999</cvv></order>", null, PayloadPhase.REQUEST);
+        assertThat(result).contains("[REDACTED]").doesNotContain("999");
+    }
+
+    @Test
+    void should_return_original_for_unrecognised_format() {
+        PayloadFieldRedactor redactor = redactorWith(
+            new PayloadMaskingRule("$.password", MaskingStrategy.DEFAULT, PayloadPhase.BOTH, PayloadFormat.AUTO)
+        );
+        String body = "plain text body";
+        String result = redactor.redact(body, null, PayloadPhase.REQUEST);
+        assertThat(result).isSameAs(body);
+    }
+
+    @Test
+    void should_not_mask_response_body_with_request_only_rule() {
+        PayloadFieldRedactor redactor = redactorWith(
+            new PayloadMaskingRule("$.password", MaskingStrategy.DEFAULT, PayloadPhase.REQUEST, PayloadFormat.JSON)
+        );
+        String body = "{\"password\":\"secret\"}";
+        String result = redactor.redact(body, "JSON", PayloadPhase.RESPONSE);
+        assertThat(result).contains("secret");
+    }
+
+    @Test
+    void should_mask_both_phases_with_both_rule() {
+        PayloadFieldRedactor redactor = redactorWith(
+            new PayloadMaskingRule("$.password", MaskingStrategy.DEFAULT, PayloadPhase.BOTH, PayloadFormat.JSON)
+        );
+        assertThat(redactor.redact("{\"password\":\"s\"}", "JSON", PayloadPhase.REQUEST)).contains("[REDACTED]");
+        assertThat(redactor.redact("{\"password\":\"s\"}", "JSON", PayloadPhase.RESPONSE)).contains("[REDACTED]");
+    }
+
+    @Test
+    void should_apply_json_format_rule_to_json_body() {
+        PayloadFieldRedactor redactor = redactorWith(
+            new PayloadMaskingRule("$.token", MaskingStrategy.DEFAULT, PayloadPhase.BOTH, PayloadFormat.JSON)
+        );
+        String result = redactor.redact("{\"token\":\"abc\"}", "JSON", PayloadPhase.REQUEST);
+        assertThat(result).contains("[REDACTED]");
+    }
+
+    @Test
+    void should_apply_xml_format_rule_to_xml_body() {
+        PayloadFieldRedactor redactor = redactorWith(
+            new PayloadMaskingRule("//token", MaskingStrategy.DEFAULT, PayloadPhase.BOTH, PayloadFormat.XML)
+        );
+        String result = redactor.redact("<root><token>abc</token></root>", "XML", PayloadPhase.REQUEST);
+        assertThat(result).contains("[REDACTED]");
+    }
+
+    @Test
+    void should_not_apply_xml_rule_to_json_body() {
+        PayloadFieldRedactor redactor = redactorWith(
+            new PayloadMaskingRule("//token", MaskingStrategy.DEFAULT, PayloadPhase.BOTH, PayloadFormat.XML)
+        );
+        String body = "{\"token\":\"abc\"}";
+        String result = redactor.redact(body, "JSON", PayloadPhase.REQUEST);
+        assertThat(result).contains("abc");
+    }
+
+    @Test
+    void should_return_null_unchanged() {
+        PayloadFieldRedactor redactor = redactorWith(
+            new PayloadMaskingRule("$.password", MaskingStrategy.DEFAULT, PayloadPhase.BOTH, PayloadFormat.JSON)
+        );
+        assertThat(redactor.redact(null, "JSON", PayloadPhase.REQUEST)).isNull();
+    }
+
+    @Test
+    void should_return_blank_body_unchanged() {
+        PayloadFieldRedactor redactor = redactorWith(
+            new PayloadMaskingRule("$.password", MaskingStrategy.DEFAULT, PayloadPhase.BOTH, PayloadFormat.JSON)
+        );
+        assertThat(redactor.redact("   ", "JSON", PayloadPhase.REQUEST)).isEqualTo("   ");
+    }
+
+    @Test
+    void should_return_original_when_no_rules_configured() {
+        PayloadFieldRedactor redactor = new PayloadFieldRedactor(PayloadMaskingConfig.EMPTY);
+        String body = "{\"password\":\"secret\"}";
+        assertThat(redactor.redact(body, "JSON", PayloadPhase.REQUEST)).isSameAs(body);
+    }
+}

--- a/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/exporter/redact/PayloadMaskingConfigTest.java
+++ b/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/exporter/redact/PayloadMaskingConfigTest.java
@@ -27,166 +27,160 @@ import io.gravitee.node.api.opentelemetry.redaction.RedactionRule;
 import java.util.List;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class PayloadMaskingConfigTest {
 
-    @Nested
-    class PayloadMaskingRuleTests {
+    // --- PayloadMaskingRule ---
 
-        @Test
-        void should_require_non_null_path() {
-            assertThatThrownBy(() -> new PayloadMaskingRule(null)).isInstanceOf(NullPointerException.class).hasMessageContaining("path");
-        }
-
-        @Test
-        void should_default_strategy_to_DEFAULT() {
-            var rule = new PayloadMaskingRule("$.password");
-            assertThat(rule.maskingStrategy()).isEqualTo(MaskingStrategy.DEFAULT);
-        }
-
-        @Test
-        void should_default_phase_to_BOTH() {
-            var rule = new PayloadMaskingRule("$.password");
-            assertThat(rule.phase()).isEqualTo(PayloadPhase.BOTH);
-        }
-
-        @Test
-        void should_default_format_to_AUTO() {
-            var rule = new PayloadMaskingRule("$.password");
-            assertThat(rule.format()).isEqualTo(PayloadFormat.AUTO);
-        }
-
-        @Test
-        void should_coerce_null_strategy_to_DEFAULT() {
-            var rule = new PayloadMaskingRule("$.password", null, PayloadPhase.REQUEST, PayloadFormat.JSON);
-            assertThat(rule.maskingStrategy()).isEqualTo(MaskingStrategy.DEFAULT);
-        }
-
-        @Test
-        void should_coerce_null_phase_to_BOTH() {
-            var rule = new PayloadMaskingRule("$.password", MaskingStrategy.DEFAULT, null, PayloadFormat.JSON);
-            assertThat(rule.phase()).isEqualTo(PayloadPhase.BOTH);
-        }
-
-        @Test
-        void should_coerce_null_format_to_AUTO() {
-            var rule = new PayloadMaskingRule("$.password", MaskingStrategy.DEFAULT, PayloadPhase.REQUEST, null);
-            assertThat(rule.format()).isEqualTo(PayloadFormat.AUTO);
-        }
-
-        @Test
-        void should_preserve_explicit_values() {
-            var strategy = MaskingStrategy.partialMask(2, 2);
-            var rule = new PayloadMaskingRule("//cvv", strategy, PayloadPhase.RESPONSE, PayloadFormat.XML);
-            assertThat(rule.path()).isEqualTo("//cvv");
-            assertThat(rule.maskingStrategy()).isEqualTo(strategy);
-            assertThat(rule.phase()).isEqualTo(PayloadPhase.RESPONSE);
-            assertThat(rule.format()).isEqualTo(PayloadFormat.XML);
-        }
+    @Test
+    void should_require_non_null_path() {
+        assertThatThrownBy(() -> new PayloadMaskingRule(null)).isInstanceOf(NullPointerException.class).hasMessageContaining("path");
     }
 
-    @Nested
-    class PayloadMaskingConfigTests {
-
-        @Test
-        void EMPTY_should_have_no_rules() {
-            assertThat(PayloadMaskingConfig.EMPTY.hasRules()).isFalse();
-            assertThat(PayloadMaskingConfig.EMPTY.rules()).isEmpty();
-        }
-
-        @Test
-        void EMPTY_should_use_default_replacement() {
-            assertThat(PayloadMaskingConfig.EMPTY.defaultReplacement()).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
-        }
-
-        @Test
-        void should_coerce_null_rules_to_empty_list() {
-            var config = new PayloadMaskingConfig(null);
-            assertThat(config.hasRules()).isFalse();
-        }
-
-        @Test
-        void should_coerce_null_defaultReplacement_to_default() {
-            var config = new PayloadMaskingConfig(List.of(), null);
-            assertThat(config.defaultReplacement()).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
-        }
-
-        @Test
-        void should_coerce_blank_defaultReplacement_to_default() {
-            var config = new PayloadMaskingConfig(List.of(), "   ");
-            assertThat(config.defaultReplacement()).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
-        }
-
-        @Test
-        void rules_list_should_be_immutable() {
-            var rule = new PayloadMaskingRule("$.password");
-            var config = new PayloadMaskingConfig(List.of(rule));
-            assertThatThrownBy(() -> config.rules().add(new PayloadMaskingRule("$.other")))
-                .isInstanceOf(UnsupportedOperationException.class);
-        }
+    @Test
+    void should_default_strategy_to_DEFAULT() {
+        var rule = new PayloadMaskingRule("$.password");
+        assertThat(rule.maskingStrategy()).isEqualTo(MaskingStrategy.DEFAULT);
     }
 
-    @Nested
-    class MergeWithTests {
+    @Test
+    void should_default_phase_to_BOTH() {
+        var rule = new PayloadMaskingRule("$.password");
+        assertThat(rule.phase()).isEqualTo(PayloadPhase.BOTH);
+    }
 
-        private final PayloadMaskingRule ruleA = new PayloadMaskingRule("$.password");
-        private final PayloadMaskingRule ruleB = new PayloadMaskingRule("$.creditCard");
-        private final PayloadMaskingRule ruleC = new PayloadMaskingRule(
-            "//cvv",
-            MaskingStrategy.DEFAULT,
-            PayloadPhase.REQUEST,
-            PayloadFormat.XML
-        );
+    @Test
+    void should_default_format_to_AUTO() {
+        var rule = new PayloadMaskingRule("$.password");
+        assertThat(rule.format()).isEqualTo(PayloadFormat.AUTO);
+    }
 
-        @Test
-        void should_return_this_when_other_is_null() {
-            var config = new PayloadMaskingConfig(List.of(ruleA));
-            assertThat(config.mergeWith(null)).isSameAs(config);
-        }
+    @Test
+    void should_coerce_null_strategy_to_DEFAULT() {
+        var rule = new PayloadMaskingRule("$.password", null, PayloadPhase.REQUEST, PayloadFormat.JSON);
+        assertThat(rule.maskingStrategy()).isEqualTo(MaskingStrategy.DEFAULT);
+    }
 
-        @Test
-        void should_return_this_when_other_has_no_rules() {
-            var config = new PayloadMaskingConfig(List.of(ruleA));
-            assertThat(config.mergeWith(PayloadMaskingConfig.EMPTY)).isSameAs(config);
-        }
+    @Test
+    void should_coerce_null_phase_to_BOTH() {
+        var rule = new PayloadMaskingRule("$.password", MaskingStrategy.DEFAULT, null, PayloadFormat.JSON);
+        assertThat(rule.phase()).isEqualTo(PayloadPhase.BOTH);
+    }
 
-        @Test
-        void should_return_other_when_this_has_no_rules() {
-            var other = new PayloadMaskingConfig(List.of(ruleB));
-            assertThat(PayloadMaskingConfig.EMPTY.mergeWith(other)).isSameAs(other);
-        }
+    @Test
+    void should_coerce_null_format_to_AUTO() {
+        var rule = new PayloadMaskingRule("$.password", MaskingStrategy.DEFAULT, PayloadPhase.REQUEST, null);
+        assertThat(rule.format()).isEqualTo(PayloadFormat.AUTO);
+    }
 
-        @Test
-        void should_put_global_rules_first_then_api_rules() {
-            var global = new PayloadMaskingConfig(List.of(ruleA, ruleB));
-            var perApi = new PayloadMaskingConfig(List.of(ruleC));
+    @Test
+    void should_preserve_explicit_values() {
+        var strategy = MaskingStrategy.partialMask(2, 2);
+        var rule = new PayloadMaskingRule("//cvv", strategy, PayloadPhase.RESPONSE, PayloadFormat.XML);
+        assertThat(rule.path()).isEqualTo("//cvv");
+        assertThat(rule.maskingStrategy()).isEqualTo(strategy);
+        assertThat(rule.phase()).isEqualTo(PayloadPhase.RESPONSE);
+        assertThat(rule.format()).isEqualTo(PayloadFormat.XML);
+    }
 
-            var merged = global.mergeWith(perApi);
+    // --- PayloadMaskingConfig ---
 
-            assertThat(merged.rules()).containsExactly(ruleA, ruleB, ruleC);
-        }
+    @Test
+    void EMPTY_should_have_no_rules() {
+        assertThat(PayloadMaskingConfig.EMPTY.hasRules()).isFalse();
+        assertThat(PayloadMaskingConfig.EMPTY.rules()).isEmpty();
+    }
 
-        @Test
-        void should_keep_defaultReplacement_from_this() {
-            var global = new PayloadMaskingConfig(List.of(ruleA), "***");
-            var perApi = new PayloadMaskingConfig(List.of(ruleB), "XXX");
+    @Test
+    void EMPTY_should_use_default_replacement() {
+        assertThat(PayloadMaskingConfig.EMPTY.defaultReplacement()).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+    }
 
-            var merged = global.mergeWith(perApi);
+    @Test
+    void should_coerce_null_rules_to_empty_list() {
+        var config = new PayloadMaskingConfig(null);
+        assertThat(config.hasRules()).isFalse();
+    }
 
-            assertThat(merged.defaultReplacement()).isEqualTo("***");
-        }
+    @Test
+    void should_coerce_null_defaultReplacement_to_default() {
+        var config = new PayloadMaskingConfig(List.of(), null);
+        assertThat(config.defaultReplacement()).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+    }
 
-        @Test
-        void merged_rules_list_should_be_immutable() {
-            var global = new PayloadMaskingConfig(List.of(ruleA));
-            var perApi = new PayloadMaskingConfig(List.of(ruleB));
+    @Test
+    void should_coerce_blank_defaultReplacement_to_default() {
+        var config = new PayloadMaskingConfig(List.of(), "   ");
+        assertThat(config.defaultReplacement()).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+    }
 
-            var merged = global.mergeWith(perApi);
+    @Test
+    void rules_list_should_be_immutable() {
+        var rule = new PayloadMaskingRule("$.password");
+        var config = new PayloadMaskingConfig(List.of(rule));
+        assertThatThrownBy(() -> config.rules().add(new PayloadMaskingRule("$.other"))).isInstanceOf(UnsupportedOperationException.class);
+    }
 
-            assertThatThrownBy(() -> merged.rules().add(ruleC)).isInstanceOf(UnsupportedOperationException.class);
-        }
+    // --- mergeWith ---
+
+    @Test
+    void mergeWith_should_return_this_when_other_is_null() {
+        var ruleA = new PayloadMaskingRule("$.password");
+        var config = new PayloadMaskingConfig(List.of(ruleA));
+        assertThat(config.mergeWith(null)).isSameAs(config);
+    }
+
+    @Test
+    void mergeWith_should_return_this_when_other_has_no_rules() {
+        var ruleA = new PayloadMaskingRule("$.password");
+        var config = new PayloadMaskingConfig(List.of(ruleA));
+        assertThat(config.mergeWith(PayloadMaskingConfig.EMPTY)).isSameAs(config);
+    }
+
+    @Test
+    void mergeWith_should_return_other_when_this_has_no_rules() {
+        var ruleB = new PayloadMaskingRule("$.creditCard");
+        var other = new PayloadMaskingConfig(List.of(ruleB));
+        assertThat(PayloadMaskingConfig.EMPTY.mergeWith(other)).isSameAs(other);
+    }
+
+    @Test
+    void mergeWith_should_put_global_rules_first_then_api_rules() {
+        var ruleA = new PayloadMaskingRule("$.password");
+        var ruleB = new PayloadMaskingRule("$.creditCard");
+        var ruleC = new PayloadMaskingRule("//cvv", MaskingStrategy.DEFAULT, PayloadPhase.REQUEST, PayloadFormat.XML);
+        var global = new PayloadMaskingConfig(List.of(ruleA, ruleB));
+        var perApi = new PayloadMaskingConfig(List.of(ruleC));
+
+        var merged = global.mergeWith(perApi);
+
+        assertThat(merged.rules()).containsExactly(ruleA, ruleB, ruleC);
+    }
+
+    @Test
+    void mergeWith_should_keep_defaultReplacement_from_this() {
+        var ruleA = new PayloadMaskingRule("$.password");
+        var ruleB = new PayloadMaskingRule("$.creditCard");
+        var global = new PayloadMaskingConfig(List.of(ruleA), "***");
+        var perApi = new PayloadMaskingConfig(List.of(ruleB), "XXX");
+
+        var merged = global.mergeWith(perApi);
+
+        assertThat(merged.defaultReplacement()).isEqualTo("***");
+    }
+
+    @Test
+    void mergeWith_merged_rules_list_should_be_immutable() {
+        var ruleA = new PayloadMaskingRule("$.password");
+        var ruleB = new PayloadMaskingRule("$.creditCard");
+        var ruleC = new PayloadMaskingRule("//cvv", MaskingStrategy.DEFAULT, PayloadPhase.REQUEST, PayloadFormat.XML);
+        var global = new PayloadMaskingConfig(List.of(ruleA));
+        var perApi = new PayloadMaskingConfig(List.of(ruleB));
+
+        var merged = global.mergeWith(perApi);
+
+        assertThatThrownBy(() -> merged.rules().add(ruleC)).isInstanceOf(UnsupportedOperationException.class);
     }
 }

--- a/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/exporter/redact/PayloadMaskingConfigTest.java
+++ b/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/exporter/redact/PayloadMaskingConfigTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.opentelemetry.exporter.redact;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.gravitee.node.api.opentelemetry.redaction.MaskingStrategy;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadFormat;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadMaskingConfig;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadMaskingRule;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadPhase;
+import io.gravitee.node.api.opentelemetry.redaction.RedactionRule;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PayloadMaskingConfigTest {
+
+    @Nested
+    class PayloadMaskingRuleTests {
+
+        @Test
+        void should_require_non_null_path() {
+            assertThatThrownBy(() -> new PayloadMaskingRule(null)).isInstanceOf(NullPointerException.class).hasMessageContaining("path");
+        }
+
+        @Test
+        void should_default_strategy_to_DEFAULT() {
+            var rule = new PayloadMaskingRule("$.password");
+            assertThat(rule.maskingStrategy()).isEqualTo(MaskingStrategy.DEFAULT);
+        }
+
+        @Test
+        void should_default_phase_to_BOTH() {
+            var rule = new PayloadMaskingRule("$.password");
+            assertThat(rule.phase()).isEqualTo(PayloadPhase.BOTH);
+        }
+
+        @Test
+        void should_default_format_to_AUTO() {
+            var rule = new PayloadMaskingRule("$.password");
+            assertThat(rule.format()).isEqualTo(PayloadFormat.AUTO);
+        }
+
+        @Test
+        void should_coerce_null_strategy_to_DEFAULT() {
+            var rule = new PayloadMaskingRule("$.password", null, PayloadPhase.REQUEST, PayloadFormat.JSON);
+            assertThat(rule.maskingStrategy()).isEqualTo(MaskingStrategy.DEFAULT);
+        }
+
+        @Test
+        void should_coerce_null_phase_to_BOTH() {
+            var rule = new PayloadMaskingRule("$.password", MaskingStrategy.DEFAULT, null, PayloadFormat.JSON);
+            assertThat(rule.phase()).isEqualTo(PayloadPhase.BOTH);
+        }
+
+        @Test
+        void should_coerce_null_format_to_AUTO() {
+            var rule = new PayloadMaskingRule("$.password", MaskingStrategy.DEFAULT, PayloadPhase.REQUEST, null);
+            assertThat(rule.format()).isEqualTo(PayloadFormat.AUTO);
+        }
+
+        @Test
+        void should_preserve_explicit_values() {
+            var strategy = MaskingStrategy.partialMask(2, 2);
+            var rule = new PayloadMaskingRule("//cvv", strategy, PayloadPhase.RESPONSE, PayloadFormat.XML);
+            assertThat(rule.path()).isEqualTo("//cvv");
+            assertThat(rule.maskingStrategy()).isEqualTo(strategy);
+            assertThat(rule.phase()).isEqualTo(PayloadPhase.RESPONSE);
+            assertThat(rule.format()).isEqualTo(PayloadFormat.XML);
+        }
+    }
+
+    @Nested
+    class PayloadMaskingConfigTests {
+
+        @Test
+        void EMPTY_should_have_no_rules() {
+            assertThat(PayloadMaskingConfig.EMPTY.hasRules()).isFalse();
+            assertThat(PayloadMaskingConfig.EMPTY.rules()).isEmpty();
+        }
+
+        @Test
+        void EMPTY_should_use_default_replacement() {
+            assertThat(PayloadMaskingConfig.EMPTY.defaultReplacement()).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+        }
+
+        @Test
+        void should_coerce_null_rules_to_empty_list() {
+            var config = new PayloadMaskingConfig(null);
+            assertThat(config.hasRules()).isFalse();
+        }
+
+        @Test
+        void should_coerce_null_defaultReplacement_to_default() {
+            var config = new PayloadMaskingConfig(List.of(), null);
+            assertThat(config.defaultReplacement()).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+        }
+
+        @Test
+        void should_coerce_blank_defaultReplacement_to_default() {
+            var config = new PayloadMaskingConfig(List.of(), "   ");
+            assertThat(config.defaultReplacement()).isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+        }
+
+        @Test
+        void rules_list_should_be_immutable() {
+            var rule = new PayloadMaskingRule("$.password");
+            var config = new PayloadMaskingConfig(List.of(rule));
+            assertThatThrownBy(() -> config.rules().add(new PayloadMaskingRule("$.other")))
+                .isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @Nested
+    class MergeWithTests {
+
+        private final PayloadMaskingRule ruleA = new PayloadMaskingRule("$.password");
+        private final PayloadMaskingRule ruleB = new PayloadMaskingRule("$.creditCard");
+        private final PayloadMaskingRule ruleC = new PayloadMaskingRule(
+            "//cvv",
+            MaskingStrategy.DEFAULT,
+            PayloadPhase.REQUEST,
+            PayloadFormat.XML
+        );
+
+        @Test
+        void should_return_this_when_other_is_null() {
+            var config = new PayloadMaskingConfig(List.of(ruleA));
+            assertThat(config.mergeWith(null)).isSameAs(config);
+        }
+
+        @Test
+        void should_return_this_when_other_has_no_rules() {
+            var config = new PayloadMaskingConfig(List.of(ruleA));
+            assertThat(config.mergeWith(PayloadMaskingConfig.EMPTY)).isSameAs(config);
+        }
+
+        @Test
+        void should_return_other_when_this_has_no_rules() {
+            var other = new PayloadMaskingConfig(List.of(ruleB));
+            assertThat(PayloadMaskingConfig.EMPTY.mergeWith(other)).isSameAs(other);
+        }
+
+        @Test
+        void should_put_global_rules_first_then_api_rules() {
+            var global = new PayloadMaskingConfig(List.of(ruleA, ruleB));
+            var perApi = new PayloadMaskingConfig(List.of(ruleC));
+
+            var merged = global.mergeWith(perApi);
+
+            assertThat(merged.rules()).containsExactly(ruleA, ruleB, ruleC);
+        }
+
+        @Test
+        void should_keep_defaultReplacement_from_this() {
+            var global = new PayloadMaskingConfig(List.of(ruleA), "***");
+            var perApi = new PayloadMaskingConfig(List.of(ruleB), "XXX");
+
+            var merged = global.mergeWith(perApi);
+
+            assertThat(merged.defaultReplacement()).isEqualTo("***");
+        }
+
+        @Test
+        void merged_rules_list_should_be_immutable() {
+            var global = new PayloadMaskingConfig(List.of(ruleA));
+            var perApi = new PayloadMaskingConfig(List.of(ruleB));
+
+            var merged = global.mergeWith(perApi);
+
+            assertThatThrownBy(() -> merged.rules().add(ruleC)).isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+}

--- a/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/exporter/redact/RedactSpanExporterTest.java
+++ b/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/exporter/redact/RedactSpanExporterTest.java
@@ -18,6 +18,8 @@ package io.gravitee.node.opentelemetry.exporter.redact;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.gravitee.node.api.opentelemetry.internal.InternalRequest;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadMaskingConfig;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadMaskingRule;
 import io.gravitee.node.api.opentelemetry.redaction.RedactionConfig;
 import io.gravitee.node.api.opentelemetry.redaction.RedactionRule;
 import io.gravitee.node.opentelemetry.tracer.instrumentation.internal.InternalInstrumenterTracer;
@@ -288,6 +290,96 @@ class RedactSpanExporterTest {
             assertThat(events.get(1)).isNotSameAs(sensitiveEvent);
             assertThat(events.get(1).getAttributes().get(AttributeKey.stringKey("secret.key")))
                 .isEqualTo(RedactionRule.DEFAULT_REPLACEMENT);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Payload event body masking through export()
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class PayloadEventBodyMasking {
+
+        @Test
+        void should_mask_payload_body_in_payload_span_event() {
+            AtomicReference<Collection<SpanData>> received = new AtomicReference<>();
+            var exporter = new RedactSpanExporter(
+                capturingExporter(received),
+                RedactionConfig.EMPTY,
+                new PayloadMaskingConfig(List.of(new PayloadMaskingRule("$.password")))
+            );
+
+            SpanData span = TestSpanData
+                .builder()
+                .setName("test")
+                .setKind(SpanKind.INTERNAL)
+                .setStartEpochNanos(0)
+                .setEndEpochNanos(1)
+                .setHasEnded(true)
+                .setStatus(StatusData.ok())
+                .setAttributes(Attributes.empty())
+                .setEvents(
+                    List.of(
+                        EventData.create(
+                            1L,
+                            "payload",
+                            Attributes.of(
+                                AttributeKey.stringKey("payload.body"),
+                                "{\"password\":\"secret\"}",
+                                AttributeKey.stringKey("payload.format"),
+                                "JSON",
+                                AttributeKey.stringKey("payload.phase"),
+                                "REQUEST"
+                            ),
+                            3
+                        )
+                    )
+                )
+                .build();
+
+            exporter.export(List.of(span));
+
+            var result = new ArrayList<>(received.get());
+            assertThat(result).hasSize(1);
+            String maskedBody = result.get(0).getEvents().get(0).getAttributes().get(AttributeKey.stringKey("payload.body"));
+            assertThat(maskedBody).contains("[REDACTED]").doesNotContain("secret");
+        }
+
+        @Test
+        void should_not_touch_non_payload_events_when_payload_masking_configured() {
+            AtomicReference<Collection<SpanData>> received = new AtomicReference<>();
+            var exporter = new RedactSpanExporter(
+                capturingExporter(received),
+                RedactionConfig.EMPTY,
+                new PayloadMaskingConfig(List.of(new PayloadMaskingRule("$.password")))
+            );
+
+            SpanData span = TestSpanData
+                .builder()
+                .setName("test")
+                .setKind(SpanKind.INTERNAL)
+                .setStartEpochNanos(0)
+                .setEndEpochNanos(1)
+                .setHasEnded(true)
+                .setStatus(StatusData.ok())
+                .setAttributes(Attributes.empty())
+                .setEvents(
+                    List.of(
+                        EventData.create(
+                            1L,
+                            "request-received",
+                            Attributes.of(AttributeKey.stringKey("payload.body"), "{\"password\":\"secret\"}"),
+                            1
+                        )
+                    )
+                )
+                .build();
+
+            var original = List.of(span);
+            exporter.export(original);
+
+            // non-payload event — original collection reference forwarded unchanged
+            assertThat(received.get()).isSameAs(original);
         }
     }
 

--- a/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/exporter/redact/SpanAttributeRedactorTest.java
+++ b/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/exporter/redact/SpanAttributeRedactorTest.java
@@ -20,10 +20,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.gravitee.node.api.opentelemetry.redaction.MaskingStrategy;
 import io.gravitee.node.api.opentelemetry.redaction.PartialMaskingStrategy;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadMaskingConfig;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadMaskingRule;
 import io.gravitee.node.api.opentelemetry.redaction.RedactionConfig;
 import io.gravitee.node.api.opentelemetry.redaction.RedactionRule;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.trace.data.EventData;
 import java.util.List;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -699,6 +702,102 @@ class SpanAttributeRedactorTest {
             // must not throw
             var redactor = new SpanAttributeRedactor(new RedactionConfig(List.of(rule)));
             assertThat(redactor.hasRules()).isTrue();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Contract: payload body masking via PayloadMaskingConfig
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class PayloadBodyMasking {
+
+        @Test
+        void should_mask_payload_body_in_payload_event() {
+            var config = new PayloadMaskingConfig(List.of(new PayloadMaskingRule("$.password")));
+            var redactor = new SpanAttributeRedactor(RedactionConfig.EMPTY, config);
+
+            Attributes attrs = Attributes.of(
+                AttributeKey.stringKey("payload.body"),
+                "{\"password\":\"secret\"}",
+                AttributeKey.stringKey("payload.format"),
+                "JSON",
+                AttributeKey.stringKey("payload.phase"),
+                "REQUEST"
+            );
+            EventData event = EventData.create(1L, "payload", attrs, 3);
+            List<EventData> result = redactor.redactEvents(List.of(event));
+
+            assertThat(result).hasSize(1);
+            String maskedBody = result.get(0).getAttributes().get(AttributeKey.stringKey("payload.body"));
+            assertThat(maskedBody).contains("[REDACTED]").doesNotContain("secret");
+        }
+
+        @Test
+        void should_preserve_other_payload_event_attributes_unchanged() {
+            var config = new PayloadMaskingConfig(List.of(new PayloadMaskingRule("$.password")));
+            var redactor = new SpanAttributeRedactor(RedactionConfig.EMPTY, config);
+
+            Attributes attrs = Attributes.of(
+                AttributeKey.stringKey("payload.body"),
+                "{\"password\":\"secret\"}",
+                AttributeKey.stringKey("payload.format"),
+                "JSON",
+                AttributeKey.stringKey("payload.phase"),
+                "REQUEST"
+            );
+            EventData event = EventData.create(1L, "payload", attrs, 3);
+            List<EventData> result = redactor.redactEvents(List.of(event));
+
+            assertThat(result.get(0).getAttributes().get(AttributeKey.stringKey("payload.format"))).isEqualTo("JSON");
+            assertThat(result.get(0).getAttributes().get(AttributeKey.stringKey("payload.phase"))).isEqualTo("REQUEST");
+        }
+
+        @Test
+        void should_return_original_event_list_reference_when_body_does_not_match_any_rule() {
+            var config = new PayloadMaskingConfig(List.of(new PayloadMaskingRule("$.token")));
+            var redactor = new SpanAttributeRedactor(RedactionConfig.EMPTY, config);
+
+            Attributes attrs = Attributes.of(
+                AttributeKey.stringKey("payload.body"),
+                "{\"user\":\"alice\"}",
+                AttributeKey.stringKey("payload.format"),
+                "JSON",
+                AttributeKey.stringKey("payload.phase"),
+                "REQUEST"
+            );
+            EventData event = EventData.create(1L, "payload", attrs, 3);
+            var original = List.of(event);
+            List<EventData> result = redactor.redactEvents(original);
+
+            assertThat(result).isSameAs(original);
+        }
+
+        @Test
+        void should_not_touch_non_payload_events() {
+            var config = new PayloadMaskingConfig(List.of(new PayloadMaskingRule("$.password")));
+            var redactor = new SpanAttributeRedactor(RedactionConfig.EMPTY, config);
+
+            Attributes attrs = Attributes.of(AttributeKey.stringKey("payload.body"), "{\"password\":\"secret\"}");
+            EventData event = EventData.create(1L, "request-received", attrs, 1);
+            var original = List.of(event);
+            List<EventData> result = redactor.redactEvents(original);
+
+            // event name is "request-received", not "payload" — must not be touched
+            assertThat(result).isSameAs(original);
+        }
+
+        @Test
+        void should_report_has_rules_true_when_only_payload_masking_configured() {
+            var config = new PayloadMaskingConfig(List.of(new PayloadMaskingRule("$.password")));
+            var redactor = new SpanAttributeRedactor(RedactionConfig.EMPTY, config);
+            assertThat(redactor.hasRules()).isTrue();
+        }
+
+        @Test
+        void should_report_has_rules_false_when_both_configs_are_empty() {
+            var redactor = new SpanAttributeRedactor(RedactionConfig.EMPTY, PayloadMaskingConfig.EMPTY);
+            assertThat(redactor.hasRules()).isFalse();
         }
     }
 

--- a/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/exporter/redact/XPathPayloadRedactorTest.java
+++ b/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/exporter/redact/XPathPayloadRedactorTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.opentelemetry.exporter.redact;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.node.api.opentelemetry.redaction.MaskingStrategy;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadFormat;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadMaskingRule;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadPhase;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class XPathPayloadRedactorTest {
+
+    private static final String DEFAULT_REPLACEMENT = "[REDACTED]";
+    private final XPathPayloadRedactor redactor = new XPathPayloadRedactor();
+
+    private CompiledPayloadMaskingRule compiled(String xpath) {
+        return new CompiledPayloadMaskingRule(
+            new PayloadMaskingRule(xpath, MaskingStrategy.DEFAULT, PayloadPhase.BOTH, PayloadFormat.XML),
+            DEFAULT_REPLACEMENT
+        );
+    }
+
+    private CompiledPayloadMaskingRule compiledPartial(String xpath, MaskingStrategy strategy) {
+        return new CompiledPayloadMaskingRule(
+            new PayloadMaskingRule(xpath, strategy, PayloadPhase.BOTH, PayloadFormat.XML),
+            DEFAULT_REPLACEMENT
+        );
+    }
+
+    @Test
+    void should_mask_single_element() {
+        String xml = "<order><payment><cvv>123</cvv></payment></order>";
+        String result = redactor.redact(xml, List.of(compiled("//cvv")), PayloadPhase.REQUEST);
+        assertThat(result).contains("[REDACTED]").doesNotContain("123");
+    }
+
+    @Test
+    void should_mask_repeated_elements() {
+        String xml = "<orders><order><cvv>111</cvv></order><order><cvv>222</cvv></order></orders>";
+        String result = redactor.redact(xml, List.of(compiled("//cvv")), PayloadPhase.REQUEST);
+        assertThat(result).doesNotContain("111").doesNotContain("222");
+        assertThat(result.split("\\[REDACTED\\]", -1).length - 1).isEqualTo(2);
+    }
+
+    @Test
+    void should_apply_partial_masking_strategy() {
+        String xml = "<order><card>4111111111111111</card></order>";
+        MaskingStrategy partial = MaskingStrategy.partialMask(4, 4);
+        String result = redactor.redact(xml, List.of(compiledPartial("//card", partial)), PayloadPhase.REQUEST);
+        assertThat(result).contains("4111").contains("1111").doesNotContain("4111111111111111");
+    }
+
+    @Test
+    void should_return_original_when_xpath_does_not_match() {
+        String xml = "<order><user>alice</user></order>";
+        String result = redactor.redact(xml, List.of(compiled("//cvv")), PayloadPhase.REQUEST);
+        assertThat(result).contains("alice");
+    }
+
+    @Test
+    void should_return_original_when_rules_list_is_empty() {
+        String xml = "<order><cvv>123</cvv></order>";
+        String result = redactor.redact(xml, List.of(), PayloadPhase.REQUEST);
+        assertThat(result).isSameAs(xml);
+    }
+
+    @Test
+    void should_return_original_on_malformed_xml_fail_open() {
+        String notXml = "not xml at all";
+        String result = redactor.redact(notXml, List.of(compiled("//cvv")), PayloadPhase.REQUEST);
+        assertThat(result).isSameAs(notXml);
+    }
+
+    @Test
+    void should_skip_rule_that_does_not_apply_to_phase() {
+        String xml = "<order><cvv>123</cvv></order>";
+        CompiledPayloadMaskingRule requestOnlyRule = new CompiledPayloadMaskingRule(
+            new PayloadMaskingRule("//cvv", MaskingStrategy.DEFAULT, PayloadPhase.REQUEST, PayloadFormat.XML),
+            DEFAULT_REPLACEMENT
+        );
+        String result = redactor.redact(xml, List.of(requestOnlyRule), PayloadPhase.RESPONSE);
+        assertThat(result).contains("123");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
         <hazelcast.version>5.5.0</hazelcast.version>
         <gravitee-alert-api.version>1.9.1</gravitee-alert-api.version>
         <protobuf-java.version>3.25.5</protobuf-java.version>
+        <json-path.version>2.9.0</json-path.version>
         <opentelemetry.version>1.39.0</opentelemetry.version>
         <opentelemetry-instrumentation.version>1.33.4-alpha</opentelemetry-instrumentation.version>
         <opentelemetry-semconv.version>1.23.1-alpha</opentelemetry-semconv.version>
@@ -367,6 +368,12 @@
                 <version>${smallrye-common.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+
+            <dependency>
+                <groupId>com.jayway.jsonpath</groupId>
+                <artifactId>json-path</artifactId>
+                <version>${json-path.version}</version>
             </dependency>
 
             <!-- Test -->


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-13576
https://gravitee.atlassian.net/browse/APIM-13578
https://gravitee.atlassian.net/browse/APIM-13579

**Description**

Implements OTel payload body masking for verbose tracing (APIM-13569).

  Adds the data model, masking engine, and export pipeline integration needed to redact sensitive fields from request/response bodies before they are exported to the tracing backend.

  - APIM-13576: PayloadMaskingRule/Config models (path, format, phase, strategy)
  - APIM-13578: JSONPath + XPath masking engine with AUTO format detection
  - APIM-13579: Hook into RedactSpanExporter to mask payload span event bodies before export + global rules from gravitee.yml


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `9.0.0-feat-APIM-13569-payload-masking-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/9.0.0-feat-APIM-13569-payload-masking-SNAPSHOT/gravitee-node-9.0.0-feat-APIM-13569-payload-masking-SNAPSHOT.zip)
  <!-- Version placeholder end -->
