### PR TITLE
fix(license): guard organization license lookup against null id

### DIFF
--- a/gravitee-node-license/src/main/java/io/gravitee/node/license/DefaultLicenseManager.java
+++ b/gravitee-node-license/src/main/java/io/gravitee/node/license/DefaultLicenseManager.java
@@ -70,6 +70,11 @@ public class DefaultLicenseManager extends AbstractService<LicenseManager> imple
 
     @Override
     public License getOrganizationLicense(String organizationId) {
+        if (organizationId == null) {
+            // The backing ConcurrentHashMap rejects null keys; a missing organization degrades to the
+            // platform license via getOrganizationLicenseOrPlatform instead of throwing.
+            return null;
+        }
         return organizationLicenses.getOrDefault(organizationId, Optional.empty()).orElse(null);
     }
 

--- a/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseManagerTest.java
+++ b/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseManagerTest.java
@@ -80,6 +80,16 @@ class DefaultLicenseManagerTest {
     }
 
     @Test
+    void should_return_null_license_when_organization_id_is_null() {
+        assertThat(cut.getOrganizationLicense(null)).isNull();
+    }
+
+    @Test
+    void should_return_platform_license_when_organization_id_is_null() {
+        assertThat(cut.getOrganizationLicenseOrPlatform(null)).isSameAs(cut.getPlatformLicense());
+    }
+
+    @Test
     void should_validate_plugin_features_when_allowed_by_platform_license() {
         mockPluginRegistry();
         final License license = mock(License.class);


### PR DESCRIPTION
## Problem

`DefaultLicenseManager.getOrganizationLicense` passes the organization id straight to
`ConcurrentHashMap.getOrDefault`, which throws `NullPointerException` on a null key. When a gateway
fails to resolve an API's organization (e.g. a transient control-plane bridge error), the resulting
null organization id crashes the license lookup for every affected API.

## Change

Guard the null organization id: return no license so `getOrganizationLicenseOrPlatform` degrades to
the platform license instead of throwing.

## Tests

Two new cases in `DefaultLicenseManagerTest` (null id → null license; null id → platform license).
The pre-fix tests reproduced the exact `NullPointerException: … "key" is null`.

## Context

Defence-in-depth for a gateway sync outage; the primary fix lives in gravitee-api-management
(companion PR).
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `9.4.1-fix-license-manager-null-organization-guard-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/9.4.1-fix-license-manager-null-organization-guard-SNAPSHOT/gravitee-node-9.4.1-fix-license-manager-null-organization-guard-SNAPSHOT.zip)
  <!-- Version placeholder end -->
