### PR TITLE
feat: add cloud Redis cache license pack

### DIFF
--- a/gravitee-node-license/src/main/resources/license-model.yml
+++ b/gravitee-node-license/src/main/resources/license-model.yml
@@ -306,6 +306,10 @@ packs:
         features:
             - gamma-edge-module # module: gravitee-gamma-module-edge
             - gamma-edge-reactor # reactor: gravitee-reactor-edge
+
+    gravitee-cloud:
+        features:
+            - cache-cloud-redis # resource: cache-cloud-redis
     #############################################################################
 
 tiers:

--- a/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseModelServiceTest.java
+++ b/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseModelServiceTest.java
@@ -227,7 +227,8 @@ class DefaultLicenseModelServiceTest {
                     "gamma-esm-module",
                 }
             ),
-            arguments("edge-management", new String[] { "gamma-edge-module", "gamma-edge-reactor" })
+            arguments("edge-management", new String[] { "gamma-edge-module", "gamma-edge-reactor" }),
+            arguments("gravitee-cloud", new String[] { "cache-cloud-redis" })
         );
     }
 


### PR DESCRIPTION
**Issue**

N/A

**Description**

Add the `gravitee-cloud` license pack with the `cache-cloud-redis` feature.

**Additional context**

Validated with:

```bash
mvn -pl gravitee-node-license -am -Dtest=DefaultLicenseModelServiceTest -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.compiler.proc=full test
```
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `9.3.0-feat-redis-cloud-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/9.3.0-feat-redis-cloud-SNAPSHOT/gravitee-node-9.3.0-feat-redis-cloud-SNAPSHOT.zip)
  <!-- Version placeholder end -->
