### PR TITLE
fix: bump gravitee-common to 5.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 
     <properties>
         <gravitee-bom.version>9.0.0</gravitee-bom.version>
-        <gravitee-common.version>4.6.0</gravitee-common.version>
+        <gravitee-common.version>5.1.0</gravitee-common.version>
         <gravitee-plugin.version>4.2.1</gravitee-plugin.version>
         <gravitee-plugin-common-configurations.version>1.4.0</gravitee-plugin-common-configurations.version>
         <gravitee-reporter-api.version>2.5.0</gravitee-reporter-api.version>


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/FOUND-199

major bump of gravitee-common is safe because the breaking change was the upgrade to vertx 5 but gravitee-node is also already upgraded to vertx 5 since version 9.0.0 (commit 2c696d60).

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `9.6.1-fips-compliant-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/9.6.1-fips-compliant-SNAPSHOT/gravitee-node-9.6.1-fips-compliant-SNAPSHOT.zip)
  <!-- Version placeholder end -->
