### PR TITLE
fix: add missing secret features to gamma entreprise pack

### DIFF
--- a/gravitee-node-license/src/main/resources/license-model.yml
+++ b/gravitee-node-license/src/main/resources/license-model.yml
@@ -214,6 +214,13 @@ packs:
 
             - alert-engine # node: gravitee-alert-engine
 
+            - am-certificate-aws # certificate: gravitee-am-certificate-aws
+            - am-certificate-aws-cloudhsm # certificate: gravitee-am-certificate-hsm-aws
+            - gravitee-en-secretprovider-aws # secret-provider: gravitee-secret-provider-aws
+            - gravitee-en-secretprovider-azure-keyvault # secret-provider: gravitee-secret-provider-azure-keyvault
+            - gravitee-en-secretprovider-vault # secret-provider: gravitee-secret-provider-hc-vault
+            - gravitee-en-secrets # service: gravitee-service-secrets
+
     authorization-management:
         features:
             - gamma-authz-module # module: gravitee-gamma-module-authz

--- a/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseModelServiceTest.java
+++ b/gravitee-node-license/src/test/java/io/gravitee/node/license/DefaultLicenseModelServiceTest.java
@@ -133,6 +133,12 @@ class DefaultLicenseModelServiceTest {
                         "apim-policy-transform-avro-protobuf",
                         "apim-policy-transform-protobuf-json",
                         "alert-engine",
+                        "am-certificate-aws",
+                        "am-certificate-aws-cloudhsm",
+                        "gravitee-en-secretprovider-aws",
+                        "gravitee-en-secretprovider-azure-keyvault",
+                        "gravitee-en-secretprovider-vault",
+                        "gravitee-en-secrets",
                     }
                 )
             ),


### PR DESCRIPTION
**Issue**

N/A

**Description**

when defining new gamma tiers and packs, features related to secret management have been forgotten in the enterprise pack.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `9.4.1-fix-gamma-entreprise-pack-license-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/9.4.1-fix-gamma-entreprise-pack-license-SNAPSHOT/gravitee-node-9.4.1-fix-gamma-entreprise-pack-license-SNAPSHOT.zip)
  <!-- Version placeholder end -->
