### PR TITLE
feat: am-certificate-oci-kms license feature -> 8.x

### DIFF
--- a/gravitee-node-license/src/main/resources/license-model.yml
+++ b/gravitee-node-license/src/main/resources/license-model.yml
@@ -105,6 +105,7 @@ packs:
             - gravitee-en-secrets
             - am-certificate-aws
             - am-certificate-aws-cloudhsm
+            - am-certificate-oci-kms
     enterprise-alert-engine:
         features:
             - alert-engine

--- a/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
+++ b/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
@@ -437,6 +437,7 @@ class DefaultLicenseFactoryTest {
             "gravitee-en-secrets",
             "am-certificate-aws",
             "am-certificate-aws-cloudhsm",
+            "am-certificate-oci-kms",
             "apim-policy-graphql-ratelimit",
             "apim-policy-interops-a-idp",
             "apim-policy-interops-r-idp",


### PR DESCRIPTION
License feature update for new AM Certificate plugin
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `8.2.0-feat-AM-6845-certificate-oci-license-8-x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/8.2.0-feat-AM-6845-certificate-oci-license-8-x-SNAPSHOT/gravitee-node-8.2.0-feat-AM-6845-certificate-oci-license-8-x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
