### PR TITLE
feat(redis): support Redis Cluster in Vert.x client factory [APIM-14146]

### DIFF
--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/redis/VertxRedisClientFactory.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/redis/VertxRedisClientFactory.java
@@ -20,6 +20,7 @@ import io.gravitee.node.vertx.client.ssl.KeyStore;
 import io.gravitee.node.vertx.client.ssl.TrustStore;
 import io.gravitee.plugin.configurations.redis.HostAndPort;
 import io.gravitee.plugin.configurations.redis.RedisClientOptions;
+import io.gravitee.plugin.configurations.redis.RedisClusterOptions;
 import io.gravitee.plugin.configurations.redis.RedisSentinelOptions;
 import io.gravitee.plugin.mappers.RedisClientOptionsMapper;
 import io.gravitee.plugin.mappers.SslOptionsMapper;
@@ -60,6 +61,7 @@ import lombok.RequiredArgsConstructor;
  *   <li>{@code username}</li>
  *   <li>{@code password} (never logged)</li>
  *   <li>sentinel {@code masterId} and sorted {@code nodes}</li>
+ *   <li>cluster {@code useReplicas} and sorted {@code nodes}</li>
  * </ul>
  *
  * <p><b>Invariant:</b> callers using the same connection tuple are assumed to use the
