### PR TITLE
fix: read documented plural services.metrics.domains config key

### DIFF
--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/VertxFactory.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/VertxFactory.java
@@ -269,13 +269,21 @@ public class VertxFactory implements FactoryBean<Vertx> {
     private Set<MetricsDomain> loadMetricsDomains() {
         final Set<MetricsDomain> metricsDomains = new HashSet<>();
 
-        String value;
-        int counter = 0;
-        while ((value = environment.getProperty("services.metrics.domain[" + (counter++) + "]")) != null) {
-            metricsDomains.add(MetricsDomain.valueOf(value));
-        }
+        // "services.metrics.domains" (plural) is the documented configuration key. The singular
+        // "services.metrics.domain" is also read for backward compatibility, as some deployments
+        // relied on it as a workaround while the plural key was ignored (APIM-14510).
+        readIndexedMetricsDomains("services.metrics.domains", metricsDomains);
+        readIndexedMetricsDomains("services.metrics.domain", metricsDomains);
 
         return metricsDomains;
+    }
+
+    private void readIndexedMetricsDomains(String baseProperty, Set<MetricsDomain> metricsDomains) {
+        String value;
+        int counter = 0;
+        while ((value = environment.getProperty(baseProperty + "[" + (counter++) + "]")) != null) {
+            metricsDomains.add(MetricsDomain.valueOf(value));
+        }
     }
 
     private void setBinders(CompositeMeterRegistry compositeMeterRegistry, Vertx instance) {

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/VertxFactory.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/VertxFactory.java
@@ -282,7 +282,7 @@ public class VertxFactory implements FactoryBean<Vertx> {
         String value;
         int counter = 0;
         while ((value = environment.getProperty(baseProperty + "[" + (counter++) + "]")) != null) {
-            metricsDomains.add(MetricsDomain.valueOf(value));
+            metricsDomains.add(MetricsDomain.valueOf(value.trim().toUpperCase()));
         }
     }
 

--- a/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/VertxFactoryTest.java
+++ b/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/VertxFactoryTest.java
@@ -360,6 +360,17 @@ class VertxFactoryTest {
         assertThat(domains).containsExactly(MetricsDomain.NAMED_POOLS);
     }
 
+    @Test
+    void should_read_metrics_domains_ignoring_case_and_whitespace() {
+        environment.setProperty("services.metrics.domains[0]", " http_server ");
+        environment.setProperty("services.metrics.domains[1]", "Named_Pools");
+
+        @SuppressWarnings("unchecked")
+        Set<MetricsDomain> domains = (Set<MetricsDomain>) ReflectionTestUtils.invokeMethod(cut, "loadMetricsDomains");
+
+        assertThat(domains).containsExactlyInAnyOrder(MetricsDomain.HTTP_SERVER, MetricsDomain.NAMED_POOLS);
+    }
+
     private void enableMetrics() {
         environment.setProperty("services.metrics.enabled", "true");
         when(node.application()).thenReturn("graviteeio-test");

--- a/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/VertxFactoryTest.java
+++ b/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/VertxFactoryTest.java
@@ -32,6 +32,7 @@ import io.vertx.core.VertxBuilder;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.internal.VertxInternal;
 import io.vertx.micrometer.Label;
+import io.vertx.micrometer.MetricsDomain;
 import io.vertx.micrometer.MetricsNaming;
 import io.vertx.micrometer.MicrometerMetricsFactory;
 import io.vertx.micrometer.MicrometerMetricsOptions;
@@ -78,8 +79,8 @@ class VertxFactoryTest {
     void init() {
         vertxStatic = Mockito.mockStatic(Vertx.class);
 
-        when(vertxBuilder.with(any())).thenReturn(vertxBuilder);
-        when(vertxBuilder.build()).thenReturn(vertx);
+        lenient().when(vertxBuilder.with(any())).thenReturn(vertxBuilder);
+        lenient().when(vertxBuilder.build()).thenReturn(vertx);
         vertxStatic.when(Vertx::builder).thenReturn(vertxBuilder);
 
         EventLoopGroup eventLoopGroup = mock(EventLoopGroup.class);
@@ -336,6 +337,27 @@ class VertxFactoryTest {
         cut.getObject();
 
         verify(vertxBuilder).with(argThat(vertxOptions -> !vertxOptions.getPreferNativeTransport()));
+    }
+
+    @Test
+    void should_read_metrics_domains_from_documented_plural_key() {
+        environment.setProperty("services.metrics.domains[0]", "NAMED_POOLS");
+        environment.setProperty("services.metrics.domains[1]", "HTTP_SERVER");
+
+        @SuppressWarnings("unchecked")
+        Set<MetricsDomain> domains = (Set<MetricsDomain>) ReflectionTestUtils.invokeMethod(cut, "loadMetricsDomains");
+
+        assertThat(domains).containsExactlyInAnyOrder(MetricsDomain.NAMED_POOLS, MetricsDomain.HTTP_SERVER);
+    }
+
+    @Test
+    void should_still_read_metrics_domains_from_legacy_singular_key() {
+        environment.setProperty("services.metrics.domain[0]", "NAMED_POOLS");
+
+        @SuppressWarnings("unchecked")
+        Set<MetricsDomain> domains = (Set<MetricsDomain>) ReflectionTestUtils.invokeMethod(cut, "loadMetricsDomains");
+
+        assertThat(domains).containsExactly(MetricsDomain.NAMED_POOLS);
     }
 
     private void enableMetrics() {


### PR DESCRIPTION
## Problem

The gateway silently ignores the documented `services.metrics.domains` (plural) YAML list, so a disabled metrics domain such as `NAMED_POOLS` can never be re-enabled — `pool_queue_pending` / `pool_queue_time_seconds` never appear in the Prometheus output. (APIM-14510)

## Root cause

`VertxFactory.loadMetricsDomains()` reads the **singular** indexed key `services.metrics.domain[N]` via manual `Environment.getProperty`, but the documented/used config key is the **plural** `services.metrics.domains`. Because this is a manual indexed lookup (not relaxed-binding `@ConfigurationProperties`), the plural key is never read, and the code always falls back to the hardcoded default-disabled domains list (which includes `NAMED_POOLS` since 8.0.2).

A known workaround was to use the singular `domain` key, which Spring's `YamlPropertySourceLoader` flattens into exactly the path the code expected.

## Fix

Read the documented plural key `services.metrics.domains[N]`. Also keep reading the singular `services.metrics.domain[N]` for **backward compatibility** with deployments that adopted the singular workaround, so upgrading doesn't silently drop their config.

## Tests

`VertxFactoryTest`:
- `should_read_metrics_domains_from_documented_plural_key`
- `should_still_read_metrics_domains_from_legacy_singular_key`

(The two shared builder stubs were made `lenient()` — consistent with the existing lenient stub — since these direct-method tests don't bootstrap Vert.x.)

`mvn -pl gravitee-node-vertx test -Dtest=VertxFactoryTest` → `Tests run: 16, Failures: 0, Errors: 0`.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `9.2.3-fix-apim-14510-metrics-domains-plural-key-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/9.2.3-fix-apim-14510-metrics-domains-plural-key-SNAPSHOT/gravitee-node-9.2.3-fix-apim-14510-metrics-domains-plural-key-SNAPSHOT.zip)
  <!-- Version placeholder end -->
