### PR TITLE
fix(tracing): correct SERVER span kind for gateway entry span

### DIFF
--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/tracer/instrumentation/AbstractInstrumenterTracer.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/tracer/instrumentation/AbstractInstrumenterTracer.java
@@ -38,19 +38,13 @@ public abstract class AbstractInstrumenterTracer<REQ, RESP> extends AbstractServ
 
     @Override
     public <R> Span startSpan(final Context vertxContext, final R request, final boolean root, final Span parentSpan) {
-        io.opentelemetry.context.Context parentContext;
-        if (parentSpan instanceof OpenTelemetrySpan<?> openTelemetryParentSpan) {
-            parentContext = openTelemetryParentSpan.otelContext();
-        } else {
-            parentContext = VertxContextStorage.getContext(vertxContext);
-            if (parentContext == null) {
-                parentContext = io.opentelemetry.context.Context.current();
-            }
-        }
-        Instrumenter<REQ, RESP> instrumenter;
-        if (parentContext.equals(io.opentelemetry.context.Context.root())) {
+        final io.opentelemetry.context.Context parentContext;
+        final Instrumenter<REQ, RESP> instrumenter;
+        if (root) {
+            parentContext = io.opentelemetry.context.Context.root();
             instrumenter = getRootInstrumenter();
         } else {
+            parentContext = resolveParentContext(vertxContext, parentSpan);
             instrumenter = getDefaultInstrumenter();
         }
 
@@ -59,11 +53,18 @@ public abstract class AbstractInstrumenterTracer<REQ, RESP> extends AbstractServ
             Scope scope = VertxContextStorage.INSTANCE.attach(vertxContext, otelContext);
             return new OpenTelemetrySpan<>(vertxContext, otelContext, scope, root, request);
         }
-        if (root) {
-            return NoOpSpan.asRoot();
-        } else {
-            return NoOpSpan.asDefault();
+        return root ? NoOpSpan.asRoot() : NoOpSpan.asDefault();
+    }
+
+    private static io.opentelemetry.context.Context resolveParentContext(final Context vertxContext, final Span parentSpan) {
+        if (parentSpan instanceof OpenTelemetrySpan<?> openTelemetryParentSpan) {
+            return openTelemetryParentSpan.otelContext();
         }
+        io.opentelemetry.context.Context parentContext = VertxContextStorage.getContext(vertxContext);
+        if (parentContext == null) {
+            parentContext = io.opentelemetry.context.Context.current();
+        }
+        return parentContext;
     }
 
     @Override

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/tracer/instrumentation/vertx/VertxHttpInstrumenterTracer.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/tracer/instrumentation/vertx/VertxHttpInstrumenterTracer.java
@@ -18,6 +18,7 @@ package io.gravitee.node.opentelemetry.tracer.instrumentation.vertx;
 import io.gravitee.node.api.opentelemetry.Span;
 import io.gravitee.node.api.opentelemetry.http.ObservableHttpRequest;
 import io.gravitee.node.api.opentelemetry.http.ObservableHttpResponse;
+import io.gravitee.node.api.opentelemetry.http.ObservableHttpServerRequest;
 import io.gravitee.node.opentelemetry.tracer.instrumentation.AbstractInstrumenterTracer;
 import io.gravitee.node.opentelemetry.tracer.instrumentation.vertx.extractor.AdditionalServerAttributesExtractor;
 import io.gravitee.node.opentelemetry.tracer.instrumentation.vertx.extractor.ClientSpanNameExtractor;
@@ -82,7 +83,11 @@ public class VertxHttpInstrumenterTracer extends AbstractInstrumenterTracer<Obse
 
     @Override
     public <R> void endSpan(final Context vertxContext, final Span span, final R response, final Throwable throwable) {
-        if (span instanceof OpenTelemetrySpan<?> requestSpan && response instanceof ObservableHttpResponse observableHttpResponse) {
+        if (
+            span instanceof OpenTelemetrySpan<?> requestSpan &&
+            requestSpan.request() instanceof ObservableHttpServerRequest &&
+            response instanceof ObservableHttpResponse observableHttpResponse
+        ) {
             HttpServerRoute.update(
                 requestSpan.otelContext(),
                 HttpServerRouteSource.SERVER_FILTER,

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/tracer/instrumentation/vertx/extractor/RouteGetter.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/tracer/instrumentation/vertx/extractor/RouteGetter.java
@@ -3,9 +3,7 @@ package io.gravitee.node.opentelemetry.tracer.instrumentation.vertx.extractor;
 import io.gravitee.node.api.opentelemetry.http.ObservableHttpRequest;
 import io.gravitee.node.api.opentelemetry.http.ObservableHttpResponse;
 import io.gravitee.node.opentelemetry.tracer.span.OpenTelemetrySpan;
-import io.netty.handler.codec.http.HttpResponseStatus;
 import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerRouteBiGetter;
-import io.vertx.core.spi.observability.HttpResponse;
 
 /**
  * See <a href="https://github.com/quarkusio/quarkus/blob/main/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/tracing/intrumentation/vertx/HttpInstrumenterVertxTracer.java#L428">HttpInstrumenterVertxTracer.java</a>

--- a/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/tracer/instrumentation/vertx/VertxHttpInstrumenterTracerTest.java
+++ b/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/tracer/instrumentation/vertx/VertxHttpInstrumenterTracerTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.opentelemetry.tracer.instrumentation.vertx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.node.api.opentelemetry.Span;
+import io.gravitee.node.api.opentelemetry.http.ObservableHttpClientRequest;
+import io.gravitee.node.api.opentelemetry.http.ObservableHttpClientResponse;
+import io.gravitee.node.api.opentelemetry.http.ObservableHttpServerRequest;
+import io.gravitee.node.api.opentelemetry.http.ObservableHttpServerResponse;
+import io.gravitee.node.opentelemetry.tracer.vertx.VertxContextStorage;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.smallrye.common.vertx.VertxContext;
+import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.http.RequestOptions;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.junit5.VertxExtension;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(VertxExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class VertxHttpInstrumenterTracerTest {
+
+    private InMemorySpanExporter spanExporter;
+    private VertxHttpInstrumenterTracer tracer;
+    private OpenTelemetrySdk openTelemetry;
+
+    @BeforeEach
+    void setUp() {
+        spanExporter = InMemorySpanExporter.create();
+        SdkTracerProvider tracerProvider = SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)).build();
+        openTelemetry = OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).build();
+        tracer = new VertxHttpInstrumenterTracer(openTelemetry);
+    }
+
+    @Test
+    void should_start_root_span_with_server_kind_when_vertx_context_has_non_root_otel_context(Vertx vertx) {
+        var vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+        var otelTracer = openTelemetry.getTracer("test");
+        var existingSpan = otelTracer.spanBuilder("existing").setSpanKind(SpanKind.SERVER).startSpan();
+
+        try (var ignored = VertxContextStorage.INSTANCE.attach(vertxContext, Context.root().with(existingSpan))) {
+            HttpServerRequest serverRequest = mockServerRequest(HttpMethod.POST, "/test");
+            HttpServerResponse serverResponse = mockServerResponse(200);
+
+            Span rootSpan = tracer.startSpan(vertxContext, new ObservableHttpServerRequest(serverRequest), true, null);
+            tracer.endSpan(vertxContext, rootSpan, new ObservableHttpServerResponse(serverResponse), null);
+        } finally {
+            existingSpan.end();
+        }
+
+        List<SpanData> spans = spanExporter.getFinishedSpanItems();
+        SpanData serverSpan = spans.stream().filter(span -> span.getKind() == SpanKind.SERVER).findFirst().orElseThrow();
+        assertThat(serverSpan.getName()).isEqualTo("POST /test");
+        assertThat(serverSpan.getParentSpanContext().isValid()).isFalse();
+    }
+
+    @Test
+    void should_keep_server_span_name_when_client_span_ends(Vertx vertx) {
+        var vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
+
+        HttpServerRequest serverRequest = mockServerRequest(HttpMethod.POST, "/test");
+        HttpServerResponse serverResponse = mockServerResponse(200);
+
+        Span rootSpan = tracer.startSpan(vertxContext, new ObservableHttpServerRequest(serverRequest), true, null);
+
+        RequestOptions clientOptions = new RequestOptions()
+            .setMethod(HttpMethod.POST)
+            .setURI("/endpoint")
+            .setHost("localhost")
+            .setPort(8080)
+            .setServer(SocketAddress.inetSocketAddress(8080, "localhost"));
+        Span clientSpan = tracer.startSpan(vertxContext, new ObservableHttpClientRequest(clientOptions), false, rootSpan);
+
+        HttpClientResponse clientResponse = mock(HttpClientResponse.class);
+        when(clientResponse.statusCode()).thenReturn(200);
+        when(clientResponse.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
+
+        tracer.endSpan(vertxContext, clientSpan, new ObservableHttpClientResponse(clientResponse), null);
+        tracer.endSpan(vertxContext, rootSpan, new ObservableHttpServerResponse(serverResponse), null);
+
+        List<SpanData> spans = spanExporter.getFinishedSpanItems();
+        assertThat(spans).hasSize(2);
+
+        SpanData serverSpan = spans.stream().filter(span -> span.getKind() == SpanKind.SERVER).findFirst().orElseThrow();
+        SpanData backendSpan = spans.stream().filter(span -> span.getKind() == SpanKind.CLIENT).findFirst().orElseThrow();
+
+        assertThat(serverSpan.getName()).isEqualTo("POST /test");
+        assertThat(backendSpan.getName()).isNotEqualTo("POST /test");
+        assertThat(backendSpan.getParentSpanId()).isEqualTo(serverSpan.getSpanId());
+    }
+
+    private static HttpServerRequest mockServerRequest(HttpMethod method, String uri) {
+        HttpServerRequest serverRequest = mock(HttpServerRequest.class);
+        when(serverRequest.method()).thenReturn(method);
+        when(serverRequest.uri()).thenReturn(uri);
+        when(serverRequest.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
+        when(serverRequest.scheme()).thenReturn("http");
+        when(serverRequest.remoteAddress()).thenReturn(SocketAddress.inetSocketAddress(12345, "127.0.0.1"));
+        return serverRequest;
+    }
+
+    private static HttpServerResponse mockServerResponse(int statusCode) {
+        HttpServerResponse serverResponse = mock(HttpServerResponse.class);
+        when(serverResponse.getStatusCode()).thenReturn(statusCode);
+        when(serverResponse.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
+        return serverResponse;
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-12354

**Description**

Gateway HTTP entry spans were recorded as CLIENT instead of SERVER, and client span teardown could overwrite the entry span name with the backend URI.

- Honor `root=true` with `Context.root()` and the server instrumenter
- Resolve parent context from Vert.x storage only for non-root spans
- Guard `HttpServerRoute.update` to server spans in `endSpan`
- Add `VertxHttpInstrumenterTracerTest`

**Additional context**

Regression coverage verified: new tests FAIL on the base branch (entry span recorded as CLIENT / entry span name overwritten by backend URI) and PASS on this branch.

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `8.0.7-apim-12354-master-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/8.0.7-apim-12354-master-SNAPSHOT/gravitee-node-8.0.7-apim-12354-master-SNAPSHOT.zip)
  <!-- Version placeholder end -->
