### PR TITLE
feat: filter reporter dispatch by ReportTarget

### DIFF
--- a/gravitee-node-reporter/pom.xml
+++ b/gravitee-node-reporter/pom.xml
@@ -63,5 +63,22 @@
             <artifactId>spring-context</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/gravitee-node-reporter/src/main/java/io/gravitee/node/reporter/vertx/eventbus/EventBusReporterWrapper.java
+++ b/gravitee-node-reporter/src/main/java/io/gravitee/node/reporter/vertx/eventbus/EventBusReporterWrapper.java
@@ -16,13 +16,14 @@
 package io.gravitee.node.reporter.vertx.eventbus;
 
 import io.gravitee.common.component.Lifecycle;
+import io.gravitee.reporter.api.ReportTarget;
 import io.gravitee.reporter.api.Reportable;
 import io.gravitee.reporter.api.Reporter;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.Message;
+import java.util.Collections;
+import java.util.Set;
 import lombok.CustomLog;
 
 /**
@@ -75,8 +76,27 @@ public class EventBusReporterWrapper implements Reporter, Handler<Message<Report
     @Override
     public void handle(Message<Reportable> reportableMsg) {
         Reportable reportable = reportableMsg.body();
-        if (reporter.canHandle(reportable)) {
+        if (reporter.canHandle(reportable) && hasMatchingTarget(reportable)) {
             reporter.report(reportable);
         }
+    }
+
+    /**
+     * Checks whether the reporter's supported targets intersect with the reportable's
+     * intended targets. A reportable is only dispatched to a reporter when at least one
+     * target is shared between both sets.
+     *
+     * <p>Both sides default to {@link ReportTarget#ALL} for backward compatibility, so
+     * existing reporters and reportables that do not declare explicit targets continue
+     * to match unconditionally.
+     */
+    private boolean hasMatchingTarget(Reportable reportable) {
+        Set<ReportTarget> reportableTargets = reportable.getTargets();
+        Set<ReportTarget> reporterTargets = reporter.supportedTargets();
+        // Null or empty targets = legacy reportable/reporter with no explicit routing → dispatch unconditionally.
+        if (reportableTargets == null || reportableTargets.isEmpty() || reporterTargets == null || reporterTargets.isEmpty()) {
+            return true;
+        }
+        return !Collections.disjoint(reportableTargets, reporterTargets);
     }
 }

