### PR TITLE
feat: am-certificate-oci-kms license feature -> MASTER

### DIFF
--- a/gravitee-node-license/src/main/resources/license-model.yml
+++ b/gravitee-node-license/src/main/resources/license-model.yml
@@ -118,6 +118,7 @@ packs:
         features:
             - am-certificate-aws # certificate: gravitee-am-certificate-aws
             - am-certificate-aws-cloudhsm # certificate: gravitee-am-certificate-hsm-aws
+            - am-certificate-oci-kms # certificate: gravitee-am-certificate-oci
             - gravitee-en-secretprovider-aws # secret-provider: gravitee-secret-provider-aws
             - gravitee-en-secretprovider-azure-keyvault # secret-provider: gravitee-secret-provider-azure-keyvault
             - gravitee-en-secretprovider-vault # secret-provider: gravitee-secret-provider-hc-vault

--- a/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
+++ b/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseFactoryTest.java
@@ -438,6 +438,7 @@ class DefaultLicenseFactoryTest {
             "gravitee-en-secrets",
             "am-certificate-aws",
             "am-certificate-aws-cloudhsm",
+            "am-certificate-oci-kms",
             "apim-policy-graphql-ratelimit",
             "apim-policy-interops-a-idp",
             "apim-policy-interops-r-idp",


### PR DESCRIPTION
License feature update for new AM Certificate plugin
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `9.5.0-feat-AM-6845-certificate-oci-license-master-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/9.5.0-feat-AM-6845-certificate-oci-license-master-SNAPSHOT/gravitee-node-9.5.0-feat-AM-6845-certificate-oci-license-master-SNAPSHOT.zip)
  <!-- Version placeholder end -->
