### PR TITLE
fix: read documented plural services.metrics.domains config key

### DIFF
--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/VertxFactory.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/VertxFactory.java
@@ -268,13 +268,21 @@ public class VertxFactory implements FactoryBean<Vertx> {
     private Set<MetricsDomain> loadMetricsDomains() {
         final Set<MetricsDomain> metricsDomains = new HashSet<>();
 
-        String value;
-        int counter = 0;
-        while ((value = environment.getProperty("services.metrics.domain[" + (counter++) + "]")) != null) {
-            metricsDomains.add(MetricsDomain.valueOf(value));
-        }
+        // "services.metrics.domains" (plural) is the documented configuration key. The singular
+        // "services.metrics.domain" is also read for backward compatibility, as some deployments
+        // relied on it as a workaround while the plural key was ignored (APIM-14510).
+        readIndexedMetricsDomains("services.metrics.domains", metricsDomains);
+        readIndexedMetricsDomains("services.metrics.domain", metricsDomains);
 
         return metricsDomains;
+    }
+
+    private void readIndexedMetricsDomains(String baseProperty, Set<MetricsDomain> metricsDomains) {
+        String value;
+        int counter = 0;
+        while ((value = environment.getProperty(baseProperty + "[" + (counter++) + "]")) != null) {
+            metricsDomains.add(MetricsDomain.valueOf(value.trim().toUpperCase()));
+        }
     }
 
     private void setBinders(CompositeMeterRegistry compositeMeterRegistry, Vertx instance) {

--- a/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/VertxFactoryTest.java
+++ b/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/VertxFactoryTest.java
@@ -31,6 +31,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.VertxBuilder;
 import io.vertx.core.VertxOptions;
 import io.vertx.micrometer.Label;
+import io.vertx.micrometer.MetricsDomain;
 import io.vertx.micrometer.MetricsNaming;
 import io.vertx.micrometer.MicrometerMetricsFactory;
 import io.vertx.micrometer.MicrometerMetricsOptions;
@@ -77,8 +78,8 @@ class VertxFactoryTest {
     void init() {
         vertxStatic = Mockito.mockStatic(Vertx.class);
 
-        when(vertxBuilder.with(any())).thenReturn(vertxBuilder);
-        when(vertxBuilder.build()).thenReturn(vertx);
+        lenient().when(vertxBuilder.with(any())).thenReturn(vertxBuilder);
+        lenient().when(vertxBuilder.build()).thenReturn(vertx);
         vertxStatic.when(Vertx::builder).thenReturn(vertxBuilder);
 
         EventLoopGroup eventLoopGroup = mock(EventLoopGroup.class);
@@ -334,6 +335,38 @@ class VertxFactoryTest {
         cut.getObject();
 
         verify(vertxBuilder).with(argThat(vertxOptions -> !vertxOptions.getPreferNativeTransport()));
+    }
+
+    @Test
+    void should_read_metrics_domains_from_documented_plural_key() {
+        environment.setProperty("services.metrics.domains[0]", "NAMED_POOLS");
+        environment.setProperty("services.metrics.domains[1]", "HTTP_SERVER");
+
+        @SuppressWarnings("unchecked")
+        Set<MetricsDomain> domains = (Set<MetricsDomain>) ReflectionTestUtils.invokeMethod(cut, "loadMetricsDomains");
+
+        assertThat(domains).containsExactlyInAnyOrder(MetricsDomain.NAMED_POOLS, MetricsDomain.HTTP_SERVER);
+    }
+
+    @Test
+    void should_still_read_metrics_domains_from_legacy_singular_key() {
+        environment.setProperty("services.metrics.domain[0]", "NAMED_POOLS");
+
+        @SuppressWarnings("unchecked")
+        Set<MetricsDomain> domains = (Set<MetricsDomain>) ReflectionTestUtils.invokeMethod(cut, "loadMetricsDomains");
+
+        assertThat(domains).containsExactly(MetricsDomain.NAMED_POOLS);
+    }
+
+    @Test
+    void should_read_metrics_domains_ignoring_case_and_whitespace() {
+        environment.setProperty("services.metrics.domains[0]", " http_server ");
+        environment.setProperty("services.metrics.domains[1]", "Named_Pools");
+
+        @SuppressWarnings("unchecked")
+        Set<MetricsDomain> domains = (Set<MetricsDomain>) ReflectionTestUtils.invokeMethod(cut, "loadMetricsDomains");
+
+        assertThat(domains).containsExactlyInAnyOrder(MetricsDomain.HTTP_SERVER, MetricsDomain.NAMED_POOLS);
     }
 
     private void enableMetrics() {


### PR DESCRIPTION
## Summary

Cherry-pick of `65b7c1a2` from `master` to `8.x`.

Commits cherry-picked:
- `65b7c1a2` fix: read documented plural services.metrics.domains config key (#587)

## Jira

[APIM-14510](https://gravitee.atlassian.net/browse/APIM-14510)

## Notes

Applied cleanly (auto-merge, no conflicts). `mvn compile -pl gravitee-node-vertx -am` passes.

[APIM-14510]: https://gravitee.atlassian.net/browse/APIM-14510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `8.1.1-cherry-pick-APIM-14510-8-x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/8.1.1-cherry-pick-APIM-14510-8-x-SNAPSHOT/gravitee-node-8.1.1-cherry-pick-APIM-14510-8-x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