--- a/gravitee-node-reporter/src/test/java/io/gravitee/node/reporter/vertx/eventbus/EventBusReporterWrapperTest.java
+++ b/gravitee-node-reporter/src/test/java/io/gravitee/node/reporter/vertx/eventbus/EventBusReporterWrapperTest.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.reporter.vertx.eventbus;
+
+import static org.mockito.Mockito.*;
+
+import io.gravitee.reporter.api.ReportTarget;
+import io.gravitee.reporter.api.Reportable;
+import io.gravitee.reporter.api.Reporter;
+import io.vertx.core.eventbus.Message;
+import java.util.EnumSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EventBusReporterWrapperTest {
+
+    @Mock
+    private Reporter reporter;
+
+    @Mock
+    private Message<Reportable> message;
+
+    @Mock
+    private Reportable reportable;
+
+    private EventBusReporterWrapper wrapper;
+
+    @BeforeEach
+    void setUp() {
+        wrapper = new EventBusReporterWrapper(null, reporter);
+    }
+
+    @Nested
+    class TargetFiltering {
+
+        @Test
+        void should_dispatch_when_targets_match() {
+            when(message.body()).thenReturn(reportable);
+            when(reporter.canHandle(reportable)).thenReturn(true);
+            when(reportable.getTargets()).thenReturn(EnumSet.of(ReportTarget.TRACING));
+            when(reporter.supportedTargets()).thenReturn(EnumSet.of(ReportTarget.TRACING));
+
+            wrapper.handle(message);
+
+            verify(reporter).report(reportable);
+        }
+
+        @Test
+        void should_not_dispatch_when_targets_are_disjoint() {
+            when(message.body()).thenReturn(reportable);
+            when(reporter.canHandle(reportable)).thenReturn(true);
+            when(reportable.getTargets()).thenReturn(EnumSet.of(ReportTarget.TRACING));
+            when(reporter.supportedTargets()).thenReturn(EnumSet.of(ReportTarget.ANALYTICS));
+
+            wrapper.handle(message);
+
+            verify(reporter, never()).report(reportable);
+        }
+
+        @Test
+        void should_dispatch_when_reportable_targets_both_and_reporter_supports_analytics() {
+            when(message.body()).thenReturn(reportable);
+            when(reporter.canHandle(reportable)).thenReturn(true);
+            when(reportable.getTargets()).thenReturn(EnumSet.of(ReportTarget.ANALYTICS, ReportTarget.TRACING));
+            when(reporter.supportedTargets()).thenReturn(EnumSet.of(ReportTarget.ANALYTICS));
+
+            wrapper.handle(message);
+
+            verify(reporter).report(reportable);
+        }
+
+        @Test
+        void should_dispatch_when_both_use_defaults() {
+            when(message.body()).thenReturn(reportable);
+            when(reporter.canHandle(reportable)).thenReturn(true);
+            when(reportable.getTargets()).thenReturn(ReportTarget.DEFAULT);
+            when(reporter.supportedTargets()).thenReturn(ReportTarget.DEFAULT);
+
+            wrapper.handle(message);
+
+            verify(reporter).report(reportable);
+        }
+
+        @Test
+        void should_not_dispatch_tracing_log_to_default_analytics_reporter() {
+            when(message.body()).thenReturn(reportable);
+            when(reporter.canHandle(reportable)).thenReturn(true);
+            when(reportable.getTargets()).thenReturn(EnumSet.of(ReportTarget.TRACING));
+            when(reporter.supportedTargets()).thenReturn(ReportTarget.DEFAULT);
+
+            wrapper.handle(message);
+
+            verify(reporter, never()).report(reportable);
+        }
+
+        @Test
+        void should_not_dispatch_when_can_handle_is_false() {
+            when(message.body()).thenReturn(reportable);
+            when(reporter.canHandle(reportable)).thenReturn(false);
+
+            wrapper.handle(message);
+
+            verify(reporter, never()).report(reportable);
+        }
+
+        @Test
+        void should_dispatch_when_reportable_targets_is_null() {
+            when(message.body()).thenReturn(reportable);
+            when(reporter.canHandle(reportable)).thenReturn(true);
+            when(reportable.getTargets()).thenReturn(null);
+            when(reporter.supportedTargets()).thenReturn(EnumSet.of(ReportTarget.ANALYTICS));
+
+            wrapper.handle(message);
+
+            verify(reporter).report(reportable);
+        }
+
+        @Test
+        void should_dispatch_when_reporter_supported_targets_is_null() {
+            when(message.body()).thenReturn(reportable);
+            when(reporter.canHandle(reportable)).thenReturn(true);
+            when(reportable.getTargets()).thenReturn(EnumSet.of(ReportTarget.TRACING));
+            when(reporter.supportedTargets()).thenReturn(null);
+
+            wrapper.handle(message);
+
+            verify(reporter).report(reportable);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <gravitee-common.version>4.6.0</gravitee-common.version>
         <gravitee-plugin.version>4.2.1</gravitee-plugin.version>
         <gravitee-plugin-common-configurations.version>1.4.0</gravitee-plugin-common-configurations.version>
-        <gravitee-reporter-api.version>2.3.0</gravitee-reporter-api.version>
+        <gravitee-reporter-api.version>2.5.0</gravitee-reporter-api.version>
         <gravitee-kubernetes.version>3.5.2</gravitee-kubernetes.version>
         <gravitee-secret-api.version>1.0.0</gravitee-secret-api.version>
         <snakeyaml.version>2.0</snakeyaml.version>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-14388

**Description**

- `EventBusReporterWrapper.handle()` checks target intersection via `Collections.disjoint()`
- `canHandle()` evaluated first (short-circuit), then target match
- Add test deps (junit, assertj, mockito) to gravitee-node-reporter

**Additional context**

Part of the OTel Logs dual reporting fix. The dispatch layer now only forwards a Reportable to reporters whose supported targets intersect with the reportable's intended targets. 
*Both sides default to ALL for backward compatibility.

**Depends on**: **_gravitee-reporter-api_** release with `ReportTarget` enum.

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `9.0.0-fix-APIM-14388-report-target-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/9.0.0-fix-APIM-14388-report-target-SNAPSHOT/gravitee-node-9.0.0-fix-APIM-14388-report-target-SNAPSHOT.zip)
  <!-- Version placeholder end -->
