### PR TITLE
fix(vertx): honor user-configured metric labels in MicrometerMetricsOptions

### DIFF
--- a/gravitee-node-opentelemetry/pom.xml
+++ b/gravitee-node-opentelemetry/pom.xml
@@ -108,11 +108,13 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
+            <version>1.21.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <version>1.21.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/VertxFactory.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/VertxFactory.java
@@ -180,7 +180,7 @@ public class VertxFactory implements FactoryBean<Vertx> {
 
         // Read labels
         this.loadMetricLabels();
-        micrometerMetricsOptions.setLabels(DEFAULT_LABELS);
+        micrometerMetricsOptions.setLabels(metricsLabels);
 
         options.setMetricsOptions(micrometerMetricsOptions);
     }
@@ -203,7 +203,7 @@ public class VertxFactory implements FactoryBean<Vertx> {
         if (labels != null && !labels.isEmpty()) {
             metricsLabels = labels.stream().map(this::toLabel).collect(Collectors.toSet());
         } else {
-            metricsLabels = DEFAULT_LABELS;
+            metricsLabels = EnumSet.copyOf(DEFAULT_LABELS);
         }
 
         // If a label is activated for a specific category, it must be added globally and then manually excluded for all other categories :-(

--- a/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/VertxFactoryTest.java
+++ b/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/VertxFactoryTest.java
@@ -51,6 +51,11 @@ import org.springframework.test.util.ReflectionTestUtils;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class VertxFactoryTest {
 
+    @SuppressWarnings("unchecked")
+    private static final Set<Label> ORIGINAL_DEFAULT_LABELS = EnumSet.copyOf(
+        (Set<Label>) ReflectionTestUtils.getField(VertxFactory.class, "DEFAULT_LABELS")
+    );
+
     @Mock
     private Node node;
 
@@ -128,6 +133,37 @@ class VertxFactoryTest {
         cut.getObject();
 
         verifyGlobalLabels(List.of(Label.LOCAL, Label.REMOTE, Label.HTTP_METHOD, Label.HTTP_CODE));
+    }
+
+    @Test
+    void should_pass_user_configured_labels_to_micrometer_options() throws Exception {
+        enableMetrics();
+        environment.setProperty("services.metrics.labels[0]", "local");
+        environment.setProperty("services.metrics.labels[1]", "remote");
+        environment.setProperty("services.metrics.labels[2]", "http_method");
+        environment.setProperty("services.metrics.labels[3]", "http_path");
+
+        cut.getObject();
+
+        verify(vertxBuilder)
+            .with(
+                argThat(options -> {
+                    final MicrometerMetricsOptions metricsOptions = (MicrometerMetricsOptions) options.getMetricsOptions();
+                    return metricsOptions.getLabels().equals(EnumSet.of(Label.LOCAL, Label.REMOTE, Label.HTTP_METHOD, Label.HTTP_PATH));
+                })
+            );
+    }
+
+    @Test
+    void should_not_mutate_DEFAULT_LABELS_when_loading_default_labels_with_include() throws Exception {
+        enableMetrics();
+        environment.setProperty("services.metrics.include.http.client[0]", "remote");
+
+        cut.getObject();
+
+        @SuppressWarnings("unchecked")
+        Set<Label> defaultLabelsField = (Set<Label>) ReflectionTestUtils.getField(VertxFactory.class, "DEFAULT_LABELS");
+        assertThat(defaultLabelsField).isEqualTo(ORIGINAL_DEFAULT_LABELS);
     }
 
     @Test


### PR DESCRIPTION
Backport of #564 to `7.26.x`.

Fixes [APIM-13559](https://gravitee.atlassian.net/browse/APIM-13559).

`VertxFactory.configureMetrics` called `loadMetricLabels()` to populate `metricsLabels` from user config, then overwrote it with `setLabels(DEFAULT_LABELS)`. Result: user-configured Prometheus labels (e.g. `http_path`) never reached Vert.x-emitted metrics like `http_server_requests_total`.

## Summary
- `setLabels(DEFAULT_LABELS)` → `setLabels(metricsLabels)` so user config wins.
- `metricsLabels = DEFAULT_LABELS` → `EnumSet.copyOf(DEFAULT_LABELS)` to stop `addAll` on the include path from mutating the static.

## Why backport
APIM 4.10.x consumes gravitee-node from the `7.26.x` line. The fix is already on `master` (released as 8.0.5) and is needed in a `7.26.x` patch so 4.10.x can pick it up without a major-version jump.

## Test plan
- [x] `mvn -pl gravitee-node-vertx test` — 117/117 pass (includes 2 new tests added in the original PR).

[APIM-13559]: https://gravitee.atlassian.net/browse/APIM-13559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.26.4-apim-13559-726x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/7.26.4-apim-13559-726x-SNAPSHOT/gravitee-node-7.26.4-apim-13559-726x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
