### PR TITLE
fix(deps): bump hazelcast version - alpha

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <gravitee-kubernetes.version>3.5.2</gravitee-kubernetes.version>
         <gravitee-secret-api.version>1.0.0</gravitee-secret-api.version>
         <snakeyaml.version>2.0</snakeyaml.version>
-        <hazelcast.version>5.5.0</hazelcast.version>
+        <hazelcast.version>5.7.0</hazelcast.version>
         <gravitee-alert-api.version>1.9.1</gravitee-alert-api.version>
         <protobuf-java.version>3.25.5</protobuf-java.version>
         <opentelemetry.version>1.39.0</opentelemetry.version>


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-13243

## Description
Fixes GHSA-72hv-8253-57qq: jackson-core was bundled in `gravitee-node-cluster-plugin-hazelcast` ZIP via hazelcast's internal shaded jackson.

Changes (pom.xml only, no breaking changes):
- Upgrade `hazelcast.version` from `5.5.0` → `5.7.0` (hazelcast 5.5.0 bundles jackson-core 2.17.2 which is vulnerable; 5.7.0 does not)
- Add `hazelcast-releases` Maven repository (required for hazelcast >= 5.6)

## Grype evidence
Before fix: `gravitee-node-cluster-plugin-hazelcast-9.0.0-alpha.17.zip` reported GHSA-72hv-8253-57qq (via `lib/hazelcast-5.5.0.jar`)
After fix: 0 matches

## Notes
- Previous PRs #557 and #560 fixed the `master` branch (8.x line) — this PR fixes the `alpha` branch where `9.0.0-alpha.17` was produced
- Version bumped from `9.0.0-alpha.17` → `9.0.0-alpha.18`
- Same hazelcast upgrade approach as the master-branch fix

Made with [Cursor](https://cursor.com)
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `9.0.0-fix-apim-13243-alpha-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/9.0.0-fix-apim-13243-alpha-SNAPSHOT/gravitee-node-9.0.0-fix-apim-13243-alpha-SNAPSHOT.zip)
  <!-- Version placeholder end -->
