### PR TITLE
feat(license): add Azure Key Vault secret provider to enterprise pack

### DIFF
--- a/gravitee-node-license/src/main/resources/license-model.yml
+++ b/gravitee-node-license/src/main/resources/license-model.yml
@@ -101,6 +101,7 @@ packs:
         features:
             - gravitee-en-secretprovider-vault
             - gravitee-en-secretprovider-aws
+            - gravitee-en-secretprovider-azure-keyvault
             - gravitee-en-secrets
             - am-certificate-aws
             - am-certificate-aws-cloudhsm

--- a/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
+++ b/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
@@ -54,13 +54,13 @@ class DefaultLicenseFactoryTest {
     }
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         mockedStaticLicense3j = mockStatic(License3J.class);
         mockedStaticLicense3j.when(License3J::publicKey).thenReturn(keyPair.getPublic());
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         mockedStaticLicense3j.close();
     }
 
@@ -448,6 +448,7 @@ class DefaultLicenseFactoryTest {
             "apim-en-endpoint-agent-to-agent",
             "am-authenticator-cba",
             "am-authenticator-magic-link",
+            "gravitee-en-secretprovider-azure-keyvault",
         };
         assertThat(license.getFeatures()).containsExactlyInAnyOrder(features);
 


### PR DESCRIPTION
Add gravitee-en-secretprovider-azure-keyvault to the enterprise license model.

**Issue**

[APIM-9649](https://gravitee.atlassian.net/browse/APIM-9649)

**Description**

Add Azure KeyVault support for 4.11.x

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->



[APIM-9649]: https://gravitee.atlassian.net/browse/APIM-9649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `8.0.6-APIM-9649-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/8.0.6-APIM-9649-SNAPSHOT/gravitee-node-8.0.6-APIM-9649-SNAPSHOT.zip)
  <!-- Version placeholder end -->