@@ -224,11 +226,24 @@ public class VertxRedisClientFactory {
         sb.append("|user=").append(nullSafe(options.getUsername()));
         sb.append("|pw=").append(nullSafe(options.getPassword()));
 
+        // Gate each topology on isEnabled() too — mirror the mapper's isSentinelMode/isClusterMode
+        // predicates so two configs differing only by 'enabled' (same nodes) don't share a key
+        // yet resolve to different client types.
         RedisSentinelOptions sentinel = options.getSentinel();
-        if (sentinel != null && sentinel.getNodes() != null && !sentinel.getNodes().isEmpty()) {
+        if (sentinel != null && sentinel.isEnabled() && sentinel.getNodes() != null && !sentinel.getNodes().isEmpty()) {
             sb.append("|sentinel=").append(nullSafe(sentinel.getMasterId()));
             // Sort nodes so the key is stable regardless of declaration order.
             List<HostAndPort> sortedNodes = sentinel.getNodes().stream().sorted(VertxRedisClientFactory::compareNode).toList();
+            for (HostAndPort node : sortedNodes) {
+                sb.append(',').append(node.getHost()).append(':').append(node.getPort());
+            }
+        }
+
+        RedisClusterOptions cluster = options.getCluster();
+        if (cluster != null && cluster.isEnabled() && cluster.getNodes() != null && !cluster.getNodes().isEmpty()) {
+            sb.append("|cluster=").append(nullSafe(cluster.getUseReplicas()));
+            // Sort nodes so the key is stable regardless of declaration order.
+            List<HostAndPort> sortedNodes = cluster.getNodes().stream().sorted(VertxRedisClientFactory::compareNode).toList();
             for (HostAndPort node : sortedNodes) {
                 sb.append(',').append(node.getHost()).append(':').append(node.getPort());
             }
@@ -255,6 +270,10 @@ public class VertxRedisClientFactory {
         RedisSentinelOptions sentinel = options.getSentinel();
         if (sentinel != null && sentinel.getNodes() != null && !sentinel.getNodes().isEmpty()) {
             sb.append(" sentinel=").append(sentinel.getMasterId()).append('(').append(sentinel.getNodes().size()).append(" nodes)");
+        }
+        RedisClusterOptions cluster = options.getCluster();
+        if (cluster != null && cluster.getNodes() != null && !cluster.getNodes().isEmpty()) {
+            sb.append(" cluster=(").append(cluster.getNodes().size()).append(" nodes)");
         }
         return sb.toString();
     }

--- a/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/client/redis/VertxRedisClientFactoryTest.java
+++ b/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/client/redis/VertxRedisClientFactoryTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.gravitee.plugin.configurations.redis.HostAndPort;
 import io.gravitee.plugin.configurations.redis.RedisClientOptions;
+import io.gravitee.plugin.configurations.redis.RedisClusterOptions;
 import io.gravitee.plugin.configurations.redis.RedisSentinelOptions;
 import io.gravitee.plugin.configurations.ssl.SslOptions;
 import io.gravitee.plugin.configurations.ssl.jks.JKSTrustStore;
@@ -76,6 +77,21 @@ class VertxRedisClientFactoryTest {
 
             assertThat(result.getType()).isEqualTo(RedisClientType.SENTINEL);
             assertThat(result.getMasterName()).isEqualTo("mymaster");
+        }
+
+        @Test
+        void shouldBuildClusterRedisOptions() {
+            var cluster = RedisClusterOptions
+                .builder()
+                .nodes(List.of(HostAndPort.builder().host("c1").port(6379).build(), HostAndPort.builder().host("c2").port(6379).build()))
+                .build();
+
+            var options = RedisClientOptions.builder().host("redis.local").port(6379).cluster(cluster).build();
+
+            RedisOptions result = factory.buildRedisOptions(options);
+
+            assertThat(result.getType()).isEqualTo(RedisClientType.CLUSTER);
+            assertThat(result.getEndpoints()).hasSize(2);
         }
 
         @Test
@@ -173,6 +189,51 @@ class VertxRedisClientFactoryTest {
         void shouldCreateSeparateClientsForDifferentUsername() {
             Redis c1 = factory.acquire(RedisClientOptions.builder().host("redis.local").port(6379).username("alice").build());
             Redis c2 = factory.acquire(RedisClientOptions.builder().host("redis.local").port(6379).username("bob").build());
+
+            assertThat(c1).isNotSameAs(c2);
+            assertThat(factory.sharedClientCount()).isEqualTo(2);
+        }
+
+        @Test
+        void shouldCreateSeparateClientsForDifferentClusterNodes() {
+            var clusterA = RedisClusterOptions.builder().nodes(List.of(HostAndPort.builder().host("c1").port(6379).build())).build();
+            var clusterB = RedisClusterOptions.builder().nodes(List.of(HostAndPort.builder().host("c2").port(6379).build())).build();
+
+            Redis c1 = factory.acquire(RedisClientOptions.builder().host("redis.local").port(6379).cluster(clusterA).build());
+            Redis c2 = factory.acquire(RedisClientOptions.builder().host("redis.local").port(6379).cluster(clusterB).build());
+
+            assertThat(c1).isNotSameAs(c2);
+            assertThat(factory.sharedClientCount()).isEqualTo(2);
+        }
+
+        @Test
+        void shouldShareClientForSameClusterNodesRegardlessOfOrder() {
+            var clusterA = RedisClusterOptions
+                .builder()
+                .nodes(List.of(HostAndPort.builder().host("c1").port(6379).build(), HostAndPort.builder().host("c2").port(6379).build()))
+                .build();
+            var clusterB = RedisClusterOptions
+                .builder()
+                .nodes(List.of(HostAndPort.builder().host("c2").port(6379).build(), HostAndPort.builder().host("c1").port(6379).build()))
+                .build();
+
+            Redis c1 = factory.acquire(RedisClientOptions.builder().host("redis.local").port(6379).cluster(clusterA).build());
+            Redis c2 = factory.acquire(RedisClientOptions.builder().host("redis.local").port(6379).cluster(clusterB).build());
+
+            assertThat(c1).isSameAs(c2);
+            assertThat(factory.sharedClientCount()).isEqualTo(1);
+        }
+
+        @Test
+        void shouldCreateSeparateClientsForClusterEnabledVsDisabled() {
+            var nodes = List.of(HostAndPort.builder().host("c1").port(6379).build());
+            var enabled = RedisClusterOptions.builder().enabled(true).nodes(nodes).build();
+            var disabled = RedisClusterOptions.builder().enabled(false).nodes(nodes).build();
+
+            // Same nodes but different 'enabled' resolve to different client types (CLUSTER vs STANDALONE),
+            // so they must not share a dedup key.
+            Redis c1 = factory.acquire(RedisClientOptions.builder().host("redis.local").port(6379).cluster(enabled).build());
+            Redis c2 = factory.acquire(RedisClientOptions.builder().host("redis.local").port(6379).cluster(disabled).build());
 
             assertThat(c1).isNotSameAs(c2);
             assertThat(factory.sharedClientCount()).isEqualTo(2);

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <gravitee-bom.version>9.0.0-alpha.2</gravitee-bom.version>
         <gravitee-common.version>4.6.0</gravitee-common.version>
         <gravitee-plugin.version>4.2.1</gravitee-plugin.version>
-        <gravitee-plugin-common-configurations.version>1.2.3</gravitee-plugin-common-configurations.version>
+        <gravitee-plugin-common-configurations.version>1.4.0</gravitee-plugin-common-configurations.version>
         <gravitee-reporter-api.version>2.3.0</gravitee-reporter-api.version>
         <gravitee-kubernetes.version>3.5.2</gravitee-kubernetes.version>
         <gravitee-secret-api.version>1.0.0</gravitee-secret-api.version>


### PR DESCRIPTION
## APIM-14146 — Enable Redis Cluster (2/3: node client factory)

Part of [APIM-14146](https://gravitee.atlassian.net/browse/APIM-14146).

Teaches the Vert.x Redis client factory about cluster topology. The actual `RedisClientType.CLUSTER` wiring lives in `gravitee-plugin-common-configurations` (PR 1/3); this PR adds the node-side awareness.

### Changes
- `VertxRedisClientFactory.dedupKey()` includes the cluster node set (sorted) so distinct cluster configs don't collide in the shared-client registry.
- `summary()` logs cluster node count (credentials never logged).
- SSL is untouched — the single `NetClientOptions` already applies across all endpoints.

### Tests
`VertxRedisClientFactoryTest` — cluster `buildRedisOptions` + dedup-by-cluster-nodes. Full suite green.

### Release chain
Depends on **PR 1/3** (`gravitee-plugin-common-configurations`). ⚠️ Before merge, bump `gravitee-plugin-common-configurations.version` to the version released from PR 1 (currently set to `1.3.0` for local cross-repo testing). Consumed downstream by `gravitee-api-management` (PR 3/3).


[APIM-14146]: https://gravitee.atlassian.net/browse/APIM-14146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `9.0.0-wba-APIM-14146-redis-cluster-client-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/9.0.0-wba-APIM-14146-redis-cluster-client-SNAPSHOT/gravitee-node-9.0.0-wba-APIM-14146-redis-cluster-client-SNAPSHOT.zip)
  <!-- Version placeholder end -->
