### PR TITLE
feat(otel-logger): add Logger.record overload taking raw traceId/spanId

### DIFF
--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/Logger.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/opentelemetry/Logger.java
@@ -50,4 +50,24 @@ public interface Logger extends Service<Logger> {
      * @param attributes the attributes to attach to the Log
      */
     void record(final Context vertxContext, Span span, String body, Map<String, Object> attributes);
+
+    /**
+     * Log a body correlated with a trace by raw {@code traceId} / {@code spanId} strings. Intended for
+     * callers that receive the identifiers from elsewhere (e.g. a request header or a reporter input)
+     * and don't hold the originating {@link Span}. The implementation reconstructs a
+     * {@code SpanContext} from the two ids so the resulting log record carries them in the OTLP
+     * top-level {@code TraceId} / {@code SpanId} fields rather than as record attributes.
+     *
+     * <p>When the supplied identifiers are malformed (wrong hex length, non-hex characters, …) the
+     * record is emitted uncorrelated — same fallback as the overloads that take no span at all — so
+     * data is never silently dropped.
+     *
+     * @param vertxContext current vert context, used as fallback for tracing information when the
+     *                     supplied identifiers are invalid
+     * @param traceId 32-char lowercase-hex trace id
+     * @param spanId 16-char lowercase-hex span id
+     * @param body the body to be logged
+     * @param attributes the attributes to attach to the Log
+     */
+    void record(final Context vertxContext, String traceId, String spanId, String body, Map<String, Object> attributes);
 }

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/logger/OpenTelemetryLogger.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/logger/OpenTelemetryLogger.java
@@ -22,15 +22,20 @@ import io.gravitee.node.opentelemetry.tracer.span.OpenTelemetrySpan;
 import io.gravitee.node.opentelemetry.tracer.vertx.VertxContextStorage;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.vertx.core.Context;
 import java.util.Map;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 
 /**
  * @author Remi Baptiste (remi.baptiste at graviteesource.com)
  * @author GraviteeSource Team
  */
+@CustomLog
 @RequiredArgsConstructor
 public class OpenTelemetryLogger extends AbstractService<Logger> implements Logger {
 
@@ -65,7 +70,33 @@ public class OpenTelemetryLogger extends AbstractService<Logger> implements Logg
         if (span instanceof OpenTelemetrySpan<?> openTelemetrySpan) {
             openTelemetryContext = openTelemetrySpan.otelContext();
         }
+        emit(openTelemetryContext, body, attributes);
+    }
 
