### PR TITLE
feat(http-client): support configurable max header and chunk size

### DIFF
--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/http/VertxHttpClientFactory.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/http/VertxHttpClientFactory.java
@@ -52,6 +52,8 @@ public class VertxHttpClientFactory {
         }
     };
     protected static final String HTTP_SSL_OPENSSL_CONFIGURATION = "http.ssl.openssl";
+    protected static final String HTTP_CLIENT_MAX_HEADER_SIZE_CONFIGURATION = "http.client.maxHeaderSize";
+    protected static final String HTTP_CLIENT_MAX_CHUNK_SIZE_CONFIGURATION = "http.client.maxChunkSize";
 
     @NonNull
     private final Vertx vertx;
@@ -123,7 +125,17 @@ public class VertxHttpClientFactory {
             .setIdleTimeout((int) (httpOptions.getIdleTimeout() / 1000))
             .setKeepAliveTimeout((int) (httpOptions.getKeepAliveTimeout() / 1000))
             .setConnectTimeout((int) httpOptions.getConnectTimeout())
-            .setDecompressionSupported(httpOptions.isUseCompression());
+            .setDecompressionSupported(httpOptions.isUseCompression())
+            .setMaxHeaderSize(
+                nodeConfiguration.getProperty(
+                    HTTP_CLIENT_MAX_HEADER_SIZE_CONFIGURATION,
+                    Integer.class,
+                    httpOptions.getMaxHeaderSize()
+                )
+            )
+            .setMaxChunkSize(
+                nodeConfiguration.getProperty(HTTP_CLIENT_MAX_CHUNK_SIZE_CONFIGURATION, Integer.class, httpOptions.getMaxChunkSize())
+            );
 
         if (httpOptions.getVersion() == VertxHttpProtocolVersion.HTTP_2) {
             options

--- a/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/http/VertxHttpClientOptions.java
+++ b/gravitee-node-vertx/src/main/java/io/gravitee/node/vertx/client/http/VertxHttpClientOptions.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.node.vertx.client.http;
 
+import io.vertx.core.http.HttpClientOptions;
 import java.io.Serial;
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
@@ -55,6 +56,8 @@ public class VertxHttpClientOptions implements Serializable {
     public static final boolean DEFAULT_FOLLOW_REDIRECTS = false;
     public static final boolean DEFAULT_CLEAR_TEXT_UPGRADE = true;
     public static final VertxHttpProtocolVersion DEFAULT_PROTOCOL_VERSION = VertxHttpProtocolVersion.HTTP_1_1;
+    public static final int DEFAULT_MAX_HEADER_SIZE = HttpClientOptions.DEFAULT_MAX_HEADER_SIZE;
+    public static final int DEFAULT_MAX_CHUNK_SIZE = HttpClientOptions.DEFAULT_MAX_CHUNK_SIZE;
 
     @Builder.Default
     private int http2MultiplexingLimit = DEFAULT_HTTP2_MULTIPLEXING_LIMIT;
@@ -125,4 +128,10 @@ public class VertxHttpClientOptions implements Serializable {
 
     @Builder.Default
     private VertxHttpProtocolVersion version = DEFAULT_PROTOCOL_VERSION;
+
+    @Builder.Default
+    private int maxHeaderSize = DEFAULT_MAX_HEADER_SIZE;
+
+    @Builder.Default
+    private int maxChunkSize = DEFAULT_MAX_CHUNK_SIZE;
 }

--- a/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/client/http/VertxHttpClientFactoryTest.java
+++ b/gravitee-node-vertx/src/test/java/io/gravitee/node/vertx/client/http/VertxHttpClientFactoryTest.java
@@ -1,13 +1,19 @@
 package io.gravitee.node.vertx.client.http;
 
+import static io.gravitee.node.vertx.client.http.VertxHttpClientFactory.HTTP_CLIENT_MAX_CHUNK_SIZE_CONFIGURATION;
+import static io.gravitee.node.vertx.client.http.VertxHttpClientFactory.HTTP_CLIENT_MAX_HEADER_SIZE_CONFIGURATION;
 import static io.gravitee.node.vertx.client.http.VertxHttpClientFactory.HTTP_SSL_OPENSSL_CONFIGURATION;
 import static io.gravitee.node.vertx.client.http.VertxHttpProtocolVersion.HTTP_2;
 import static io.gravitee.node.vertx.client.http.VertxHttpProxyType.HTTP;
+import static io.vertx.core.http.HttpClientOptions.DEFAULT_MAX_CHUNK_SIZE;
+import static io.vertx.core.http.HttpClientOptions.DEFAULT_MAX_HEADER_SIZE;
 import static io.vertx.core.http.Http2Settings.*;
 import static io.vertx.core.http.HttpClientOptions.DEFAULT_HTTP2_MULTIPLEXING_LIMIT;
 import static io.vertx.core.http.HttpServerOptions.DEFAULT_HTTP2_CONNECTION_WINDOW_SIZE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.node.api.configuration.Configuration;
@@ -77,6 +83,10 @@ class VertxHttpClientFactoryTest {
             .build();
 
         when(nodeConfiguration.getProperty(HTTP_SSL_OPENSSL_CONFIGURATION, Boolean.class, false)).thenReturn(false);
+        when(nodeConfiguration.getProperty(eq(HTTP_CLIENT_MAX_HEADER_SIZE_CONFIGURATION), eq(Integer.class), anyInt()))
+            .thenAnswer(invocation -> invocation.getArgument(2));
+        when(nodeConfiguration.getProperty(eq(HTTP_CLIENT_MAX_CHUNK_SIZE_CONFIGURATION), eq(Integer.class), anyInt()))
+            .thenAnswer(invocation -> invocation.getArgument(2));
 
         return VertxHttpClientFactory
             .builder()
@@ -133,6 +143,50 @@ class VertxHttpClientFactoryTest {
         assertThat(httpClientOptions.getInitialSettings().getInitialWindowSize()).isEqualTo(72000);
         assertThat(httpClientOptions.getInitialSettings().getMaxConcurrentStreams()).isEqualTo(13);
         assertThat(httpClientOptions.getInitialSettings().getMaxFrameSize()).isEqualTo(32000);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_build_client_with_default_max_header_and_chunk_size() {
+        final HttpClient httpClient = builder().build().createHttpClient();
+
+        assertThat(httpClient).isNotNull();
+        HttpClientOptions httpClientOptions = ((CleanableHttpClient) httpClient.getDelegate()).options();
+
+        assertThat(httpClientOptions.getMaxHeaderSize()).isEqualTo(DEFAULT_MAX_HEADER_SIZE);
+        assertThat(httpClientOptions.getMaxChunkSize()).isEqualTo(DEFAULT_MAX_CHUNK_SIZE);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_build_client_with_custom_max_header_and_chunk_size_from_http_options() {
+        final HttpClient httpClient = builder()
+            .httpOptions(VertxHttpClientOptions.builder().maxHeaderSize(65536).maxChunkSize(65536).build())
+            .build()
+            .createHttpClient();
+
+        assertThat(httpClient).isNotNull();
+        HttpClientOptions httpClientOptions = ((CleanableHttpClient) httpClient.getDelegate()).options();
+
+        assertThat(httpClientOptions.getMaxHeaderSize()).isEqualTo(65536);
+        assertThat(httpClientOptions.getMaxChunkSize()).isEqualTo(65536);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_build_client_with_custom_max_header_and_chunk_size_from_node_configuration() {
+        when(nodeConfiguration.getProperty(eq(HTTP_CLIENT_MAX_HEADER_SIZE_CONFIGURATION), eq(Integer.class), anyInt()))
+            .thenReturn(32768);
+        when(nodeConfiguration.getProperty(eq(HTTP_CLIENT_MAX_CHUNK_SIZE_CONFIGURATION), eq(Integer.class), anyInt()))
+            .thenReturn(32768);
+
+        final HttpClient httpClient = builder().build().createHttpClient();
+
+        assertThat(httpClient).isNotNull();
+        HttpClientOptions httpClientOptions = ((CleanableHttpClient) httpClient.getDelegate()).options();
+
+        assertThat(httpClientOptions.getMaxHeaderSize()).isEqualTo(32768);
+        assertThat(httpClientOptions.getMaxChunkSize()).isEqualTo(32768);
     }
 
     @Test


### PR DESCRIPTION
## Summary

This PR adds support for configuring the maximum HTTP header and chunk size on Vert.x HTTP **clients** created by `VertxHttpClientFactory`.

Today, `maxHeaderSize` is configurable for incoming gateway HTTP **servers** (`http.maxHeaderSize` / `servers[].maxHeaderSize`), but not for outbound calls to backend services. When a backend returns headers larger than Vert.x's default (8192 bytes), the gateway can fail with 502 errors.

This change mirrors the existing server-side pattern:

- new `maxHeaderSize` and `maxChunkSize` fields on `VertxHttpClientOptions`
- global overrides via node configuration:
  - `http.client.maxHeaderSize`
  - `http.client.maxChunkSize`

## Motivation / context

We hit this issue in production (Gravitee APIM 4.11.x on Kubernetes): increasing `gateway.http.maxHeaderSize` only affects incoming requests, not backend responses. Gravitee support confirmed on the community forum that backend `maxHeaderSize` is not currently supported and suggested opening a PR.

Community thread: https://community.gravitee.io/t/increase-max-http-response-header-size-limit-8192-bytes/7071

Replaces closed PR #581 (fork was accidentally deleted).

## Configuration example

`gravitee.yml`:

```yaml
http:
  client:
    maxHeaderSize: 65536
    maxChunkSize: 65536
```

Helm (`values.yaml`):

```yaml
gateway:
  env:
    - name: GRAVITEE_HTTP_CLIENT_MAXHEADERSIZE
      value: "65536"
    - name: GRAVITEE_HTTP_CLIENT_MAXCHUNKSIZE
      value: "65536"
```

## Test plan

- [x] Added unit tests in `VertxHttpClientFactoryTest`
- [x] `mvn -pl gravitee-node-vertx -am test -Dtest=VertxHttpClientFactoryTest`
- [ ] Manual validation: gateway calling a backend with response headers > 8192 bytes