### PR TITLE
fix: evaluate certificate expiry

### DIFF
--- a/gravitee-node-certificates/src/main/java/io/gravitee/node/certificates/CertificateExpiryUtils.java
+++ b/gravitee-node-certificates/src/main/java/io/gravitee/node/certificates/CertificateExpiryUtils.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.certificates;
+
+import io.gravitee.common.util.KeyStoreUtils;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateExpiredException;
+import java.security.cert.CertificateNotYetValidException;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.slf4j.Logger;
+
+/**
+ * Utility for checking X.509 certificate expiry and logging actionable warnings.
+ *
+ * @author GraviteeSource Team
+ */
+public final class CertificateExpiryUtils {
+
+    static final int EXPIRY_WARNING_THRESHOLD_DAYS = 30;
+
+    private CertificateExpiryUtils() {}
+
+    /**
+     * Inspects every certificate entry in the given {@link KeyStore} and logs a warning when a
+     * certificate has expired, is not yet valid, or will expire within {@value #EXPIRY_WARNING_THRESHOLD_DAYS} days.
+     */
+    public static void warnIfExpired(KeyStore keyStore, Logger log) {
+        try {
+            for (String alias : Collections.list(keyStore.aliases())) {
+                Certificate cert = keyStore.getCertificate(alias);
+                if (cert instanceof X509Certificate x509) {
+                    checkCertificate(alias, x509, log);
+                }
+            }
+        } catch (KeyStoreException e) {
+            log.warn("Unable to inspect keystore for certificate expiry", e);
+        }
+    }
+
+    /**
+     * Inspects a collection of certificates (e.g. parsed from a PEM stream) and logs expiry warnings.
+     * The {@code source} label is used in log messages to identify where the certificates come from.
+     */
+    public static void warnIfExpired(Collection<? extends Certificate> certificates, String source, Logger log) {
+        int index = 0;
+        for (Certificate cert : certificates) {
+            if (cert instanceof X509Certificate x509) {
+                String identifier = buildIdentifier(source, index, x509);
+                checkCertificate(identifier, x509, log);
+            }
+            index++;
+        }
+    }
+
+    /**
+     * Materializes a JKS or PKCS12 store from a file path or base64-encoded content, then logs expiry
+     * warnings for its certificates. Best-effort: any materialization failure is logged at debug level
+     * so that an inspection problem can never prevent the caller from proceeding.
+     *
+     * @param type the keystore type (e.g. {@code JKS}, {@code PKCS12})
+     * @param source a human-readable label used in log messages when a failure occurs
+     */
+    public static void inspectKeyStore(String type, String path, String base64Content, String password, String source, Logger log) {
+        try {
+            KeyStore keyStore = null;
+            if (path != null && !path.isEmpty()) {
+                keyStore = KeyStoreUtils.initFromPath(type, path, password);
+            } else if (base64Content != null && !base64Content.isEmpty()) {
+                keyStore = KeyStoreUtils.initFromContent(type, base64Content, password);
+            }
+            if (keyStore != null) {
+                warnIfExpired(keyStore, log);
+            }
+        } catch (RuntimeException e) {
+            log.debug("Unable to inspect {} certificate expiry", source, e);
+        }
+    }
+
+    /**
+     * Parses PEM certificate material provided as file paths and/or inline content, then logs expiry
+     * warnings. Best-effort: parsing failures are logged at debug level.
+     *
+     * @param source a human-readable label used to identify the certificates in log messages
+     */
+    public static void inspectPem(List<String> paths, List<String> contents, String source, Logger log) {
+        try {
+            if (paths != null) {
+                final var keystore = KeyStoreUtils.initFromPemCertificateFiles(
+                    paths.stream().filter(Objects::nonNull).toList(),
+                    UUID.randomUUID().toString()
+                );
+                warnIfExpired(keystore, log);
+            }
+            if (contents != null) {
+                for (String content : contents) {
+                    if (content != null && !content.isEmpty()) {
+                        warnIfExpired(List.of(KeyStoreUtils.loadPemCertificates(content)), source, log);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.debug("Unable to inspect {} certificate expiry", source, e);
+        }
+    }
+
+    private static String buildIdentifier(String source, int index, X509Certificate x509) {
+        String dn = x509.getSubjectX500Principal().getName();
+        return dn.isEmpty() ? source + "[" + index + "]" : source + " - " + dn;
+    }
+
+    private static void checkCertificate(String identifier, X509Certificate cert, Logger log) {
+        try {
+            cert.checkValidity();
+        } catch (CertificateExpiredException e) {
+            log.error("Certificate '{}' has EXPIRED on {}", identifier, cert.getNotAfter());
+            return;
+        } catch (CertificateNotYetValidException e) {
+            log.warn("Certificate '{}' is not yet valid (valid from {})", identifier, cert.getNotBefore());
+            return;
+        }
+        long daysLeft = ChronoUnit.DAYS.between(Instant.now(), cert.getNotAfter().toInstant());
+        if (daysLeft <= EXPIRY_WARNING_THRESHOLD_DAYS) {
+            log.warn("Certificate '{}' expires in {} day(s) on {}", identifier, daysLeft, cert.getNotAfter());
+        }
+    }
+}

--- a/gravitee-node-certificates/src/main/java/io/gravitee/node/certificates/x509/RefreshableX509KeyManagerDelegator.java
+++ b/gravitee-node-certificates/src/main/java/io/gravitee/node/certificates/x509/RefreshableX509KeyManagerDelegator.java
@@ -20,6 +20,7 @@ import static javax.net.ssl.StandardConstants.SNI_HOST_NAME;
 import io.gravitee.common.util.KeyStoreUtils;
 import io.gravitee.node.api.certificate.KeyStoreProcessingException;
 import io.gravitee.node.api.certificate.RefreshableX509Manager;
+import io.gravitee.node.certificates.CertificateExpiryUtils;
 import java.net.Socket;
 import java.security.*;
 import java.security.cert.X509Certificate;
@@ -88,6 +89,7 @@ public class RefreshableX509KeyManagerDelegator extends X509ExtendedKeyManager i
             dataHolder = new KeyManagerDataHolder(sniFallbackAlias, new ConcurrentHashMap<>(newCommonNamesByAlias), keyManager);
 
             log.info("Key store has been (re)loaded with {} entries for target: {}", keyStore.size(), target);
+            CertificateExpiryUtils.warnIfExpired(keyStore, log);
         } catch (KeyStoreException | NoSuchAlgorithmException | UnrecoverableKeyException e) {
             throw new KeyStoreProcessingException("Unable to initialize key manager keystore", e);
         }

--- a/gravitee-node-certificates/src/main/java/io/gravitee/node/certificates/x509/RefreshableX509TrustManagerDelegator.java
+++ b/gravitee-node-certificates/src/main/java/io/gravitee/node/certificates/x509/RefreshableX509TrustManagerDelegator.java
@@ -17,6 +17,7 @@ package io.gravitee.node.certificates.x509;
 
 import io.gravitee.node.api.certificate.CRLRefreshable;
 import io.gravitee.node.api.certificate.RefreshableX509Manager;
+import io.gravitee.node.certificates.CertificateExpiryUtils;
 import java.net.Socket;
 import java.security.KeyStore;
 import java.security.cert.CRL;
@@ -58,6 +59,7 @@ public class RefreshableX509TrustManagerDelegator extends X509ExtendedTrustManag
             this.delegate = (X509ExtendedTrustManager) trustManagerFactory.getTrustManagers()[0];
 
             log.info("Trust store has been (re)loaded with {} entries for target: {}", keyStore.size(), target);
+            CertificateExpiryUtils.warnIfExpired(keyStore, log);
         } catch (Exception e) {
             throw new IllegalArgumentException("Unable to create trust manager for target: %s".formatted(target), e);
         }

--- a/gravitee-node-certificates/src/test/java/io/gravitee/node/certificates/CertificateExpiryUtilsTest.java
+++ b/gravitee-node-certificates/src/test/java/io/gravitee/node/certificates/CertificateExpiryUtilsTest.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.certificates;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.List;
+import javax.security.auth.x500.X500Principal;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.Logger;
+
+/**
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@RunWith(MockitoJUnitRunner.class)
+public class CertificateExpiryUtilsTest {
+
+    @Mock
+    private Logger log;
+
+    private KeyPair keyPair;
+
+    @Before
+    public void before() throws Exception {
+        keyPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
+    }
+
+    @Test
+    public void should_warn_when_certificate_expires_within_threshold() throws Exception {
+        KeyStore keyStore = keyStoreWith("expiring", Instant.now().minus(1, ChronoUnit.DAYS), Instant.now().plus(10, ChronoUnit.DAYS));
+
+        CertificateExpiryUtils.warnIfExpired(keyStore, log);
+
+        verify(log).warn(contains("expires in"), eq("expiring"), anyLong(), any());
+    }
+
+    @Test
+    public void should_log_error_when_certificate_already_expired() throws Exception {
+        KeyStore keyStore = keyStoreWith("expired", Instant.now().minus(20, ChronoUnit.DAYS), Instant.now().minus(1, ChronoUnit.DAYS));
+
+        CertificateExpiryUtils.warnIfExpired(keyStore, log);
+
+        verify(log).error(contains("EXPIRED"), eq("expired"), any());
+    }
+
+    @Test
+    public void should_warn_when_certificate_not_yet_valid() throws Exception {
+        KeyStore keyStore = keyStoreWith("future", Instant.now().plus(5, ChronoUnit.DAYS), Instant.now().plus(100, ChronoUnit.DAYS));
+
+        CertificateExpiryUtils.warnIfExpired(keyStore, log);
+
+        verify(log).warn(contains("not yet valid"), eq("future"), any());
+    }
+
+    @Test
+    public void should_not_warn_when_certificate_valid_for_a_long_time() throws Exception {
+        KeyStore keyStore = keyStoreWith("healthy", Instant.now().minus(1, ChronoUnit.DAYS), Instant.now().plus(365, ChronoUnit.DAYS));
+
+        CertificateExpiryUtils.warnIfExpired(keyStore, log);
+
+        verify(log, never()).warn(any(String.class), any(), any(), any());
+        verify(log, never()).warn(any(String.class), any(), any());
+        verify(log, never()).error(any(String.class), any(), any());
+    }
+
+    @Test
+    public void should_warn_for_collection_of_certificates() throws Exception {
+        var cert = certificate("expiring", Instant.now().minus(1, ChronoUnit.DAYS), Instant.now().plus(10, ChronoUnit.DAYS));
+
+        CertificateExpiryUtils.warnIfExpired(List.of(cert), "pem-source", log);
+
+        verify(log).warn(contains("expires in"), contains("pem-source"), anyLong(), any());
+    }
+
+    private KeyStore keyStoreWith(String alias, Instant notBefore, Instant notAfter) throws Exception {
+        KeyStore keyStore = KeyStore.getInstance("PKCS12");
+        keyStore.load(null, null);
+        keyStore.setKeyEntry(
+            alias,
+            keyPair.getPrivate(),
+            "secret".toCharArray(),
+            new java.security.cert.Certificate[] { certificate(alias, notBefore, notAfter) }
+        );
+        return keyStore;
+    }
+
+    private java.security.cert.X509Certificate certificate(String cn, Instant notBefore, Instant notAfter) throws Exception {
+        X500Principal subject = new X500Principal("CN=" + cn);
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA").build(keyPair.getPrivate());
+        var holder = new JcaX509v3CertificateBuilder(
+            subject,
+            BigInteger.valueOf(System.nanoTime()),
+            Date.from(notBefore),
+            Date.from(notAfter),
+            subject,
+            keyPair.getPublic()
+        )
+            .build(signer);
+        return new JcaX509CertificateConverter().getCertificate(holder);
+    }
+}

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/ssl/KeyStore.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/ssl/KeyStore.java
@@ -20,6 +20,7 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.util.Optional;
 import lombok.Getter;
+import org.slf4j.Logger;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
@@ -38,6 +39,14 @@ public abstract class KeyStore implements Serializable {
     }
 
     public abstract Optional<KeyCertOptions> keyCertOptions();
+
+    /**
+     * Best-effort check that logs a warning when this keystore holds a certificate that is expired,
+     * not yet valid, or about to expire. No-op by default; overridden by concrete keystore types.
+     */
+    public void warnIfCertificateExpired(Logger log) {
+        // no-op by default
+    }
 
     public static class KeyStoreCertOptionsException extends RuntimeException {
 

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/ssl/TrustStore.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/ssl/TrustStore.java
@@ -20,6 +20,7 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.util.Optional;
 import lombok.Getter;
+import org.slf4j.Logger;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
@@ -38,6 +39,14 @@ public abstract class TrustStore implements Serializable {
     }
 
     public abstract Optional<TrustOptions> trustOptions();
+
+    /**
+     * Best-effort check that logs a warning when this truststore holds a certificate that is expired,
+     * not yet valid, or about to expire. No-op by default; overridden by concrete truststore types.
+     */
+    public void warnIfCertificateExpired(Logger log) {
+        // no-op by default
+    }
 
     public static class TrustOptionsException extends RuntimeException {
 

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/ssl/jks/JKSKeyStore.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/ssl/jks/JKSKeyStore.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.node.vertx.client.ssl.jks;
 
+import io.gravitee.common.util.KeyStoreUtils;
+import io.gravitee.node.certificates.CertificateExpiryUtils;
+import io.gravitee.node.logging.NodeLoggerFactory;
 import io.gravitee.node.vertx.client.ssl.KeyStore;
 import io.gravitee.node.vertx.client.ssl.KeyStoreType;
 import io.vertx.core.net.JksOptions;
@@ -24,6 +27,7 @@ import java.util.Base64;
 import java.util.Optional;
 import lombok.Builder;
 import lombok.Data;
+import org.slf4j.Logger;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
@@ -61,6 +65,7 @@ public class JKSKeyStore extends KeyStore {
 
     @Override
     public Optional<KeyCertOptions> keyCertOptions() {
+        warnIfCertificateExpired(NodeLoggerFactory.getLogger(getClass()));
         final JksOptions jksOptions = new JksOptions();
 
         if (getPath() != null && !getPath().isEmpty()) {
@@ -75,5 +80,17 @@ public class JKSKeyStore extends KeyStore {
         jksOptions.setAliasPassword(getKeyPassword());
         jksOptions.setPassword(getPassword());
         return Optional.of(jksOptions);
+    }
+
+    @Override
+    public void warnIfCertificateExpired(Logger log) {
+        CertificateExpiryUtils.inspectKeyStore(
+            KeyStoreUtils.TYPE_JKS,
+            getPath(),
+            getContent(),
+            getPassword(),
+            "client keystore (JKS)",
+            log
+        );
     }
 }

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/ssl/jks/JKSTrustStore.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/ssl/jks/JKSTrustStore.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.node.vertx.client.ssl.jks;
 
+import io.gravitee.common.util.KeyStoreUtils;
+import io.gravitee.node.certificates.CertificateExpiryUtils;
+import io.gravitee.node.logging.NodeLoggerFactory;
 import io.gravitee.node.vertx.client.ssl.TrustStore;
 import io.gravitee.node.vertx.client.ssl.TrustStoreType;
 import io.vertx.core.net.JksOptions;
@@ -24,6 +27,7 @@ import java.util.Base64;
 import java.util.Optional;
 import lombok.Builder;
 import lombok.Data;
+import org.slf4j.Logger;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
@@ -55,6 +59,7 @@ public class JKSTrustStore extends TrustStore {
 
     @Override
     public Optional<TrustOptions> trustOptions() {
+        warnIfCertificateExpired(NodeLoggerFactory.getLogger(getClass()));
         final JksOptions jksOptions = new JksOptions();
         if (getPath() != null && !getPath().isEmpty()) {
             jksOptions.setPath(getPath());
@@ -67,5 +72,17 @@ public class JKSTrustStore extends TrustStore {
         jksOptions.setAlias(getAlias());
         jksOptions.setPassword(getPassword());
         return Optional.of(jksOptions);
+    }
+
+    @Override
+    public void warnIfCertificateExpired(Logger log) {
+        CertificateExpiryUtils.inspectKeyStore(
+            KeyStoreUtils.TYPE_JKS,
+            getPath(),
+            getContent(),
+            getPassword(),
+            "client truststore (JKS)",
+            log
+        );
     }
 }

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/ssl/pem/PEMKeyStore.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/ssl/pem/PEMKeyStore.java
@@ -15,15 +15,20 @@
  */
 package io.gravitee.node.vertx.client.ssl.pem;
 
+import io.gravitee.node.certificates.CertificateExpiryUtils;
+import io.gravitee.node.logging.NodeLoggerFactory;
 import io.gravitee.node.vertx.client.ssl.KeyStore;
 import io.gravitee.node.vertx.client.ssl.KeyStoreType;
 import io.vertx.core.net.KeyCertOptions;
 import io.vertx.core.net.PemKeyCertOptions;
 import java.io.Serial;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import lombok.Builder;
 import lombok.Data;
+import org.slf4j.Logger;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
@@ -70,6 +75,7 @@ public class PEMKeyStore extends KeyStore {
 
     @Override
     public Optional<KeyCertOptions> keyCertOptions() {
+        warnIfCertificateExpired(NodeLoggerFactory.getLogger(getClass()));
         final PemKeyCertOptions pemKeyCertOptions = new PemKeyCertOptions();
 
         if (certPaths != null && !certPaths.isEmpty()) {
@@ -99,5 +105,17 @@ public class PEMKeyStore extends KeyStore {
         }
 
         return Optional.of(pemKeyCertOptions);
+    }
+
+    @Override
+    public void warnIfCertificateExpired(Logger log) {
+        final List<String> paths = new ArrayList<>();
+        if (getCertPath() != null) {
+            paths.add(getCertPath());
+        }
+        if (getCertPaths() != null) {
+            paths.addAll(getCertPaths());
+        }
+        CertificateExpiryUtils.inspectPem(paths, Arrays.asList(getCertContent()), "client keystore (PEM)", log);
     }
 }

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/ssl/pem/PEMTrustStore.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/ssl/pem/PEMTrustStore.java
@@ -15,14 +15,18 @@
  */
 package io.gravitee.node.vertx.client.ssl.pem;
 
+import io.gravitee.node.certificates.CertificateExpiryUtils;
+import io.gravitee.node.logging.NodeLoggerFactory;
 import io.gravitee.node.vertx.client.ssl.TrustStore;
 import io.gravitee.node.vertx.client.ssl.TrustStoreType;
 import io.vertx.core.net.PemTrustOptions;
 import io.vertx.core.net.TrustOptions;
 import java.io.Serial;
+import java.util.Arrays;
 import java.util.Optional;
 import lombok.Builder;
 import lombok.Data;
+import org.slf4j.Logger;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
@@ -50,6 +54,7 @@ public class PEMTrustStore extends TrustStore {
 
     @Override
     public Optional<TrustOptions> trustOptions() {
+        warnIfCertificateExpired(NodeLoggerFactory.getLogger(getClass()));
         final PemTrustOptions pemTrustOptions = new PemTrustOptions();
 
         if (getPath() != null && !getPath().isEmpty()) {
@@ -61,5 +66,10 @@ public class PEMTrustStore extends TrustStore {
         }
 
         return Optional.of(pemTrustOptions);
+    }
+
+    @Override
+    public void warnIfCertificateExpired(Logger log) {
+        CertificateExpiryUtils.inspectPem(Arrays.asList(getPath()), Arrays.asList(getContent()), "client truststore (PEM)", log);
     }
 }

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/ssl/pkcs12/PKCS12KeyStore.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/ssl/pkcs12/PKCS12KeyStore.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.node.vertx.client.ssl.pkcs12;
 
+import io.gravitee.common.util.KeyStoreUtils;
+import io.gravitee.node.certificates.CertificateExpiryUtils;
+import io.gravitee.node.logging.NodeLoggerFactory;
 import io.gravitee.node.vertx.client.ssl.KeyStore;
 import io.gravitee.node.vertx.client.ssl.KeyStoreType;
 import io.vertx.core.net.KeyCertOptions;
@@ -24,6 +27,7 @@ import java.util.Base64;
 import java.util.Optional;
 import lombok.Builder;
 import lombok.Data;
+import org.slf4j.Logger;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
@@ -61,6 +65,7 @@ public class PKCS12KeyStore extends KeyStore {
 
     @Override
     public Optional<KeyCertOptions> keyCertOptions() {
+        warnIfCertificateExpired(NodeLoggerFactory.getLogger(getClass()));
         final PfxOptions pfxOptions = new PfxOptions();
 
         if (getPath() != null && !getPath().isEmpty()) {
@@ -75,5 +80,17 @@ public class PKCS12KeyStore extends KeyStore {
         pfxOptions.setAliasPassword(getKeyPassword());
         pfxOptions.setPassword(getPassword());
         return Optional.of(pfxOptions);
+    }
+
+    @Override
+    public void warnIfCertificateExpired(Logger log) {
+        CertificateExpiryUtils.inspectKeyStore(
+            KeyStoreUtils.TYPE_PKCS12,
+            getPath(),
+            getContent(),
+            getPassword(),
+            "client keystore (PKCS#12)",
+            log
+        );
     }
 }

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/ssl/pkcs12/PKCS12TrustStore.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/ssl/pkcs12/PKCS12TrustStore.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.node.vertx.client.ssl.pkcs12;
 
+import io.gravitee.common.util.KeyStoreUtils;
+import io.gravitee.node.certificates.CertificateExpiryUtils;
+import io.gravitee.node.logging.NodeLoggerFactory;
 import io.gravitee.node.vertx.client.ssl.TrustStore;
 import io.gravitee.node.vertx.client.ssl.TrustStoreType;
 import io.vertx.core.net.PfxOptions;
@@ -24,6 +27,7 @@ import java.util.Base64;
 import java.util.Optional;
 import lombok.Builder;
 import lombok.Data;
+import org.slf4j.Logger;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
@@ -55,6 +59,7 @@ public class PKCS12TrustStore extends TrustStore {
 
     @Override
     public Optional<TrustOptions> trustOptions() {
+        warnIfCertificateExpired(NodeLoggerFactory.getLogger(getClass()));
         final PfxOptions pfxOptions = new PfxOptions();
 
         if (getPath() != null && !getPath().isEmpty()) {
@@ -68,5 +73,17 @@ public class PKCS12TrustStore extends TrustStore {
         pfxOptions.setAlias(getAlias());
         pfxOptions.setPassword(getPassword());
         return Optional.of(pfxOptions);
+    }
+
+    @Override
+    public void warnIfCertificateExpired(Logger log) {
+        CertificateExpiryUtils.inspectKeyStore(
+            KeyStoreUtils.TYPE_PKCS12,
+            getPath(),
+            getContent(),
+            getPassword(),
+            "client truststore (PKCS#12)",
+            log
+        );
     }
 }

--- a/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/client/ssl/SslStoreCertificateExpiryTest.java
+++ b/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/client/ssl/SslStoreCertificateExpiryTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.vertx.client.ssl;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.gravitee.node.vertx.client.ssl.jks.JKSTrustStore;
+import io.gravitee.node.vertx.client.ssl.none.NoneTrustStore;
+import io.gravitee.node.vertx.client.ssl.pem.PEMKeyStore;
+import io.gravitee.node.vertx.client.ssl.pem.PEMTrustStore;
+import io.gravitee.node.vertx.client.ssl.pkcs12.PKCS12KeyStore;
+import java.io.StringWriter;
+import java.math.BigInteger;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+import java.util.Date;
+import javax.security.auth.x500.X500Principal;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+
+class SslStoreCertificateExpiryTest {
+
+    private static final String PASSWORD = "secret";
+
+    private final Logger log = org.mockito.Mockito.mock(Logger.class);
+    private KeyPair keyPair;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        keyPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
+    }
+
+    @Test
+    void should_warn_for_expiring_pem_truststore_content() throws Exception {
+        var trustStore = new PEMTrustStore(null, pem(expiringCertificate()));
+
+        trustStore.warnIfCertificateExpired(log);
+
+        verify(log).warn(contains("expires in"), contains("client truststore (PEM)"), anyLong(), any());
+    }
+
+    @Test
+    void should_warn_for_expiring_pem_keystore_content() throws Exception {
+        var keyStore = PEMKeyStore.builder().certContent(pem(expiringCertificate())).keyContent("ignored").build();
+
+        keyStore.warnIfCertificateExpired(log);
+
+        verify(log).warn(contains("expires in"), contains("client keystore (PEM)"), anyLong(), any());
+    }
+
+    @Test
+    void should_warn_for_expiring_jks_truststore_path() throws Exception {
+        Path jks = writeStore("truststore.jks", "JKS", trustedStore("JKS", expiringCertificate()));
+        var trustStore = new JKSTrustStore(jks.toString(), null, PASSWORD, null);
+
+        trustStore.warnIfCertificateExpired(log);
+
+        verify(log).warn(contains("expires in"), eq("ca"), anyLong(), any());
+    }
+
+    @Test
+    void should_warn_for_expiring_pkcs12_keystore_content() throws Exception {
+        KeyStore store = KeyStore.getInstance("PKCS12");
+        store.load(null, null);
+        store.setKeyEntry(
+            "key",
+            keyPair.getPrivate(),
+            PASSWORD.toCharArray(),
+            new java.security.cert.Certificate[] { expiringCertificate() }
+        );
+        String content = Base64.getEncoder().encodeToString(toBytes(store));
+        var keyStore = new PKCS12KeyStore(null, content, PASSWORD, null, PASSWORD);
+
+        keyStore.warnIfCertificateExpired(log);
+
+        verify(log).warn(contains("expires in"), eq("key"), anyLong(), any());
+    }
+
+    @Test
+    void should_not_warn_for_healthy_certificate() throws Exception {
+        var trustStore = new PEMTrustStore(
+            null,
+            pem(certificate(Instant.now().minus(1, ChronoUnit.DAYS), Instant.now().plus(365, ChronoUnit.DAYS)))
+        );
+
+        trustStore.warnIfCertificateExpired(log);
+
+        verify(log, never()).warn(any(String.class), any(), any(), any());
+        verify(log, never()).error(any(String.class), any(), any());
+    }
+
+    @Test
+    void should_do_nothing_for_none_truststore() {
+        new NoneTrustStore().warnIfCertificateExpired(log);
+
+        verifyNoInteractions(log);
+    }
+
+    @Test
+    void should_swallow_errors_and_never_throw() {
+        // Non-existent path and unreadable content must not raise.
+        new JKSTrustStore("/does/not/exist.jks", null, PASSWORD, null).warnIfCertificateExpired(log);
+        new PEMTrustStore("/does/not/exist.pem", null).warnIfCertificateExpired(log);
+    }
+
+    // The Cockpit / Exchange WebSocket connector (and every other consumer) reaches the expiry check
+    // only because trustOptions() / keyCertOptions() invoke it — not through the node client factories.
+
+    @Test
+    void trust_options_should_trigger_expiry_check() throws Exception {
+        Path jks = writeStore("truststore.jks", "JKS", trustedStore("JKS", expiringCertificate()));
+        var trustStore = spy(new JKSTrustStore(jks.toString(), null, PASSWORD, null));
+
+        trustStore.trustOptions();
+
+        verify(trustStore).warnIfCertificateExpired(any());
+    }
+
+    @Test
+    void key_cert_options_should_trigger_expiry_check() throws Exception {
+        var keyStore = spy(PEMKeyStore.builder().certContent(pem(expiringCertificate())).keyContent("ignored").build());
+
+        keyStore.keyCertOptions();
+
+        verify(keyStore).warnIfCertificateExpired(any());
+    }
+
+    private X509Certificate expiringCertificate() throws Exception {
+        return certificate(Instant.now().minus(1, ChronoUnit.DAYS), Instant.now().plus(10, ChronoUnit.DAYS));
+    }
+
+    private X509Certificate certificate(Instant notBefore, Instant notAfter) throws Exception {
+        X500Principal subject = new X500Principal("CN=test");
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA").build(keyPair.getPrivate());
+        var holder = new JcaX509v3CertificateBuilder(
+            subject,
+            BigInteger.valueOf(System.nanoTime()),
+            Date.from(notBefore),
+            Date.from(notAfter),
+            subject,
+            keyPair.getPublic()
+        )
+            .build(signer);
+        return new JcaX509CertificateConverter().getCertificate(holder);
+    }
+
+    private KeyStore trustedStore(String type, X509Certificate certificate) throws Exception {
+        KeyStore store = KeyStore.getInstance(type);
+        store.load(null, null);
+        store.setCertificateEntry("ca", certificate);
+        return store;
+    }
+
+    private Path writeStore(String name, String type, KeyStore store) throws Exception {
+        Path path = tempDir.resolve(name);
+        Files.write(path, toBytes(store));
+        return path;
+    }
+
+    private byte[] toBytes(KeyStore store) throws Exception {
+        var out = new java.io.ByteArrayOutputStream();
+        store.store(out, PASSWORD.toCharArray());
+        return out.toByteArray();
+    }
+
+    private String pem(X509Certificate certificate) throws Exception {
+        StringWriter writer = new StringWriter();
+        try (JcaPEMWriter pemWriter = new JcaPEMWriter(writer)) {
+            pemWriter.writeObject(certificate);
+        }
+        return writer.toString();
+    }
+}


### PR DESCRIPTION
This PR evaluate the certificate expiry brings by keystores/Truststore

the goal is to help diagnose TLS handshake issue without enabling debug traces

related to AM-6934

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `9.1.2-am-6934-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/9.1.2-am-6934-SNAPSHOT/gravitee-node-9.1.2-am-6934-SNAPSHOT.zip)
  <!-- Version placeholder end -->
