### PR TITLE
fix: API Products available for all Gamma tiers

### DIFF
--- a/gravitee-node-license/src/main/resources/license-model.yml
+++ b/gravitee-node-license/src/main/resources/license-model.yml
@@ -166,7 +166,7 @@ packs:
     ############################### Gamma packs ################################
     standard:
         features: &standard-features
-            - apim-api-products # not a plugin. Feature is in the UI
+            - apim-api-products # not a plugin. Feature is in the UI (all Gamma tiers)
             - apim-audit-trail # not a plugin. Feature is in the UI
             - apim-custom-roles # not a plugin. Feature is in the UI
             - apim-dcr-registration # not a plugin. Feature is in the UI

--- a/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseModelServiceTest.java
+++ b/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseModelServiceTest.java
@@ -102,7 +102,10 @@ class DefaultLicenseModelServiceTest {
                     "enterprise-alert-engine",
                     "enterprise-authenticator",
                 }
-            )
+            ),
+            arguments("gamma-planet", new String[] { "standard" }),
+            arguments("gamma-galaxy", new String[] { "enterprise" }),
+            arguments("gamma-universe", new String[] { "enterprise" })
         );
     }
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-14554

**Description**

Target : API Product feature is accessible only with Universe tier License. 
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `9.3.1-APIM-14554-API-Products-Galaxy-license-does-not-show-UI-lock-banner-error-only-on-Create-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/9.3.1-APIM-14554-API-Products-Galaxy-license-does-not-show-UI-lock-banner-error-only-on-Create-SNAPSHOT/gravitee-node-9.3.1-APIM-14554-API-Products-Galaxy-license-does-not-show-UI-lock-banner-error-only-on-Create-SNAPSHOT.zip)
  <!-- Version placeholder end -->
