### PR TITLE
feat: add cloud Redis cache license pack

### DIFF
--- a/gravitee-node-license/src/main/resources/license-model.yml
+++ b/gravitee-node-license/src/main/resources/license-model.yml
@@ -306,6 +306,10 @@ packs:
         features:
             - gamma-edge-module # module: gravitee-gamma-module-edge
             - gamma-edge-reactor # reactor: gravitee-reactor-edge
+
+    gravitee-cloud:
+        features:
+            - cache-cloud-redis # resource: cache-cloud-redis
     #############################################################################
 
 tiers:


### PR DESCRIPTION
**Issue**

N/A

**Description**

Add the `gravitee-cloud` license pack with the `cache-cloud-redis` feature.

**Additional context**

YAML syntax was validated locally.