### PR TITLE
feat(monitoring): add probe for gpu device monitoring

### DIFF
--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/monitor/GpuInfo.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/monitor/GpuInfo.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.api.monitor;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * @author GraviteeSource Team
+ */
+public record GpuInfo(long timestamp, List<Device> devices) implements Serializable {
+    public record Device(
+        int index,
+        String name,
+        String uuid,
+        String driverVersion,
+        short utilizationPercent,
+        short memoryUtilizationPercent,
+        Mem mem,
+        short temperature,
+        double powerWatts
+    )
+        implements Serializable {
+        /** Convenience constructor for providers that only report device identity. */
+        public Device(int index, String name, Mem mem) {
+            this(index, name, null, null, (short) -1, (short) -1, mem, (short) -1, -1d);
+        }
+    }
+
+    public record Mem(long total, long free) implements Serializable {
+        public long getUsed() {
+            return total < 0 || free < 0 ? -1 : total - free;
+        }
+
+        public short getUsedPercent() {
+            return calculatePercentage(getUsed(), total);
+        }
+
+        public short getFreePercent() {
+            return calculatePercentage(free, total);
+        }
+
+        private static short calculatePercentage(long used, long max) {
+            return max <= 0 ? 0 : (short) (Math.round((100d * used) / max));
+        }
+    }
+}

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/monitor/GpuInfo.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/monitor/GpuInfo.java
@@ -46,11 +46,12 @@ public record GpuInfo(long timestamp, List<Device> devices) implements Serializa
         }
 
         public short getUsedPercent() {
-            return calculatePercentage(getUsed(), total);
+            long used = getUsed();
+            return used < 0 || total <= 0 ? -1 : calculatePercentage(used, total);
         }
 
         public short getFreePercent() {
-            return calculatePercentage(free, total);
+            return free < 0 || total <= 0 ? -1 : calculatePercentage(free, total);
         }
 
         private static short calculatePercentage(long used, long max) {

--- a/gravitee-node-api/src/main/java/io/gravitee/node/api/monitor/Monitor.java
+++ b/gravitee-node-api/src/main/java/io/gravitee/node/api/monitor/Monitor.java
@@ -32,6 +32,7 @@ public class Monitor implements Serializable, Reportable {
     JvmInfo jvm;
     OsInfo os;
     ProcessInfo process;
+    GpuInfo gpu;
 
     protected Monitor() {}
 
@@ -57,6 +58,10 @@ public class Monitor implements Serializable, Reportable {
         return process;
     }
 
+    public GpuInfo getGpu() {
+        return gpu;
+    }
+
     public long getTimestamp() {
         return timestamp;
     }
@@ -76,6 +81,7 @@ public class Monitor implements Serializable, Reportable {
         private OsInfo os;
         private JvmInfo jvm;
         private ProcessInfo process;
+        private GpuInfo gpu;
 
         public Builder on(String nodeId) {
             this.nodeId = nodeId;
@@ -102,11 +108,17 @@ public class Monitor implements Serializable, Reportable {
             return this;
         }
 
+        public Builder gpu(GpuInfo gpu) {
+            this.gpu = gpu;
+            return this;
+        }
+
         public Monitor build() {
             Monitor metrics = new Monitor(nodeId, timestamp);
             metrics.os = os;
             metrics.jvm = jvm;
             metrics.process = process;
+            metrics.gpu = gpu;
             return metrics;
         }
     }

--- a/gravitee-node-monitoring/pom.xml
+++ b/gravitee-node-monitoring/pom.xml
@@ -71,6 +71,11 @@
             <artifactId>spring-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/eventbus/GpuInfoCodec.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/eventbus/GpuInfoCodec.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.monitoring.eventbus;
+
+import io.gravitee.node.api.monitor.GpuInfo;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class GpuInfoCodec extends AbstractCodec<GpuInfo> {
+
+    public static final String CODEC_NAME = "gio:bus:codec:node_gpu";
+
+    public GpuInfoCodec() {
+        super(CODEC_NAME);
+    }
+}

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/NodeGpuMonitorService.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/NodeGpuMonitorService.java
@@ -57,10 +57,15 @@ public class NodeGpuMonitorService extends AbstractService<NodeGpuMonitorService
         }
         super.doStart();
 
+        try {
+            vertx.eventBus().registerCodec(new GpuInfoCodec());
+        } catch (IllegalStateException e) {
+            // Codec already registered (e.g. on service restart), ignore.
+        }
+
         producer =
             vertx
                 .eventBus()
-                .registerCodec(new GpuInfoCodec())
                 .sender(
                     GIO_NODE_GPU_BUS,
                     new DeliveryOptions().setTracingPolicy(TracingPolicy.IGNORE).setCodecName(GpuInfoCodec.CODEC_NAME)

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/NodeGpuMonitorService.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/NodeGpuMonitorService.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.monitoring.monitor;
+
+import io.gravitee.common.service.AbstractService;
+import io.gravitee.node.api.monitor.GpuInfo;
+import io.gravitee.node.monitoring.eventbus.GpuInfoCodec;
+import io.gravitee.node.monitoring.monitor.probe.GpuProbe;
+import io.gravitee.node.monitoring.spring.GpuConfiguration;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.DeliveryOptions;
+import io.vertx.core.eventbus.MessageProducer;
+import io.vertx.core.tracing.TracingPolicy;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Producer of the GPU producer/consumer pipeline: a scheduled thread collects the GPU snapshot
+ * (via {@link GpuProbe}) once per monitoring interval and publishes it on the event bus. Consumers
+ * ({@code GpuMonitorEventHandler}, ultimately the Micrometer gauges and the node monitor) read it
+ * from there, so the GPU is probed a single time per interval. This mirrors {@code NodeMonitorService}
+ * producing {@code Monitor} objects on {@code gio:node:monitor}.
+ *
+ * @author GraviteeSource Team
+ */
+@CustomLog
+@RequiredArgsConstructor
+public class NodeGpuMonitorService extends AbstractService<NodeGpuMonitorService> {
+
+    public static final String GIO_NODE_GPU_BUS = "gio:node:gpu";
+
+    private final Vertx vertx;
+    private final GpuConfiguration gpuConfiguration;
+
+    private MessageProducer<GpuInfo> producer;
+    private ScheduledExecutorService executorService;
+
+    @Override
+    protected void doStart() throws Exception {
+        if (!gpuConfiguration.enabled()) {
+            return;
+        }
+        super.doStart();
+
+        producer =
+            vertx
+                .eventBus()
+                .registerCodec(new GpuInfoCodec())
+                .sender(
+                    GIO_NODE_GPU_BUS,
+                    new DeliveryOptions().setTracingPolicy(TracingPolicy.IGNORE).setCodecName(GpuInfoCodec.CODEC_NAME)
+                );
+
+        executorService = Executors.newSingleThreadScheduledExecutor(r -> new Thread(r, "node-gpu-monitor"));
+        executorService.scheduleWithFixedDelay(this::collectAndPublish, 0, gpuConfiguration.delay(), gpuConfiguration.unit());
+
+        log.info("Node GPU monitoring scheduled with fixed delay {} {} ", gpuConfiguration.delay(), gpuConfiguration.unit().name());
+    }
+
+    private void collectAndPublish() {
+        try {
+            producer.write(GpuProbe.getInstance().gpuInfo());
+        } catch (Exception e) {
+            log.warn("Unable to collect and publish GPU metrics", e);
+        }
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        if (executorService != null && !executorService.isShutdown()) {
+            log.info("Stop node GPU monitor");
+            executorService.shutdownNow();
+        }
+        super.doStop();
+
+        if (producer != null) {
+            producer.close();
+        }
+    }
+
+    @Override
+    protected String name() {
+        return "Node GPU Monitor Service";
+    }
+}

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/NodeMonitorManagementEndpoint.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/NodeMonitorManagementEndpoint.java
@@ -24,6 +24,7 @@ import io.gravitee.common.http.HttpMethod;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.node.management.http.endpoint.ManagementEndpoint;
+import io.gravitee.node.monitoring.monitor.gpu.GpuSnapshotRegistry;
 import io.gravitee.node.monitoring.monitor.probe.JvmProbe;
 import io.gravitee.node.monitoring.monitor.probe.OsProbe;
 import io.gravitee.node.monitoring.monitor.probe.ProcessProbe;
@@ -41,6 +42,7 @@ import lombok.RequiredArgsConstructor;
 public class NodeMonitorManagementEndpoint implements ManagementEndpoint {
 
     private final ObjectMapper mapper;
+    private final GpuSnapshotRegistry gpuSnapshotRegistry;
 
     @Override
     public HttpMethod method() {
@@ -61,10 +63,12 @@ public class NodeMonitorManagementEndpoint implements ManagementEndpoint {
             JsonNode os = mapper.valueToTree(OsProbe.getInstance().osInfo());
             JsonNode jvm = mapper.valueToTree(JvmProbe.getInstance().jvmInfo());
             JsonNode process = mapper.valueToTree(ProcessProbe.getInstance().processInfo());
+            JsonNode gpu = mapper.valueToTree(gpuSnapshotRegistry.current());
 
             root.set("os", os);
             root.set("jvm", jvm);
             root.set("process", process);
+            root.set("gpu", gpu);
 
             response.putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
             response.setChunked(true);

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/NodeMonitorService.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/NodeMonitorService.java
@@ -23,6 +23,7 @@ import io.gravitee.node.api.Node;
 import io.gravitee.node.api.monitor.Monitor;
 import io.gravitee.node.management.http.endpoint.ManagementEndpointManager;
 import io.gravitee.node.monitoring.eventbus.MonitorCodec;
+import io.gravitee.node.monitoring.monitor.gpu.GpuSnapshotRegistry;
 import io.gravitee.node.monitoring.spring.MonitoringConfiguration;
 import io.gravitee.plugin.alert.AlertEventProducer;
 import io.vertx.core.Vertx;
@@ -52,6 +53,7 @@ public class NodeMonitorService extends AbstractService<NodeMonitorService> {
     private final Node node;
     private final Vertx vertx;
     private final MonitoringConfiguration monitoringConfiguration;
+    private final GpuSnapshotRegistry gpuSnapshotRegistry;
 
     private MessageProducer<Monitor> producer;
     private ExecutorService executorService;
@@ -72,7 +74,7 @@ public class NodeMonitorService extends AbstractService<NodeMonitorService> {
                         new DeliveryOptions().setTracingPolicy(TracingPolicy.IGNORE).setCodecName(MonitorCodec.CODEC_NAME)
                     );
 
-            NodeMonitorThread monitorThread = new NodeMonitorThread(producer, node, alertEventProducer);
+            NodeMonitorThread monitorThread = new NodeMonitorThread(producer, node, alertEventProducer, gpuSnapshotRegistry);
 
             // Send an event to notify about the node status
             alertEventProducer.send(

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/NodeMonitorThread.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/NodeMonitorThread.java
@@ -20,10 +20,12 @@ import static io.gravitee.node.monitoring.MonitoringConstants.*;
 import io.gravitee.alert.api.event.DefaultEvent;
 import io.gravitee.alert.api.event.Event;
 import io.gravitee.node.api.Node;
+import io.gravitee.node.api.monitor.GpuInfo;
 import io.gravitee.node.api.monitor.JvmInfo;
 import io.gravitee.node.api.monitor.Monitor;
 import io.gravitee.node.api.monitor.OsInfo;
 import io.gravitee.node.api.monitor.ProcessInfo;
+import io.gravitee.node.monitoring.monitor.gpu.GpuSnapshotRegistry;
 import io.gravitee.node.monitoring.monitor.probe.JvmProbe;
 import io.gravitee.node.monitoring.monitor.probe.OsProbe;
 import io.gravitee.node.monitoring.monitor.probe.ProcessProbe;
@@ -44,6 +46,7 @@ public class NodeMonitorThread implements Runnable {
     private final MessageProducer<Monitor> producer;
     private final Node node;
     private final AlertEventProducer alertEventProducer;
+    private final GpuSnapshotRegistry gpuSnapshotRegistry;
 
     @Override
     public void run() {
@@ -54,6 +57,7 @@ public class NodeMonitorThread implements Runnable {
                 .os(OsProbe.getInstance().osInfo())
                 .jvm(JvmProbe.getInstance().jvmInfo())
                 .process(ProcessProbe.getInstance().processInfo())
+                .gpu(gpuSnapshotRegistry.current())
                 .build();
 
             // And generate monitoring metrics
@@ -93,6 +97,21 @@ public class NodeMonitorThread implements Runnable {
                 event.property("jvm.mem.heap.used", jvmInfo.mem.heapUsed);
                 event.property("jvm.mem.heap.max", jvmInfo.mem.heapMax);
                 event.property("jvm.mem.heap.percent", jvmInfo.mem.getHeapUsedPercent());
+
+                // GPU metrics
+                GpuInfo gpuInfo = monitor.getGpu();
+                if (gpuInfo != null && gpuInfo.devices() != null && !gpuInfo.devices().isEmpty()) {
+                    event.property("gpu.count", gpuInfo.devices().size());
+                    for (GpuInfo.Device device : gpuInfo.devices()) {
+                        String prefix = "gpu." + device.index() + ".";
+                        event.property(prefix + "util.percent", device.utilizationPercent());
+                        event.property(prefix + "mem.percent", device.mem().getUsedPercent());
+                        event.property(prefix + "mem.used", device.mem().getUsed());
+                        event.property(prefix + "mem.total", device.mem().total());
+                        event.property(prefix + "temperature", device.temperature());
+                        event.property(prefix + "power", device.powerWatts());
+                    }
+                }
 
                 alertEventProducer.send(event.build());
             }

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/NodeMonitorThread.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/NodeMonitorThread.java
@@ -99,26 +99,30 @@ public class NodeMonitorThread implements Runnable {
                 event.property("jvm.mem.heap.percent", jvmInfo.mem.getHeapUsedPercent());
 
                 // GPU metrics
-                GpuInfo gpuInfo = monitor.getGpu();
-                if (gpuInfo != null && gpuInfo.devices() != null && !gpuInfo.devices().isEmpty()) {
-                    event.property("gpu.count", gpuInfo.devices().size());
-                    for (GpuInfo.Device device : gpuInfo.devices()) {
-                        String prefix = "gpu." + device.index() + ".";
-                        event.property(prefix + "util.percent", device.utilizationPercent());
-                        if (device.mem() != null) {
-                            event.property(prefix + "mem.percent", device.mem().getUsedPercent());
-                            event.property(prefix + "mem.used", device.mem().getUsed());
-                            event.property(prefix + "mem.total", device.mem().total());
-                        }
-                        event.property(prefix + "temperature", device.temperature());
-                        event.property(prefix + "power", device.powerWatts());
-                    }
-                }
+                appendGpuProperties(event, monitor.getGpu());
 
                 alertEventProducer.send(event.build());
             }
         } catch (Exception ex) {
             log.error("Unexpected error occurs while monitoring the node", ex);
+        }
+    }
+
+    private static void appendGpuProperties(DefaultEvent.Builder event, GpuInfo gpuInfo) {
+        if (gpuInfo == null || gpuInfo.devices() == null || gpuInfo.devices().isEmpty()) {
+            return;
+        }
+        event.property("gpu.count", gpuInfo.devices().size());
+        for (GpuInfo.Device device : gpuInfo.devices()) {
+            String prefix = "gpu." + device.index() + ".";
+            event.property(prefix + "util.percent", device.utilizationPercent());
+            if (device.mem() != null) {
+                event.property(prefix + "mem.percent", device.mem().getUsedPercent());
+                event.property(prefix + "mem.used", device.mem().getUsed());
+                event.property(prefix + "mem.total", device.mem().total());
+            }
+            event.property(prefix + "temperature", device.temperature());
+            event.property(prefix + "power", device.powerWatts());
         }
     }
 }

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/NodeMonitorThread.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/NodeMonitorThread.java
@@ -105,9 +105,11 @@ public class NodeMonitorThread implements Runnable {
                     for (GpuInfo.Device device : gpuInfo.devices()) {
                         String prefix = "gpu." + device.index() + ".";
                         event.property(prefix + "util.percent", device.utilizationPercent());
-                        event.property(prefix + "mem.percent", device.mem().getUsedPercent());
-                        event.property(prefix + "mem.used", device.mem().getUsed());
-                        event.property(prefix + "mem.total", device.mem().total());
+                        if (device.mem() != null) {
+                            event.property(prefix + "mem.percent", device.mem().getUsedPercent());
+                            event.property(prefix + "mem.used", device.mem().getUsed());
+                            event.property(prefix + "mem.total", device.mem().total());
+                        }
                         event.property(prefix + "temperature", device.temperature());
                         event.property(prefix + "power", device.powerWatts());
                     }

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/gpu/GpuMetricsProvider.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/gpu/GpuMetricsProvider.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.monitoring.monitor.gpu;
+
+import io.gravitee.node.api.monitor.GpuInfo;
+import java.util.List;
+
+/**
+ * SPI for collecting GPU metrics from a given vendor/back-end (e.g. NVIDIA via
+ * {@code nvidia-smi}, ...). Implementations must be cheap to probe
+ * for availability and must never throw from {@link #readDevices()}.
+ *
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface GpuMetricsProvider {
+    /**
+     * @return a short name identifying the provider (e.g. {@code "nvidia-smi"}).
+     */
+    String name();
+
+    /**
+     * @return {@code true} if this provider can collect metrics on the current host.
+     */
+    boolean isAvailable();
+
+    /**
+     * Collects one {@link GpuInfo.Device} per detected device.
+     *
+     * @return the list of devices, never {@code null}; an empty list when nothing could be read.
+     */
+    List<GpuInfo.Device> readDevices();
+}

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/gpu/GpuMonitorEventHandler.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/gpu/GpuMonitorEventHandler.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.monitoring.monitor.gpu;
+
+import io.gravitee.common.service.AbstractService;
+import io.gravitee.node.api.monitor.GpuInfo;
+import io.gravitee.node.monitoring.monitor.NodeGpuMonitorService;
+import io.gravitee.node.monitoring.monitor.micrometer.GpuMicrometerHandler;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.MessageConsumer;
+import io.vertx.micrometer.backends.BackendRegistries;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Consumer of the GPU producer/consumer pipeline. It listens to the GPU snapshots published by
+ * {@link NodeGpuMonitorService} on the event bus, updates the shared {@link GpuSnapshotRegistry}
+ * (read by the node monitor, the {@code /monitor} endpoint and the Micrometer gauges), and binds the
+ * {@link GpuMicrometerHandler} to the registry once devices are discovered.
+ *
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@CustomLog
+@RequiredArgsConstructor
+public class GpuMonitorEventHandler extends AbstractService<GpuMonitorEventHandler> {
+
+    private final Vertx vertx;
+    private final GpuSnapshotRegistry registry;
+
+    private MessageConsumer<GpuInfo> consumer;
+    private boolean micrometerBound;
+
+    @Override
+    protected void doStart() throws Exception {
+        super.doStart();
+
+        consumer =
+            vertx
+                .eventBus()
+                .localConsumer(
+                    NodeGpuMonitorService.GIO_NODE_GPU_BUS,
+                    event -> {
+                        GpuInfo info = event.body();
+                        registry.update(info);
+                        bindMicrometer(info);
+                    }
+                );
+    }
+
+    private void bindMicrometer(GpuInfo info) {
+        if (micrometerBound || info == null || info.devices() == null || info.devices().isEmpty()) {
+            return;
+        }
+        MeterRegistry meterRegistry = BackendRegistries.getDefaultNow();
+        if (meterRegistry == null) {
+            log.warn("Metrics registry is not available, GPU metrics will not be exposed (services.metrics.enabled=true)");
+            return;
+        }
+        // Gauges read the live snapshot from the registry; bind once, devices are stable.
+        new GpuMicrometerHandler(registry::current).bindTo(meterRegistry);
+        micrometerBound = true;
+        log.info("GPU metrics bound to Micrometer for {} device(s)", info.devices().size());
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        super.doStop();
+        if (consumer != null) {
+            consumer.unregister();
+        }
+    }
+
+    @Override
+    protected String name() {
+        return "Node GPU Monitor Event Handler";
+    }
+}

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/gpu/GpuSnapshotRegistry.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/gpu/GpuSnapshotRegistry.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.monitoring.monitor.gpu;
+
+import io.gravitee.node.api.monitor.GpuInfo;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Shared read-model holding the latest GPU snapshot produced by {@code NodeGpuMonitorService} and
+ * updated by {@code GpuMonitorEventHandler}. It is read by all GPU consumers (the node monitor, the
+ * {@code /monitor} endpoint and the Micrometer gauges) so the GPU is collected only once per interval.
+ *
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class GpuSnapshotRegistry {
+
+    private final AtomicReference<GpuInfo> snapshot = new AtomicReference<>(new GpuInfo(0L, List.of()));
+
+    public void update(GpuInfo info) {
+        if (info != null) {
+            snapshot.set(info);
+        }
+    }
+
+    public GpuInfo current() {
+        return snapshot.get();
+    }
+}

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/gpu/NvidiaSmiGpuMetricsProvider.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/gpu/NvidiaSmiGpuMetricsProvider.java
@@ -81,18 +81,19 @@ public class NvidiaSmiGpuMetricsProvider implements GpuMetricsProvider {
 
     private boolean probeAvailability() {
         try {
-            Process process = new ProcessBuilder(command, "--version").redirectErrorStream(true).start();
-            // drain output to avoid blocking, then wait
-            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
-                while (reader.readLine() != null) {
-                    // discard
-                }
-            }
+            Process process = new ProcessBuilder(command, "--version")
+                .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                .redirectError(ProcessBuilder.Redirect.DISCARD)
+                .start();
             if (!process.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
                 process.destroyForcibly();
                 return false;
             }
             return process.exitValue() == 0;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.debug("Interrupted while probing nvidia-smi availability", e);
+            return false;
         } catch (Exception e) {
             log.debug("nvidia-smi is not available", e);
             return false;
@@ -128,6 +129,10 @@ public class NvidiaSmiGpuMetricsProvider implements GpuMetricsProvider {
             }
 
             return parse(output);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.debug("Interrupted while reading GPU metrics from nvidia-smi", e);
+            return new ArrayList<>();
         } catch (Exception e) {
             log.debug("Unable to read GPU metrics from nvidia-smi", e);
             return new ArrayList<>();
@@ -144,30 +149,39 @@ public class NvidiaSmiGpuMetricsProvider implements GpuMetricsProvider {
             return devices;
         }
         for (String rawLine : output.split("\\R")) {
-            String line = rawLine.trim();
-            if (line.isEmpty()) {
-                continue;
+            GpuInfo.Device device = parseLine(rawLine.trim());
+            if (device != null) {
+                devices.add(device);
             }
-            String[] fields = line.split("\\s*,\\s*");
-            if (fields.length < 10) {
-                log.debug("Skipping unexpected nvidia-smi line: {}", line);
-                continue;
-            }
-            GpuInfo.Mem mem = new GpuInfo.Mem(toBytes(parseLong(fields[6], -1)), toBytes(parseLong(fields[7], -1)));
-            GpuInfo.Device device = new GpuInfo.Device(
-                (int) parseLong(fields[0], -1),
-                parseString(fields[1]),
-                parseString(fields[2]),
-                parseString(fields[3]),
-                (short) parseLong(fields[4], -1),
-                (short) parseLong(fields[5], -1),
-                mem,
-                (short) parseLong(fields[8], -1),
-                parseDouble(fields[9])
-            );
-            devices.add(device);
         }
         return devices;
+    }
+
+    /**
+     * Parses a single {@code nvidia-smi} CSV line into a device, or {@code null} when the line is
+     * blank or does not have the expected number of fields.
+     */
+    private GpuInfo.Device parseLine(String line) {
+        if (line.isEmpty()) {
+            return null;
+        }
+        String[] fields = line.split(",");
+        if (fields.length < 10) {
+            log.debug("Skipping unexpected nvidia-smi line: {}", line);
+            return null;
+        }
+        GpuInfo.Mem mem = new GpuInfo.Mem(toBytes(parseLong(fields[6], -1)), toBytes(parseLong(fields[7], -1)));
+        return new GpuInfo.Device(
+            (int) parseLong(fields[0], -1),
+            parseString(fields[1]),
+            parseString(fields[2]),
+            parseString(fields[3]),
+            (short) parseLong(fields[4], -1),
+            (short) parseLong(fields[5], -1),
+            mem,
+            (short) parseLong(fields[8], -1),
+            parseDouble(fields[9])
+        );
     }
 
     private static long toBytes(long mib) {
@@ -175,11 +189,15 @@ public class NvidiaSmiGpuMetricsProvider implements GpuMetricsProvider {
     }
 
     private static boolean isNotAvailable(String value) {
-        return value == null || value.isEmpty() || value.equalsIgnoreCase("[N/A]") || value.equalsIgnoreCase("N/A");
+        if (value == null) {
+            return true;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() || trimmed.equalsIgnoreCase("[N/A]") || trimmed.equalsIgnoreCase("N/A");
     }
 
     private static String parseString(String value) {
-        return isNotAvailable(value) ? null : value;
+        return isNotAvailable(value) ? null : value.trim();
     }
 
     private static long parseLong(String value, long defaultValue) {

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/gpu/NvidiaSmiGpuMetricsProvider.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/gpu/NvidiaSmiGpuMetricsProvider.java
@@ -88,7 +88,11 @@ public class NvidiaSmiGpuMetricsProvider implements GpuMetricsProvider {
                     // discard
                 }
             }
-            return process.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS) && process.exitValue() == 0;
+            if (!process.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                process.destroyForcibly();
+                return false;
+            }
+            return process.exitValue() == 0;
         } catch (Exception e) {
             log.debug("nvidia-smi is not available", e);
             return false;
@@ -99,8 +103,19 @@ public class NvidiaSmiGpuMetricsProvider implements GpuMetricsProvider {
     public List<GpuInfo.Device> readDevices() {
         try {
             Process process = new ProcessBuilder(command, "--query-gpu=" + QUERY, "--format=csv,noheader,nounits")
-                .redirectErrorStream(false)
+                .redirectError(ProcessBuilder.Redirect.DISCARD)
                 .start();
+
+            // nvidia-smi output is small, so wait for completion first to avoid blocking on a hung read.
+            if (!process.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                process.destroyForcibly();
+                log.debug("nvidia-smi timed out");
+                return new ArrayList<>();
+            }
+            if (process.exitValue() != 0) {
+                log.debug("nvidia-smi exited with code {}", process.exitValue());
+                return new ArrayList<>();
+            }
 
             String output;
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
@@ -112,15 +127,6 @@ public class NvidiaSmiGpuMetricsProvider implements GpuMetricsProvider {
                 output = sb.toString();
             }
 
-            if (!process.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-                process.destroyForcibly();
-                log.debug("nvidia-smi timed out");
-                return new ArrayList<>();
-            }
-            if (process.exitValue() != 0) {
-                log.debug("nvidia-smi exited with code {}", process.exitValue());
-                return new ArrayList<>();
-            }
             return parse(output);
         } catch (Exception e) {
             log.debug("Unable to read GPU metrics from nvidia-smi", e);

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/gpu/NvidiaSmiGpuMetricsProvider.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/gpu/NvidiaSmiGpuMetricsProvider.java
@@ -1,0 +1,200 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.monitoring.monitor.gpu;
+
+import io.gravitee.node.api.monitor.GpuInfo;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import lombok.CustomLog;
+
+/**
+ * {@link GpuMetricsProvider} backed by the NVIDIA {@code nvidia-smi} command line
+ * tool. It shells out and parses the CSV output, mirroring the defensive,
+ * dependency-free style used by {@code OsProbe} and {@code GcPressureProbe}.
+ *
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@CustomLog
+public class NvidiaSmiGpuMetricsProvider implements GpuMetricsProvider {
+
+    static final String PROVIDER_NAME = "nvidia-smi";
+
+    private static final long TIMEOUT_SECONDS = 5;
+
+    /** The metrics queried, in order. Keep aligned with {@link #parse(String)}. */
+    private static final String QUERY =
+        "index,name,uuid,driver_version,utilization.gpu,utilization.memory,memory.total,memory.free,temperature.gpu,power.draw";
+
+    private static final long MIB_TO_BYTES = 1024L * 1024L;
+
+    /** The command used to invoke nvidia-smi. Overridable for testing. */
+    private final String command;
+
+    /** Memoized availability: GPU presence is static for the node's lifetime, so probe it only once. */
+    private volatile Boolean available;
+
+    public NvidiaSmiGpuMetricsProvider() {
+        this(PROVIDER_NAME);
+    }
+
+    NvidiaSmiGpuMetricsProvider(String command) {
+        this.command = command;
+    }
+
+    @Override
+    public String name() {
+        return PROVIDER_NAME;
+    }
+
+    @Override
+    public boolean isAvailable() {
+        Boolean result = available;
+        if (result == null) {
+            synchronized (this) {
+                result = available;
+                if (result == null) {
+                    result = probeAvailability();
+                    available = result;
+                }
+            }
+        }
+        return result;
+    }
+
+    private boolean probeAvailability() {
+        try {
+            Process process = new ProcessBuilder(command, "--version").redirectErrorStream(true).start();
+            // drain output to avoid blocking, then wait
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+                while (reader.readLine() != null) {
+                    // discard
+                }
+            }
+            return process.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS) && process.exitValue() == 0;
+        } catch (Exception e) {
+            log.debug("nvidia-smi is not available", e);
+            return false;
+        }
+    }
+
+    @Override
+    public List<GpuInfo.Device> readDevices() {
+        try {
+            Process process = new ProcessBuilder(command, "--query-gpu=" + QUERY, "--format=csv,noheader,nounits")
+                .redirectErrorStream(false)
+                .start();
+
+            String output;
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+                StringBuilder sb = new StringBuilder();
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    sb.append(line).append('\n');
+                }
+                output = sb.toString();
+            }
+
+            if (!process.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                process.destroyForcibly();
+                log.debug("nvidia-smi timed out");
+                return new ArrayList<>();
+            }
+            if (process.exitValue() != 0) {
+                log.debug("nvidia-smi exited with code {}", process.exitValue());
+                return new ArrayList<>();
+            }
+            return parse(output);
+        } catch (Exception e) {
+            log.debug("Unable to read GPU metrics from nvidia-smi", e);
+            return new ArrayList<>();
+        }
+    }
+
+    /**
+     * Parses the raw {@code nvidia-smi --format=csv,noheader,nounits} output into a list of devices.
+     * Fields reported as {@code [N/A]} (or unparseable) are left at their default value.
+     */
+    List<GpuInfo.Device> parse(String output) {
+        List<GpuInfo.Device> devices = new ArrayList<>();
+        if (output == null) {
+            return devices;
+        }
+        for (String rawLine : output.split("\\R")) {
+            String line = rawLine.trim();
+            if (line.isEmpty()) {
+                continue;
+            }
+            String[] fields = line.split("\\s*,\\s*");
+            if (fields.length < 10) {
+                log.debug("Skipping unexpected nvidia-smi line: {}", line);
+                continue;
+            }
+            GpuInfo.Mem mem = new GpuInfo.Mem(toBytes(parseLong(fields[6], -1)), toBytes(parseLong(fields[7], -1)));
+            GpuInfo.Device device = new GpuInfo.Device(
+                (int) parseLong(fields[0], -1),
+                parseString(fields[1]),
+                parseString(fields[2]),
+                parseString(fields[3]),
+                (short) parseLong(fields[4], -1),
+                (short) parseLong(fields[5], -1),
+                mem,
+                (short) parseLong(fields[8], -1),
+                parseDouble(fields[9])
+            );
+            devices.add(device);
+        }
+        return devices;
+    }
+
+    private static long toBytes(long mib) {
+        return mib < 0 ? -1 : mib * MIB_TO_BYTES;
+    }
+
+    private static boolean isNotAvailable(String value) {
+        return value == null || value.isEmpty() || value.equalsIgnoreCase("[N/A]") || value.equalsIgnoreCase("N/A");
+    }
+
+    private static String parseString(String value) {
+        return isNotAvailable(value) ? null : value;
+    }
+
+    private static long parseLong(String value, long defaultValue) {
+        if (isNotAvailable(value)) {
+            return defaultValue;
+        }
+        try {
+            return Long.parseLong(value.trim());
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
+    private static double parseDouble(String value) {
+        if (isNotAvailable(value)) {
+            return -1;
+        }
+        try {
+            return Double.parseDouble(value.trim());
+        } catch (NumberFormatException e) {
+            return -1;
+        }
+    }
+}

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/micrometer/GpuMicrometerHandler.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/micrometer/GpuMicrometerHandler.java
@@ -58,8 +58,8 @@ public class GpuMicrometerHandler implements MeterBinder {
 
             register(registry, "gpu.utilization", "percent", tags, device.index(), GpuInfo.Device::utilizationPercent);
             register(registry, "gpu.memory.utilization", "percent", tags, device.index(), GpuInfo.Device::memoryUtilizationPercent);
-            register(registry, "gpu.memory.used", "bytes", tags, device.index(), d -> d.mem().getUsed());
-            register(registry, "gpu.memory.total", "bytes", tags, device.index(), d -> d.mem().total());
+            register(registry, "gpu.memory.used", "bytes", tags, device.index(), d -> d.mem() == null ? -1 : d.mem().getUsed());
+            register(registry, "gpu.memory.total", "bytes", tags, device.index(), d -> d.mem() == null ? -1 : d.mem().total());
             register(registry, "gpu.temperature", "celsius", tags, device.index(), GpuInfo.Device::temperature);
             register(registry, "gpu.power", "watts", tags, device.index(), GpuInfo.Device::powerWatts);
         }

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/micrometer/GpuMicrometerHandler.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/micrometer/GpuMicrometerHandler.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.monitoring.monitor.micrometer;
+
+import io.gravitee.node.api.monitor.GpuInfo;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import java.util.function.Supplier;
+import java.util.function.ToDoubleFunction;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * Binds GPU metrics to a Micrometer registry, the same way
+ * {@code NodeHealthCheckMicrometerHandler} binds health probes. Gauges are
+ * registered once per device discovered at bind time and read their value from
+ * the latest snapshot supplied by {@link #snapshotSupplier}, which is refreshed
+ * periodically by {@code NodeGpuMetricsService}.
+ *
+ * @author GraviteeSource Team
+ */
+@CustomLog
+@RequiredArgsConstructor
+public class GpuMicrometerHandler implements MeterBinder {
+
+    private final Supplier<GpuInfo> snapshotSupplier;
+
+    @Override
+    public void bindTo(@NonNull MeterRegistry registry) {
+        GpuInfo snapshot = snapshotSupplier.get();
+        if (snapshot == null || snapshot.devices() == null) {
+            return;
+        }
+        for (GpuInfo.Device device : snapshot.devices()) {
+            Tags tags = Tags.of("gpu", String.valueOf(device.index()));
+            if (device.name() != null) {
+                tags = tags.and("name", device.name());
+            }
+            if (device.uuid() != null) {
+                tags = tags.and("uuid", device.uuid());
+            }
+
+            register(registry, "gpu.utilization", "percent", tags, device.index(), GpuInfo.Device::utilizationPercent);
+            register(registry, "gpu.memory.utilization", "percent", tags, device.index(), GpuInfo.Device::memoryUtilizationPercent);
+            register(registry, "gpu.memory.used", "bytes", tags, device.index(), d -> d.mem().getUsed());
+            register(registry, "gpu.memory.total", "bytes", tags, device.index(), d -> d.mem().total());
+            register(registry, "gpu.temperature", "celsius", tags, device.index(), GpuInfo.Device::temperature);
+            register(registry, "gpu.power", "watts", tags, device.index(), GpuInfo.Device::powerWatts);
+        }
+    }
+
+    /**
+     * Registers a gauge for the given metric, but only when the device currently exposes it
+     * ({@code value >= 0}). This avoids publishing constant {@code -1} series for metrics a
+     * provider cannot collect (e.g. a provider that only reports device identity and VRAM).
+     */
+    private void register(
+        MeterRegistry registry,
+        String name,
+        String unit,
+        Tags tags,
+        int index,
+        ToDoubleFunction<GpuInfo.Device> accessor
+    ) {
+        if (deviceValue(index, accessor) < 0) {
+            return;
+        }
+        Gauge
+            .builder(name, snapshotSupplier, supplier -> deviceValue(index, accessor))
+            .tags(tags)
+            .baseUnit(unit)
+            .description("GPU metrics of the node")
+            .register(registry);
+    }
+
+    private double deviceValue(int index, ToDoubleFunction<GpuInfo.Device> accessor) {
+        GpuInfo snapshot = snapshotSupplier.get();
+        if (snapshot == null || snapshot.devices() == null) {
+            return Double.NaN;
+        }
+        return snapshot.devices().stream().filter(d -> d.index() == index).findFirst().map(accessor::applyAsDouble).orElse(Double.NaN);
+    }
+}

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/probe/GpuProbe.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/monitor/probe/GpuProbe.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.monitoring.monitor.probe;
+
+import io.gravitee.node.api.monitor.GpuInfo;
+import io.gravitee.node.monitoring.monitor.gpu.GpuMetricsProvider;
+import io.gravitee.node.monitoring.monitor.gpu.NvidiaSmiGpuMetricsProvider;
+import java.util.List;
+import lombok.CustomLog;
+
+/**
+ * Aggregates GPU metrics across the available {@link GpuMetricsProvider}s. Follows
+ * the holder-singleton pattern used by {@code OsProbe}, {@code JvmProbe} and
+ * {@code ProcessProbe}. When no provider can collect metrics, {@link #gpuInfo()}
+ * returns a {@link GpuInfo} with an empty device list (never throws).
+ *
+ * @author GraviteeSource Team
+ */
+@CustomLog
+public class GpuProbe {
+
+    private final List<GpuMetricsProvider> providers;
+
+    private GpuProbe() {
+        this(List.of(new NvidiaSmiGpuMetricsProvider()));
+    }
+
+    GpuProbe(List<GpuMetricsProvider> providers) {
+        this.providers = providers;
+    }
+
+    private static class GpuProbeHolder {
+
+        private static final GpuProbe INSTANCE = new GpuProbe();
+    }
+
+    public static GpuProbe getInstance() {
+        return GpuProbeHolder.INSTANCE;
+    }
+
+    public GpuInfo gpuInfo() {
+        long timestamp = System.currentTimeMillis();
+        List<GpuInfo.Device> devices = List.of();
+
+        for (GpuMetricsProvider provider : providers) {
+            try {
+                if (provider.isAvailable()) {
+                    devices = provider.readDevices();
+                    // first available provider wins
+                    break;
+                }
+            } catch (Exception ex) {
+                log.debug("GPU provider {} failed", provider.name(), ex);
+            }
+        }
+
+        return new GpuInfo(timestamp, devices);
+    }
+}

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/spring/GpuConfiguration.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/spring/GpuConfiguration.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.monitoring.spring;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Configuration of the GPU monitoring refresh rate. By default it inherits the node monitoring
+ * interval ({@code services.monitoring.delay}/{@code unit}) but can be overridden independently via
+ * {@code services.monitoring.gpu.*} to probe the GPU at a different pace.
+ *
+ * @author GraviteeSource Team
+ */
+public record GpuConfiguration(boolean enabled, long delay, TimeUnit unit) {}

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/spring/NodeMonitoringConfiguration.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/spring/NodeMonitoringConfiguration.java
@@ -30,8 +30,11 @@ import io.gravitee.node.monitoring.healthcheck.NodeHealthCheckManagementEndpoint
 import io.gravitee.node.monitoring.healthcheck.NodeHealthCheckService;
 import io.gravitee.node.monitoring.healthcheck.ProbeManagerImpl;
 import io.gravitee.node.monitoring.infos.NodeInfosService;
+import io.gravitee.node.monitoring.monitor.NodeGpuMonitorService;
 import io.gravitee.node.monitoring.monitor.NodeMonitorManagementEndpoint;
 import io.gravitee.node.monitoring.monitor.NodeMonitorService;
+import io.gravitee.node.monitoring.monitor.gpu.GpuMonitorEventHandler;
+import io.gravitee.node.monitoring.monitor.gpu.GpuSnapshotRegistry;
 import io.gravitee.plugin.alert.AlertEventProducer;
 import io.gravitee.plugin.core.api.PluginRegistry;
 import io.vertx.core.Vertx;
@@ -59,7 +62,8 @@ public class NodeMonitoringConfiguration {
         AlertEventProducer alertEventProducer,
         Node node,
         Vertx vertx,
-        MonitoringConfiguration monitoringConfiguration
+        MonitoringConfiguration monitoringConfiguration,
+        GpuSnapshotRegistry gpuSnapshotRegistry
     ) {
         return new NodeMonitorService(
             nodeMonitorManagementEndpoint,
@@ -67,13 +71,38 @@ public class NodeMonitoringConfiguration {
             alertEventProducer,
             node,
             vertx,
-            monitoringConfiguration
+            monitoringConfiguration,
+            gpuSnapshotRegistry
         );
     }
 
     @Bean
-    public NodeMonitorManagementEndpoint nodeMonitorManagementEndpoint(ObjectMapper objectMapper) {
-        return new NodeMonitorManagementEndpoint(objectMapper);
+    public NodeMonitorManagementEndpoint nodeMonitorManagementEndpoint(ObjectMapper objectMapper, GpuSnapshotRegistry gpuSnapshotRegistry) {
+        return new NodeMonitorManagementEndpoint(objectMapper, gpuSnapshotRegistry);
+    }
+
+    @Bean
+    public GpuSnapshotRegistry gpuSnapshotRegistry() {
+        return new GpuSnapshotRegistry();
+    }
+
+    @Bean
+    public GpuConfiguration gpuConfiguration(
+        @Value("${services.monitoring.gpu.enabled:${services.monitoring.enabled:true}}") boolean enabled,
+        @Value("${services.monitoring.gpu.delay:${services.monitoring.delay:5000}}") long delay,
+        @Value("${services.monitoring.gpu.unit:${services.monitoring.unit:MILLISECONDS}}") TimeUnit unit
+    ) {
+        return new GpuConfiguration(enabled, delay, unit);
+    }
+
+    @Bean
+    public NodeGpuMonitorService nodeGpuMonitorService(Vertx vertx, GpuConfiguration gpuConfiguration) {
+        return new NodeGpuMonitorService(vertx, gpuConfiguration);
+    }
+
+    @Bean
+    public GpuMonitorEventHandler gpuMonitorEventHandler(Vertx vertx, GpuSnapshotRegistry gpuSnapshotRegistry) {
+        return new GpuMonitorEventHandler(vertx, gpuSnapshotRegistry);
     }
 
     @Bean

--- a/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/spring/NodeMonitoringConfiguration.java
+++ b/gravitee-node-monitoring/src/main/java/io/gravitee/node/monitoring/spring/NodeMonitoringConfiguration.java
@@ -88,7 +88,7 @@ public class NodeMonitoringConfiguration {
 
     @Bean
     public GpuConfiguration gpuConfiguration(
-        @Value("${services.monitoring.gpu.enabled:${services.monitoring.enabled:true}}") boolean enabled,
+        @Value("${services.monitoring.gpu.enabled:false}") boolean enabled,
         @Value("${services.monitoring.gpu.delay:${services.monitoring.delay:5000}}") long delay,
         @Value("${services.monitoring.gpu.unit:${services.monitoring.unit:MILLISECONDS}}") TimeUnit unit
     ) {

--- a/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/NodeMonitorServiceTest.java
+++ b/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/NodeMonitorServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.*;
 import io.gravitee.alert.api.event.Event;
 import io.gravitee.node.api.Node;
 import io.gravitee.node.management.http.endpoint.ManagementEndpointManager;
+import io.gravitee.node.monitoring.monitor.gpu.GpuSnapshotRegistry;
 import io.gravitee.node.monitoring.spring.MonitoringConfiguration;
 import io.gravitee.plugin.alert.AlertEventProducer;
 import io.vertx.core.Vertx;
@@ -50,7 +51,8 @@ class NodeMonitorServiceTest {
             alertEventProducer,
             node,
             Vertx.vertx(),
-            new MonitoringConfiguration(true, 1, MILLISECONDS)
+            new MonitoringConfiguration(true, 1, MILLISECONDS),
+            new GpuSnapshotRegistry()
         );
 
         final Set<String> orgIds = Set.of("ORG_ID");
@@ -88,7 +90,8 @@ class NodeMonitorServiceTest {
             alertEventProducer,
             node,
             Vertx.vertx(),
-            new MonitoringConfiguration(false, 1, MILLISECONDS)
+            new MonitoringConfiguration(false, 1, MILLISECONDS),
+            new GpuSnapshotRegistry()
         );
 
         cut.doStart();
@@ -105,7 +108,8 @@ class NodeMonitorServiceTest {
             alertEventProducer,
             node,
             Vertx.vertx(),
-            new MonitoringConfiguration(true, 1, MILLISECONDS)
+            new MonitoringConfiguration(true, 1, MILLISECONDS),
+            new GpuSnapshotRegistry()
         );
 
         final Set<String> orgIds = Set.of("ORG_ID");
@@ -143,7 +147,8 @@ class NodeMonitorServiceTest {
             alertEventProducer,
             node,
             Vertx.vertx(),
-            new MonitoringConfiguration(false, 1, MILLISECONDS)
+            new MonitoringConfiguration(false, 1, MILLISECONDS),
+            new GpuSnapshotRegistry()
         );
 
         cut.preStop();

--- a/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/NodeMonitorThreadTest.java
+++ b/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/NodeMonitorThreadTest.java
@@ -9,9 +9,12 @@ import static org.mockito.Mockito.when;
 
 import io.gravitee.alert.api.event.Event;
 import io.gravitee.node.api.Node;
+import io.gravitee.node.api.monitor.GpuInfo;
 import io.gravitee.node.api.monitor.Monitor;
+import io.gravitee.node.monitoring.monitor.gpu.GpuSnapshotRegistry;
 import io.gravitee.plugin.alert.AlertEventProducer;
 import io.vertx.core.eventbus.MessageProducer;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,9 +43,11 @@ class NodeMonitorThreadTest {
 
     private NodeMonitorThread cut;
 
+    private final GpuSnapshotRegistry gpuSnapshotRegistry = new GpuSnapshotRegistry();
+
     @BeforeEach
     void init() {
-        cut = new NodeMonitorThread(producer, node, alertEventProducer);
+        cut = new NodeMonitorThread(producer, node, alertEventProducer, gpuSnapshotRegistry);
     }
 
     @Test
@@ -88,6 +93,25 @@ class NodeMonitorThreadTest {
                     assertThat(event.properties().get(Event.PROPERTY_ENVIRONMENT)).isEqualTo("ENV_ID");
 
                     assertThat(event.properties().keySet()).contains("os.cpu.percent", "process.fd.open", "jvm.uptime");
+                    return true;
+                })
+            );
+    }
+
+    @Test
+    void should_include_gpu_snapshot_from_registry() {
+        when(node.id()).thenReturn(NODE_ID);
+        GpuInfo.Device device = new GpuInfo.Device(0, "NVIDIA A100", new GpuInfo.Mem(-1, -1));
+        gpuSnapshotRegistry.update(new GpuInfo(123L, List.of(device)));
+
+        cut.run();
+
+        verify(producer)
+            .write(
+                argThat(monitor -> {
+                    assertThat(monitor.getGpu()).isNotNull();
+                    assertThat(monitor.getGpu().devices()).hasSize(1);
+                    assertThat(monitor.getGpu().devices().get(0).name()).isEqualTo("NVIDIA A100");
                     return true;
                 })
             );

--- a/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/gpu/GpuInfoMemTest.java
+++ b/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/gpu/GpuInfoMemTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.monitoring.monitor.gpu;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.node.api.monitor.GpuInfo;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+class GpuInfoMemTest {
+
+    @Test
+    void should_compute_used_and_percentages_when_available() {
+        GpuInfo.Mem mem = new GpuInfo.Mem(1000, 400);
+
+        assertThat(mem.getUsed()).isEqualTo(600);
+        assertThat(mem.getUsedPercent()).isEqualTo((short) 60);
+        assertThat(mem.getFreePercent()).isEqualTo((short) 40);
+    }
+
+    @Test
+    void should_return_minus_one_percentages_when_values_are_unavailable() {
+        // free unavailable -> used unknown -> used percent unavailable
+        assertThat(new GpuInfo.Mem(1000, -1).getUsedPercent()).isEqualTo((short) -1);
+        assertThat(new GpuInfo.Mem(1000, -1).getFreePercent()).isEqualTo((short) -1);
+        // total unavailable -> both unavailable
+        assertThat(new GpuInfo.Mem(-1, -1).getUsedPercent()).isEqualTo((short) -1);
+        assertThat(new GpuInfo.Mem(-1, -1).getFreePercent()).isEqualTo((short) -1);
+    }
+}

--- a/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/gpu/GpuInfoMemTest.java
+++ b/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/gpu/GpuInfoMemTest.java
@@ -18,11 +18,14 @@ package io.gravitee.node.monitoring.monitor.gpu;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.gravitee.node.api.monitor.GpuInfo;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 
 /**
  * @author GraviteeSource Team
  */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class GpuInfoMemTest {
 
     @Test

--- a/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/gpu/GpuMonitorEventHandlerTest.java
+++ b/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/gpu/GpuMonitorEventHandlerTest.java
@@ -27,12 +27,15 @@ import java.time.Duration;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 
 /**
  * @author Rémi SULTAN (remi.sultan at graviteesource.com)
  * @author GraviteeSource Team
  */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class GpuMonitorEventHandlerTest {
 
     private Vertx vertx;

--- a/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/gpu/GpuMonitorEventHandlerTest.java
+++ b/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/gpu/GpuMonitorEventHandlerTest.java
@@ -16,14 +16,15 @@
 package io.gravitee.node.monitoring.monitor.gpu;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import io.gravitee.node.api.monitor.GpuInfo;
 import io.gravitee.node.monitoring.eventbus.GpuInfoCodec;
 import io.gravitee.node.monitoring.monitor.NodeGpuMonitorService;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.DeliveryOptions;
+import java.time.Duration;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -62,22 +63,12 @@ class GpuMonitorEventHandlerTest {
             .registerCodec(new GpuInfoCodec())
             .send(NodeGpuMonitorService.GIO_NODE_GPU_BUS, published, new DeliveryOptions().setCodecName(GpuInfoCodec.CODEC_NAME));
 
-        awaitDevices(1);
-
-        assertThat(registry.current().devices()).hasSize(1);
-        assertThat(registry.current().devices().get(0).name()).isEqualTo("NVIDIA A100");
-    }
-
-    private void awaitDevices(int expectedSize) {
-        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
-        while (registry.current().devices().size() != expectedSize && System.nanoTime() < deadline) {
-            try {
-                TimeUnit.MILLISECONDS.sleep(10);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                break;
-            }
-        }
+        await()
+            .atMost(Duration.ofSeconds(2))
+            .untilAsserted(() -> {
+                assertThat(registry.current().devices()).hasSize(1);
+                assertThat(registry.current().devices().get(0).name()).isEqualTo("NVIDIA A100");
+            });
     }
 
     @Test

--- a/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/gpu/GpuMonitorEventHandlerTest.java
+++ b/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/gpu/GpuMonitorEventHandlerTest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.monitoring.monitor.gpu;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.node.api.monitor.GpuInfo;
+import io.gravitee.node.monitoring.eventbus.GpuInfoCodec;
+import io.gravitee.node.monitoring.monitor.NodeGpuMonitorService;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.DeliveryOptions;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class GpuMonitorEventHandlerTest {
+
+    private Vertx vertx;
+    private GpuSnapshotRegistry registry;
+    private GpuMonitorEventHandler cut;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        vertx = Vertx.vertx();
+        registry = new GpuSnapshotRegistry();
+        cut = new GpuMonitorEventHandler(vertx, registry);
+        cut.doStart();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        cut.doStop();
+        vertx.close();
+    }
+
+    @Test
+    void should_update_registry_when_a_gpu_snapshot_is_published() {
+        GpuInfo.Device device = new GpuInfo.Device(0, "NVIDIA A100", new GpuInfo.Mem(-1, -1));
+        GpuInfo published = new GpuInfo(123L, List.of(device));
+
+        vertx
+            .eventBus()
+            .registerCodec(new GpuInfoCodec())
+            .send(NodeGpuMonitorService.GIO_NODE_GPU_BUS, published, new DeliveryOptions().setCodecName(GpuInfoCodec.CODEC_NAME));
+
+        awaitDevices(1);
+
+        assertThat(registry.current().devices()).hasSize(1);
+        assertThat(registry.current().devices().get(0).name()).isEqualTo("NVIDIA A100");
+    }
+
+    private void awaitDevices(int expectedSize) {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+        while (registry.current().devices().size() != expectedSize && System.nanoTime() < deadline) {
+            try {
+                TimeUnit.MILLISECONDS.sleep(10);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+    }
+
+    @Test
+    void should_default_to_empty_devices_before_any_message() {
+        assertThat(registry.current()).isNotNull();
+        assertThat(registry.current().devices()).isEmpty();
+    }
+}

--- a/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/gpu/NvidiaSmiGpuMetricsProviderTest.java
+++ b/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/gpu/NvidiaSmiGpuMetricsProviderTest.java
@@ -1,0 +1,184 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.monitoring.monitor.gpu;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
+
+import io.gravitee.node.api.monitor.GpuInfo;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class NvidiaSmiGpuMetricsProviderTest {
+
+    private final NvidiaSmiGpuMetricsProvider provider = new NvidiaSmiGpuMetricsProvider();
+
+    @Test
+    void should_parse_a_single_device_line() {
+        String output = "0, NVIDIA A100, GPU-abc, 535.104.05, 42, 17, 40960, 30960, 55, 250.43";
+
+        List<GpuInfo.Device> devices = provider.parse(output);
+
+        assertThat(devices).hasSize(1);
+        GpuInfo.Device device = devices.get(0);
+        assertThat(device.index()).isEqualTo(0);
+        assertThat(device.name()).isEqualTo("NVIDIA A100");
+        assertThat(device.uuid()).isEqualTo("GPU-abc");
+        assertThat(device.driverVersion()).isEqualTo("535.104.05");
+        assertThat(device.utilizationPercent()).isEqualTo((short) 42);
+        assertThat(device.memoryUtilizationPercent()).isEqualTo((short) 17);
+        assertThat(device.mem().total()).isEqualTo(40960L * 1024 * 1024);
+        assertThat(device.mem().free()).isEqualTo(30960L * 1024 * 1024);
+        assertThat(device.mem().getUsed()).isEqualTo((40960L - 30960L) * 1024 * 1024);
+        assertThat(device.temperature()).isEqualTo((short) 55);
+        assertThat(device.powerWatts()).isEqualTo(250.43);
+    }
+
+    @Test
+    void should_parse_multiple_devices() {
+        String output =
+            "0, NVIDIA A100, GPU-abc, 535.104.05, 42, 17, 40960, 30960, 55, 250.43\n" +
+            "1, NVIDIA A100, GPU-def, 535.104.05, 0, 0, 40960, 40000, 30, 60.00\n";
+
+        List<GpuInfo.Device> devices = provider.parse(output);
+
+        assertThat(devices).hasSize(2);
+        assertThat(devices.get(1).index()).isEqualTo(1);
+        assertThat(devices.get(1).uuid()).isEqualTo("GPU-def");
+    }
+
+    @Test
+    void should_leave_defaults_for_not_available_fields() {
+        String output = "0, NVIDIA A100, GPU-abc, 535.104.05, [N/A], [N/A], 40960, 30960, [N/A], [N/A]";
+
+        List<GpuInfo.Device> devices = provider.parse(output);
+
+        assertThat(devices).hasSize(1);
+        GpuInfo.Device device = devices.get(0);
+        assertThat(device.utilizationPercent()).isEqualTo((short) -1);
+        assertThat(device.memoryUtilizationPercent()).isEqualTo((short) -1);
+        assertThat(device.temperature()).isEqualTo((short) -1);
+        assertThat(device.powerWatts()).isEqualTo(-1);
+    }
+
+    @Test
+    void should_return_empty_list_for_blank_or_null_output() {
+        assertThat(provider.parse(null)).isEmpty();
+        assertThat(provider.parse("")).isEmpty();
+        assertThat(provider.parse("\n  \n")).isEmpty();
+    }
+
+    @Test
+    void should_skip_malformed_lines() {
+        String output = "garbage,too,few,fields";
+
+        assertThat(provider.parse(output)).isEmpty();
+    }
+
+    @Test
+    @DisabledOnOs(WINDOWS)
+    void should_read_devices_by_emulating_nvidia_smi(@TempDir Path tempDir) throws Exception {
+        String fakeOutput =
+            "0, NVIDIA A100, GPU-abc, 535.104.05, 42, 17, 40960, 30960, 55, 250.43\\n" +
+            "1, NVIDIA A100, GPU-def, 535.104.05, 0, 0, 40960, 40000, 30, 60.00";
+        Path fakeNvidiaSmi = writeFakeNvidiaSmi(tempDir, fakeOutput);
+
+        NvidiaSmiGpuMetricsProvider emulated = new NvidiaSmiGpuMetricsProvider(fakeNvidiaSmi.toString());
+
+        assertThat(emulated.isAvailable()).isTrue();
+
+        List<GpuInfo.Device> devices = emulated.readDevices();
+        assertThat(devices).hasSize(2);
+        assertThat(devices.get(0).index()).isZero();
+        assertThat(devices.get(0).name()).isEqualTo("NVIDIA A100");
+        assertThat(devices.get(0).utilizationPercent()).isEqualTo((short) 42);
+        assertThat(devices.get(0).mem().total()).isEqualTo(40960L * 1024 * 1024);
+        assertThat(devices.get(0).powerWatts()).isEqualTo(250.43);
+        assertThat(devices.get(1).uuid()).isEqualTo("GPU-def");
+    }
+
+    @Test
+    @DisabledOnOs(WINDOWS)
+    void should_return_empty_devices_when_emulated_nvidia_smi_fails(@TempDir Path tempDir) throws Exception {
+        Path failing = tempDir.resolve("nvidia-smi");
+        Files.writeString(failing, "#!/bin/sh\nexit 1\n");
+        makeExecutable(failing);
+
+        NvidiaSmiGpuMetricsProvider emulated = new NvidiaSmiGpuMetricsProvider(failing.toString());
+
+        assertThat(emulated.isAvailable()).isFalse();
+        assertThat(emulated.readDevices()).isEmpty();
+    }
+
+    @Test
+    void should_report_unavailable_when_command_is_missing() {
+        NvidiaSmiGpuMetricsProvider missing = new NvidiaSmiGpuMetricsProvider("/path/does/not/exist/nvidia-smi");
+
+        assertThat(missing.isAvailable()).isFalse();
+        assertThat(missing.readDevices()).isEmpty();
+    }
+
+    @Test
+    @DisabledOnOs(WINDOWS)
+    void should_probe_availability_only_once(@TempDir Path tempDir) throws Exception {
+        Path versionCalls = tempDir.resolve("version-calls.log");
+        Path nvidiaSmi = tempDir.resolve("nvidia-smi");
+        // Record each --version invocation so we can count how many times availability was probed.
+        Files.writeString(
+            nvidiaSmi,
+            "#!/bin/sh\n" + "if [ \"$1\" = \"--version\" ]; then echo x >> '" + versionCalls + "'; exit 0; fi\n" + "exit 1\n"
+        );
+        makeExecutable(nvidiaSmi);
+
+        NvidiaSmiGpuMetricsProvider provider = new NvidiaSmiGpuMetricsProvider(nvidiaSmi.toString());
+
+        assertThat(provider.isAvailable()).isTrue();
+        assertThat(provider.isAvailable()).isTrue();
+        assertThat(provider.isAvailable()).isTrue();
+
+        assertThat(Files.readAllLines(versionCalls)).hasSize(1);
+    }
+
+    private static Path writeFakeNvidiaSmi(Path tempDir, String csvOutput) throws Exception {
+        Path script = tempDir.resolve("nvidia-smi");
+        // Emulate nvidia-smi: handle --version and --query-gpu invocations.
+        String content =
+            "#!/bin/sh\n" +
+            "case \"$1\" in\n" +
+            "  --version) echo 'NVIDIA-SMI 535.104.05'; exit 0;;\n" +
+            "  --query-gpu=*) printf '" +
+            csvOutput +
+            "\\n'; exit 0;;\n" +
+            "esac\n" +
+            "exit 1\n";
+        Files.writeString(script, content);
+        makeExecutable(script);
+        return script;
+    }
+
+    private static void makeExecutable(Path path) throws Exception {
+        Files.setPosixFilePermissions(path, PosixFilePermissions.fromString("rwxr-xr-x"));
+    }
+}

--- a/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/gpu/NvidiaSmiGpuMetricsProviderTest.java
+++ b/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/gpu/NvidiaSmiGpuMetricsProviderTest.java
@@ -152,11 +152,11 @@ class NvidiaSmiGpuMetricsProviderTest {
         );
         makeExecutable(nvidiaSmi);
 
-        NvidiaSmiGpuMetricsProvider provider = new NvidiaSmiGpuMetricsProvider(nvidiaSmi.toString());
+        NvidiaSmiGpuMetricsProvider cut = new NvidiaSmiGpuMetricsProvider(nvidiaSmi.toString());
 
-        assertThat(provider.isAvailable()).isTrue();
-        assertThat(provider.isAvailable()).isTrue();
-        assertThat(provider.isAvailable()).isTrue();
+        assertThat(cut.isAvailable()).isTrue();
+        assertThat(cut.isAvailable()).isTrue();
+        assertThat(cut.isAvailable()).isTrue();
 
         assertThat(Files.readAllLines(versionCalls)).hasSize(1);
     }

--- a/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/gpu/NvidiaSmiGpuMetricsProviderTest.java
+++ b/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/gpu/NvidiaSmiGpuMetricsProviderTest.java
@@ -23,6 +23,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.io.TempDir;
@@ -31,6 +33,7 @@ import org.junit.jupiter.api.io.TempDir;
  * @author Rémi SULTAN (remi.sultan at graviteesource.com)
  * @author GraviteeSource Team
  */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class NvidiaSmiGpuMetricsProviderTest {
 
     private final NvidiaSmiGpuMetricsProvider provider = new NvidiaSmiGpuMetricsProvider();

--- a/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/micrometer/GpuMicrometerHandlerTest.java
+++ b/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/micrometer/GpuMicrometerHandlerTest.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.monitoring.monitor.micrometer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.node.api.monitor.GpuInfo;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class GpuMicrometerHandlerTest {
+
+    private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+    private static GpuInfo.Device nvidiaDevice() {
+        GpuInfo.Mem mem = new GpuInfo.Mem(40960L * 1024 * 1024, 30960L * 1024 * 1024);
+        return new GpuInfo.Device(0, "NVIDIA A100", "GPU-abc", "535.104.05", (short) 42, (short) 17, mem, (short) 55, 250.43);
+    }
+
+    private static GpuInfo.Device identityOnlyDevice() {
+        // a provider that reports only identity, everything else N/A (-1)
+        return new GpuInfo.Device(0, "Some GPU", new GpuInfo.Mem(-1, -1));
+    }
+
+    @Test
+    void should_register_all_gauges_for_a_full_device() {
+        AtomicReference<GpuInfo> snapshot = new AtomicReference<>(new GpuInfo(1L, List.of(nvidiaDevice())));
+
+        new GpuMicrometerHandler(snapshot::get).bindTo(registry);
+
+        assertThat(registry.find("gpu.utilization").gauge().value()).isEqualTo(42d);
+        assertThat(registry.find("gpu.memory.utilization").gauge().value()).isEqualTo(17d);
+        assertThat(registry.find("gpu.memory.used").gauge().value()).isEqualTo((double) (40960L - 30960L) * 1024 * 1024);
+        assertThat(registry.find("gpu.memory.total").gauge().value()).isEqualTo((double) 40960L * 1024 * 1024);
+        assertThat(registry.find("gpu.temperature").gauge().value()).isEqualTo(55d);
+        assertThat(registry.find("gpu.power").gauge().value()).isEqualTo(250.43);
+    }
+
+    @Test
+    void should_tag_gauges_with_gpu_index_name_and_uuid() {
+        AtomicReference<GpuInfo> snapshot = new AtomicReference<>(new GpuInfo(1L, List.of(nvidiaDevice())));
+
+        new GpuMicrometerHandler(snapshot::get).bindTo(registry);
+
+        Gauge gauge = registry.find("gpu.utilization").gauge();
+        assertThat(gauge).isNotNull();
+        assertThat(gauge.getId().getTag("gpu")).isEqualTo("0");
+        assertThat(gauge.getId().getTag("name")).isEqualTo("NVIDIA A100");
+        assertThat(gauge.getId().getTag("uuid")).isEqualTo("GPU-abc");
+        assertThat(gauge.getId().getBaseUnit()).isEqualTo("percent");
+    }
+
+    @Test
+    void should_reflect_latest_snapshot_on_scrape() {
+        AtomicReference<GpuInfo> snapshot = new AtomicReference<>(new GpuInfo(1L, List.of(nvidiaDevice())));
+        new GpuMicrometerHandler(snapshot::get).bindTo(registry);
+
+        // simulate the scheduled refresh updating utilization to 88%
+        GpuInfo.Mem mem = new GpuInfo.Mem(40960L * 1024 * 1024, 30960L * 1024 * 1024);
+        GpuInfo.Device updated = new GpuInfo.Device(
+            0,
+            "NVIDIA A100",
+            "GPU-abc",
+            "535.104.05",
+            (short) 88,
+            (short) 17,
+            mem,
+            (short) 60,
+            300d
+        );
+        snapshot.set(new GpuInfo(2L, List.of(updated)));
+
+        assertThat(registry.find("gpu.utilization").gauge().value()).isEqualTo(88d);
+        assertThat(registry.find("gpu.temperature").gauge().value()).isEqualTo(60d);
+    }
+
+    @Test
+    void should_skip_unavailable_metrics_for_identity_only_device() {
+        AtomicReference<GpuInfo> snapshot = new AtomicReference<>(new GpuInfo(1L, List.of(identityOnlyDevice())));
+
+        new GpuMicrometerHandler(snapshot::get).bindTo(registry);
+
+        // identity-only device exposes nothing (all values are -1)
+        assertThat(registry.find("gpu.utilization").gauge()).isNull();
+        assertThat(registry.find("gpu.memory.total").gauge()).isNull();
+        assertThat(registry.find("gpu.temperature").gauge()).isNull();
+        assertThat(registry.find("gpu.power").gauge()).isNull();
+    }
+
+    @Test
+    void should_register_one_set_of_gauges_per_device() {
+        GpuInfo.Mem mem = new GpuInfo.Mem(40960L * 1024 * 1024, 30960L * 1024 * 1024);
+        GpuInfo.Device second = new GpuInfo.Device(1, "NVIDIA A100", "GPU-def", "535.104.05", (short) 10, (short) 5, mem, (short) 40, 100d);
+        AtomicReference<GpuInfo> snapshot = new AtomicReference<>(new GpuInfo(1L, List.of(nvidiaDevice(), second)));
+
+        new GpuMicrometerHandler(snapshot::get).bindTo(registry);
+
+        assertThat(registry.find("gpu.utilization").gauges()).hasSize(2);
+        assertThat(registry.find("gpu.utilization").tag("gpu", "1").gauge().value()).isEqualTo(10d);
+    }
+
+    @Test
+    void should_not_fail_on_empty_or_null_snapshot() {
+        new GpuMicrometerHandler(() -> new GpuInfo(1L, List.of())).bindTo(registry);
+        new GpuMicrometerHandler(() -> null).bindTo(registry);
+
+        assertThat(registry.getMeters()).isEmpty();
+    }
+}

--- a/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/micrometer/GpuMicrometerHandlerTest.java
+++ b/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/micrometer/GpuMicrometerHandlerTest.java
@@ -108,6 +108,29 @@ class GpuMicrometerHandlerTest {
     }
 
     @Test
+    void should_not_fail_when_device_memory_is_null() {
+        GpuInfo.Device noMem = new GpuInfo.Device(
+            0,
+            "NVIDIA A100",
+            "GPU-abc",
+            "535.104.05",
+            (short) 42,
+            (short) 17,
+            null,
+            (short) 55,
+            250.43
+        );
+        AtomicReference<GpuInfo> snapshot = new AtomicReference<>(new GpuInfo(1L, List.of(noMem)));
+
+        new GpuMicrometerHandler(snapshot::get).bindTo(registry);
+
+        // non-memory gauges still registered, memory gauges skipped (no NPE)
+        assertThat(registry.find("gpu.utilization").gauge().value()).isEqualTo(42d);
+        assertThat(registry.find("gpu.memory.used").gauge()).isNull();
+        assertThat(registry.find("gpu.memory.total").gauge()).isNull();
+    }
+
+    @Test
     void should_register_one_set_of_gauges_per_device() {
         GpuInfo.Mem mem = new GpuInfo.Mem(40960L * 1024 * 1024, 30960L * 1024 * 1024);
         GpuInfo.Device second = new GpuInfo.Device(1, "NVIDIA A100", "GPU-def", "535.104.05", (short) 10, (short) 5, mem, (short) 40, 100d);

--- a/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/micrometer/GpuMicrometerHandlerTest.java
+++ b/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/micrometer/GpuMicrometerHandlerTest.java
@@ -22,12 +22,15 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 
 /**
  * @author Rémi SULTAN (remi.sultan at graviteesource.com)
  * @author GraviteeSource Team
  */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class GpuMicrometerHandlerTest {
 
     private final SimpleMeterRegistry registry = new SimpleMeterRegistry();

--- a/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/probe/GpuProbeTest.java
+++ b/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/probe/GpuProbeTest.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.monitoring.monitor.probe;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.node.api.monitor.GpuInfo;
+import io.gravitee.node.monitoring.monitor.gpu.GpuMetricsProvider;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+class GpuProbeTest {
+
+    @Test
+    void should_return_empty_devices_when_no_provider_is_available() {
+        GpuProbe probe = new GpuProbe(List.of(unavailableProvider()));
+
+        GpuInfo info = probe.gpuInfo();
+
+        assertThat(info.timestamp()).isPositive();
+        assertThat(info.devices()).isEmpty();
+    }
+
+    @Test
+    void should_use_first_available_provider() {
+        GpuInfo.Device device = new GpuInfo.Device(0, "gpu-0", new GpuInfo.Mem(-1, -1));
+        GpuProbe probe = new GpuProbe(List.of(unavailableProvider(), availableProvider(List.of(device))));
+
+        GpuInfo info = probe.gpuInfo();
+
+        assertThat(info.devices()).hasSize(1);
+        assertThat(info.devices().get(0).index()).isEqualTo(0);
+    }
+
+    @Test
+    void should_not_throw_when_provider_fails() {
+        GpuProbe probe = new GpuProbe(
+            List.of(
+                new GpuMetricsProvider() {
+                    @Override
+                    public String name() {
+                        return "boom";
+                    }
+
+                    @Override
+                    public boolean isAvailable() {
+                        throw new RuntimeException("boom");
+                    }
+
+                    @Override
+                    public List<GpuInfo.Device> readDevices() {
+                        return List.of();
+                    }
+                }
+            )
+        );
+
+        assertThat(probe.gpuInfo().devices()).isEmpty();
+    }
+
+    private static GpuMetricsProvider unavailableProvider() {
+        return new GpuMetricsProvider() {
+            @Override
+            public String name() {
+                return "unavailable";
+            }
+
+            @Override
+            public boolean isAvailable() {
+                return false;
+            }
+
+            @Override
+            public List<GpuInfo.Device> readDevices() {
+                return List.of();
+            }
+        };
+    }
+
+    private static GpuMetricsProvider availableProvider(List<GpuInfo.Device> devices) {
+        return new GpuMetricsProvider() {
+            @Override
+            public String name() {
+                return "available";
+            }
+
+            @Override
+            public boolean isAvailable() {
+                return true;
+            }
+
+            @Override
+            public List<GpuInfo.Device> readDevices() {
+                return devices;
+            }
+        };
+    }
+}

--- a/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/probe/GpuProbeTest.java
+++ b/gravitee-node-monitoring/src/test/java/io/gravitee/node/monitoring/monitor/probe/GpuProbeTest.java
@@ -20,11 +20,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.gravitee.node.api.monitor.GpuInfo;
 import io.gravitee.node.monitoring.monitor.gpu.GpuMetricsProvider;
 import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 
 /**
  * @author GraviteeSource Team
  */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class GpuProbeTest {
 
     @Test


### PR DESCRIPTION
**Description**

 Adds GPU metrics collection to gravitee-node-monitoring, exposed via Prometheus, the /monitor endpoint, and node alerts alongside the existing OS/JVM/Process metrics.                                                               

  - GpuInfo record (gravitee-node-api): per-device utilization, memory, temperature, power, and identity (index/name/uuid/driver).                                                                                                       
  - Pluggable provider SPI (GpuMetricsProvider) with an nvidia-smi-backed implementation that shells out and parses CSV, no native dependency, matching the existing probe style. The SPI leaves room for other vendors (e.g. NVML,     
  Metal) later.                                                                                                                                                                                                                          
  - Producer/consumer pipeline: NodeGpuMonitorService collects the GPU snapshot once per interval and publishes it on the Vert.x event bus; GpuMonitorEventHandler consumes it into a shared GpuSnapshotRegistry and binds the Micrometer
  gauges. The node monitor, /monitor endpoint, and gauges all read the same snapshot, the GPU is probed only once per cycle.                                                                                                            
  - Configurable cadence via services.monitoring.gpu.{enabled,delay,unit}, defaulting to the node-monitoring settings, `services.monitoring.gpu.enabled` defaults to false not to enable it on other node-based compoments (APIM, AM, ...).                                                                                                                   
  - Performance: collection runs off the hot path on a dedicated thread; availability is probed once and memoized, so each cycle does a single lightweight nvidia-smi query. Hosts without a GPU pay nothing.

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `9.2.0-feat-metrics-gpu-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/9.2.0-feat-metrics-gpu-SNAPSHOT/gravitee-node-9.2.0-feat-metrics-gpu-SNAPSHOT.zip)
  <!-- Version placeholder end -->