+    @Override
+    public void record(Context vertxContext, String traceId, String spanId, String body, Map<String, Object> attributes) {
+        io.opentelemetry.context.Context openTelemetryContext = VertxContextStorage.getContext(vertxContext);
+        // SpanContext.create validates the ids — invalid input returns a SpanContext where isValid() is
+        // false rather than throwing. Guard against null up front so we don't NPE inside the SDK.
+        if (traceId != null && spanId != null) {
+            // TraceFlags.getSampled(): the caller is asking us to record a log for an existing trace, so
+            //   declare it sampled — downstream collectors / tail-samplers won't drop the record on the
+            //   "not sampled" branch. TraceState.getDefault(): empty W3C vendor state; we don't have
+            //   access to the parent trace's original TraceState through this API (only the two ids).
+            SpanContext spanContext = SpanContext.create(traceId, spanId, TraceFlags.getSampled(), TraceState.getDefault());
+            if (spanContext.isValid()) {
+                io.opentelemetry.context.Context base = openTelemetryContext != null
+                    ? openTelemetryContext
+                    : io.opentelemetry.context.Context.root();
+                openTelemetryContext = base.with(io.opentelemetry.api.trace.Span.wrap(spanContext));
+            } else {
+                log.warn("Skipping trace correlation for log record: invalid traceId='{}' or spanId='{}'", traceId, spanId);
+            }
+        }
+        emit(openTelemetryContext, body, attributes);
+    }
+
+    private void emit(io.opentelemetry.context.Context openTelemetryContext, String body, Map<String, Object> attributes) {
         AttributesBuilder builder = Attributes.builder();
         if (attributes != null) {
             attributes.forEach((key, value) -> {

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/logger/noop/NoOpLogger.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/logger/noop/NoOpLogger.java
@@ -35,4 +35,7 @@ public class NoOpLogger extends AbstractService<Logger> implements Logger {
 
     @Override
     public void record(Context vertxContext, Span span, String body, Map<String, Object> attributes) {}
+
+    @Override
+    public void record(Context vertxContext, String traceId, String spanId, String body, Map<String, Object> attributes) {}
 }

--- a/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/logger/OpenTelemetryLoggerTest.java
+++ b/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/logger/OpenTelemetryLoggerTest.java
@@ -231,6 +231,48 @@ class OpenTelemetryLoggerTest {
 
         noOp.record(vertxContext, "body");
         noOp.record(vertxContext, "body", Map.of("k", "v"));
-        noOp.record(vertxContext, null, "body", Map.of("k", "v"));
+        noOp.record(vertxContext, (Span) null, "body", Map.of("k", "v"));
+        noOp.record(vertxContext, "0123456789abcdef0123456789abcdef", "0123456789abcdef", "body", Map.of("k", "v"));
+    }
+
+    @Test
+    void record_with_raw_ids_should_place_trace_and_span_id_in_top_level_fields(Vertx vertx) {
+        var vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+        String traceId = "0123456789abcdef0123456789abcdef";
+        String spanId = "0123456789abcdef";
+
+        logger.record(vertxContext, traceId, spanId, "body", Map.of("k", "v"));
+
+        List<LogRecordData> records = logExporter.getFinishedLogRecordItems();
+        assertThat(records).hasSize(1);
+        assertThat(records.get(0).getSpanContext().getTraceId()).isEqualTo(traceId);
+        assertThat(records.get(0).getSpanContext().getSpanId()).isEqualTo(spanId);
+        assertThat(records.get(0).getSpanContext().isValid()).isTrue();
+        assertThat(records.get(0).getSpanContext().isSampled()).isTrue();
+        assertThat(records.get(0).getAttributes().get(AttributeKey.stringKey("k"))).isEqualTo("v");
+    }
+
+    @Test
+    void record_with_raw_ids_should_emit_uncorrelated_when_ids_are_malformed(Vertx vertx) {
+        var vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+
+        logger.record(vertxContext, "not-a-trace-id", "not-a-span-id", "body", Map.of("k", "v"));
+
+        List<LogRecordData> records = logExporter.getFinishedLogRecordItems();
+        assertThat(records).hasSize(1);
+        assertThat(records.get(0).getBody().asString()).isEqualTo("body");
+        assertThat(records.get(0).getSpanContext().isValid()).isFalse();
+        assertThat(records.get(0).getAttributes().get(AttributeKey.stringKey("k"))).isEqualTo("v");
+    }
+
+    @Test
+    void record_with_raw_ids_should_emit_uncorrelated_when_ids_are_null(Vertx vertx) {
+        var vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+
+        logger.record(vertxContext, null, null, "body", Map.of());
+
+        List<LogRecordData> records = logExporter.getFinishedLogRecordItems();
+        assertThat(records).hasSize(1);
+        assertThat(records.get(0).getSpanContext().isValid()).isFalse();
     }
 }


### PR DESCRIPTION
**Issue**

N/A — internal enablement for the APIM gravitee-reporter-otel rewrite (gravitee-api-management side, follow-up).

**Description**

Adds a new overload on `io.gravitee.node.api.opentelemetry.Logger`:

```java
void record(Context vertxContext, String traceId, String spanId,
            String body, Map<String, Object> attributes);
```

Intended for callers that only hold the trace/span identifiers as **strings** (e.g. `gravitee-reporter-otel`, which receives them from the gateway `Request` object) and don't have access to the originating `Span`. The OTel impl reconstructs a `SpanContext` and wraps it via `Span.wrap(...)` into the `Context` passed to the SDK's `LogRecordBuilder.setContext(...)` — so the resulting OTLP `LogRecord` carries `TraceId` / `SpanId` in the **top-level fields** rather than as record attributes (which is what the OTel logs data-model spec requires for trace-to-log correlation).

Validity rules:
- `traceId` / `spanId` malformed (wrong hex length, non-hex characters, …) → record emitted **uncorrelated** (warn logged, attributes preserved). Same fallback as the no-span overloads.
- Either id null → same uncorrelated path (guarded up front to avoid an NPE inside the OTel SDK).
- Both valid → `SpanContext.create(traceId, spanId, TraceFlags.getSampled(), TraceState.getDefault())` — `getSampled()` because the caller is asking us to log against an existing trace (so downstream samplers/collectors shouldn't drop the record); `getDefault()` TraceState because this API doesn't carry the parent's vendor state and we'd rather be honest than fabricate one.

Implementation notes:
- Refactored the attribute-building + emit code in `OpenTelemetryLogger` into a private `emit(...)` helper so all three `record` overloads route through it.
- `NoOpLogger` gets the matching no-op.
- 3 new tests on `OpenTelemetryLoggerTest`: valid-ids → top-level placement (and `isSampled()` true), malformed-ids → uncorrelated + attributes preserved, null-ids → uncorrelated. NoOp test extended to exercise the new overload. Full module test suite (181 tests) passes.

**Additional context**

Producer-side bug it unblocks: today `gravitee-reporter-otel` calls `Logger.record(ctx, body, attrs)` and stuffs `trace.id` / `span.id` into `attrs` — they land at `attributes.trace.id` / `attributes.span.id` instead of OTLP top-level, breaking trace ↔ payload-log stitching on the consumer side. With this overload released, the reporter can switch to `record(ctx, traceId, spanId, body, attrs)` and the log record's trace context will be set correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `9.0.0-feat-otel-logger-raw-trace-span-id-overload-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/9.0.0-feat-otel-logger-raw-trace-span-id-overload-SNAPSHOT/gravitee-node-9.0.0-feat-otel-logger-raw-trace-span-id-overload-SNAPSHOT.zip)
  <!-- Version placeholder end -->
