### PR TITLE
fix: add apim-policy-generate-wssecurity feature

### DIFF
--- a/gravitee-node-license/src/main/resources/license-model.yml
+++ b/gravitee-node-license/src/main/resources/license-model.yml
@@ -31,6 +31,7 @@ packs:
             - apim-policy-assign-metrics # policy: gravitee-policy-assign-metrics
             - apim-policy-data-cache # policy: gravitee-policy-data-cache
             - apim-policy-data-logging-masking # policy: gravitee-policy-data-logging-masking
+            - apim-policy-generate-wssecurity # policy: gravitee-policy-generate-wssecurity
             - apim-policy-geoip-filtering # policy: gravitee-policy-geoip-filtering, service: gravitee-service-geoip
             - apim-policy-graphql-ratelimit # policy: gravitee-policy-graphql-rate-limit
             - apim-policy-interops-a-idp # policy: gravitee-policy-interops-a-idp
@@ -200,6 +201,7 @@ packs:
             - apim-policy-assign-metrics # policy: gravitee-policy-assign-metrics
             - apim-policy-data-cache # policy: gravitee-policy-data-cache
             - apim-policy-data-logging-masking # policy: gravitee-policy-data-logging-masking
+            - apim-policy-generate-wssecurity # policy: gravitee-policy-generate-wssecurity
             - apim-policy-geoip-filtering # policy: gravitee-policy-geoip-filtering, service: gravitee-service-geoip
             - apim-policy-graphql-ratelimit # policy: gravitee-policy-graphql-rate-limit
             - apim-policy-interops-a-idp # policy: gravitee-policy-interops-a-idp

--- a/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
+++ b/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
@@ -416,6 +416,7 @@ class DefaultLicenseFactoryTest {
             "apim-en-entrypoint-websocket",
             "apim-sharding-tags",
             "apim-policy-data-logging-masking",
+            "apim-policy-generate-wssecurity",
             "apim-en-message-reactor",
             "apim-en-endpoint-jms",
             "apim-en-endpoint-mqtt5",

--- a/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseModelServiceTest.java
+++ b/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseModelServiceTest.java
@@ -122,6 +122,7 @@ class DefaultLicenseModelServiceTest {
                         "apim-policy-assign-metrics",
                         "apim-policy-data-cache",
                         "apim-policy-data-logging-masking",
+                        "apim-policy-generate-wssecurity",
                         "apim-policy-geoip-filtering",
                         "apim-policy-graphql-ratelimit",
                         "apim-policy-interops-a-idp",


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-13348

**Description**

Add a new feature for a new policy generate-wssecurity
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `9.1.2-fix-add-generate-wssecurity-license-feature-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/9.1.2-fix-add-generate-wssecurity-license-feature-SNAPSHOT/gravitee-node-9.1.2-fix-add-generate-wssecurity-license-feature-SNAPSHOT.zip)
  <!-- Version placeholder end -->
