### PR TITLE
feat(opentelemetry): accept base64 keystore and truststore content

### DIFF
--- a/gravitee-node-opentelemetry/README.adoc
+++ b/gravitee-node-opentelemetry/README.adoc
@@ -43,7 +43,7 @@ All the exporter configurations are located under the `services.opentelemetry.ex
 |http://localhost:3100/otlp/v1/logs
 |Sets the OTLP HTTP endpoint for log records. If unset, defaults to http://localhost:3100/otlp/v1/logs
 
-**Using `https://` will apply SSL settings**
+**Of the other exporter settings, log records currently use only `timeout`, `compression` and `headers`**
 
 |headers
 |N/A
@@ -63,6 +63,9 @@ All the exporter configurations are located under the `services.opentelemetry.ex
 |===
 
 ==== SSL settings
+
+NOTE: For now these settings apply to the trace exporter only. Log records are exported through the OpenTelemetry SDK's own OTLP HTTP exporter, which is not configured from this section.
+
 |===
 |Parameter |Default |Description
 
@@ -118,6 +121,9 @@ All the exporter configurations are located under the `services.opentelemetry.ex
 |===
 
 ==== Proxy settings
+
+NOTE: For now these settings apply to the trace exporter only. Log records are exported through the OpenTelemetry SDK's own OTLP HTTP exporter, which is not configured from this section.
+
 |===
 |Parameter |Default |Description
 

--- a/gravitee-node-opentelemetry/README.adoc
+++ b/gravitee-node-opentelemetry/README.adoc
@@ -80,7 +80,11 @@ All the exporter configurations are located under the `services.opentelemetry.ex
 
 |ssl.keystore.path
 |
-|A path is required if certificate's type is jks or pkcs12.
+|A path is required if certificate's type is jks or pkcs12, unless `content` is set.
+
+|ssl.keystore.content
+|
+|Base64-encoded keystore content. Alternative to `path`, for jks and pkcs12 keystores. `path` takes precedence when both are set.
 
 |ssl.keystore.password
 |
@@ -102,7 +106,11 @@ All the exporter configurations are located under the `services.opentelemetry.ex
 
 |ssl.truststore.path
 |
-|A path is required in any case.
+|A path is required for all types, unless `content` is set for a jks or pkcs12 truststore.
+
+|ssl.truststore.content
+|
+|Base64-encoded truststore content. Alternative to `path`, for jks and pkcs12 truststores. `path` takes precedence when both are set.
 
 |ssl.truststore.password
 |

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/configuration/OpenTelemetryConfiguration.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/configuration/OpenTelemetryConfiguration.java
@@ -153,6 +153,12 @@ public class OpenTelemetryConfiguration {
     @Value("${services.opentelemetry.exporter.ssl.keystore.password:${services.tracing.otel.ssl.keystore.password:#{null}}}")
     private String keystorePassword;
 
+    /**
+     * Base64-encoded keystore content. Alternative to {@code path}, for jks and pkcs12 keystores.
+     */
+    @Value("${services.opentelemetry.exporter.ssl.keystore.content:#{null}}")
+    private String keystoreContent;
+
     private List<String> keystorePemCerts;
 
     public List<String> getKeystorePemCerts() {
@@ -189,6 +195,12 @@ public class OpenTelemetryConfiguration {
 
     @Value("${services.opentelemetry.exporter.ssl.truststore.password:${services.tracing.otel.ssl.truststore.password:#{null}}}")
     private String truststorePassword;
+
+    /**
+     * Base64-encoded truststore content. Alternative to {@code path}, for jks and pkcs12 truststores.
+     */
+    @Value("${services.opentelemetry.exporter.ssl.truststore.content:#{null}}")
+    private String truststoreContent;
 
     /**
      * If proxy connection must be used.

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/OTelSslOptionsFactory.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/OTelSslOptionsFactory.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.opentelemetry.exporter;
+
+import io.gravitee.node.opentelemetry.configuration.OpenTelemetryConfiguration;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.net.JksOptions;
+import io.vertx.core.net.KeyCertOptions;
+import io.vertx.core.net.KeyStoreOptionsBase;
+import io.vertx.core.net.PemKeyCertOptions;
+import io.vertx.core.net.PemTrustOptions;
+import io.vertx.core.net.PfxOptions;
+import io.vertx.core.net.TrustOptions;
+import java.util.Base64;
+import java.util.List;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Builds Vert.x TLS trust and key-cert options for the OpenTelemetry exporter.
+ *
+ * <p>A jks or pkcs12 store is supplied either as a file path or as Base64-encoded content, the path winning
+ * when both are set. PEM is path-only.
+ *
+ * @author GraviteeSource Team
+ */
+@CustomLog
+@RequiredArgsConstructor
+final class OTelSslOptionsFactory {
+
+    private static final String KEYSTORE_FORMAT_JKS = "JKS";
+    private static final String KEYSTORE_FORMAT_PEM = "PEM";
+    private static final String KEYSTORE_FORMAT_PKCS12 = "PKCS12";
+    private static final List<String> KNOWN_FORMATS = List.of(KEYSTORE_FORMAT_JKS, KEYSTORE_FORMAT_PEM, KEYSTORE_FORMAT_PKCS12);
+
+    private final OpenTelemetryConfiguration configuration;
+
+    KeyCertOptions buildKeyCertOptions() {
+        var type = configuration.getKeystoreType();
+        if (type == null) {
+            return null;
+        }
+
+        if (KEYSTORE_FORMAT_JKS.equalsIgnoreCase(type)) {
+            return keystoreOptions(new JksOptions());
+        }
+        if (KEYSTORE_FORMAT_PKCS12.equalsIgnoreCase(type)) {
+            return keystoreOptions(new PfxOptions());
+        }
+        if (KEYSTORE_FORMAT_PEM.equalsIgnoreCase(type)) {
+            return new PemKeyCertOptions()
+                .setCertPaths(configuration.getKeystorePemCerts())
+                .setKeyPaths(configuration.getKeystorePemKeys());
+        }
+
+        log.warn("Keystore will not be configured because type '{}' is not one of {}", type, KNOWN_FORMATS);
+        return null;
+    }
+
+    TrustOptions buildTrustOptions() {
+        var type = configuration.getTruststoreType();
+        if (type == null) {
+            return null;
+        }
+
+        if (KEYSTORE_FORMAT_JKS.equalsIgnoreCase(type)) {
+            return truststoreOptions(new JksOptions());
+        }
+        if (KEYSTORE_FORMAT_PKCS12.equalsIgnoreCase(type)) {
+            return truststoreOptions(new PfxOptions());
+        }
+        if (KEYSTORE_FORMAT_PEM.equalsIgnoreCase(type)) {
+            var path = configuration.getTruststorePath();
+            if (path == null || path.isEmpty()) {
+                log.warn("Truststore has no path set, so it will be left empty");
+                return new PemTrustOptions();
+            }
+            return new PemTrustOptions().addCertPath(path);
+        }
+
+        log.warn("Truststore will not be configured because type '{}' is not one of {}", type, KNOWN_FORMATS);
+        return null;
+    }
+
+    private <T extends KeyStoreOptionsBase> T keystoreOptions(final T options) {
+        return applyStore(
+            options,
+            configuration.getKeystorePath(),
+            configuration.getKeystoreContent(),
+            configuration.getKeystorePassword(),
+            "Keystore"
+        );
+    }
+
+    private <T extends KeyStoreOptionsBase> T truststoreOptions(final T options) {
+        return applyStore(
+            options,
+            configuration.getTruststorePath(),
+            configuration.getTruststoreContent(),
+            configuration.getTruststorePassword(),
+            "Truststore"
+        );
+    }
+
+    /**
+     * Populates the store from its path, falling back to its Base64-encoded content.
+     *
+     * <p>When neither is usable the store is returned empty rather than {@code null}: leaving the option unset
+     * would let Vert.x fall back to the JVM default trust store, so a truststore the operator asked for but
+     * misconfigured would silently widen trust instead of failing.
+     */
+    private <T extends KeyStoreOptionsBase> T applyStore(
+        final T options,
+        final String path,
+        final String content,
+        final String password,
+        final String store
+    ) {
+        options.setPassword(password);
+
+        if (path != null && !path.isEmpty()) {
+            options.setPath(path);
+            return options;
+        }
+
+        if (content != null && !content.isEmpty()) {
+            try {
+                options.setValue(Buffer.buffer(Base64.getDecoder().decode(content)));
+                return options;
+            } catch (IllegalArgumentException e) {
+                log.warn("{} content is not valid Base64, so it will be left empty: {}", store, e.getMessage());
+                return options;
+            }
+        }
+
+        log.warn("{} has neither path nor content set, so it will be left empty", store);
+        return options;
+    }
+}

--- a/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/SpanExporterFactory.java
+++ b/gravitee-node-opentelemetry/src/main/java/io/gravitee/node/opentelemetry/exporter/SpanExporterFactory.java
@@ -33,11 +33,9 @@ import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.net.JksOptions;
-import io.vertx.core.net.PemKeyCertOptions;
-import io.vertx.core.net.PemTrustOptions;
-import io.vertx.core.net.PfxOptions;
+import io.vertx.core.net.KeyCertOptions;
 import io.vertx.core.net.ProxyOptions;
+import io.vertx.core.net.TrustOptions;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
@@ -166,10 +164,6 @@ public class SpanExporterFactory extends AbstractService<SpanExporterFactory> {
     }
 
     private record HttpClientOptionsConsumer(OpenTelemetryConfiguration configuration, URI baseUri) implements Consumer<HttpClientOptions> {
-        private static final String KEYSTORE_FORMAT_JKS = "JKS";
-        private static final String KEYSTORE_FORMAT_PEM = "PEM";
-        private static final String KEYSTORE_FORMAT_PKCS12 = "PKCS12";
-
         @Override
         public void accept(HttpClientOptions options) {
             if (OTelExporterUtil.isHttps(baseUri)) {
@@ -189,32 +183,16 @@ public class SpanExporterFactory extends AbstractService<SpanExporterFactory> {
                 options.setTrustAll(false).setVerifyHost(configuration.isVerifyHost());
             }
 
-            if (KEYSTORE_FORMAT_JKS.equalsIgnoreCase(configuration.getKeystoreType())) {
-                options.setKeyCertOptions(
-                    new JksOptions().setPath(configuration.getKeystorePath()).setPassword(configuration.getKeystorePassword())
-                );
-            } else if (KEYSTORE_FORMAT_PKCS12.equalsIgnoreCase(configuration.getKeystoreType())) {
-                options.setKeyCertOptions(
-                    new PfxOptions().setPath(configuration.getKeystorePath()).setPassword(configuration.getKeystorePassword())
-                );
-            } else if (KEYSTORE_FORMAT_PEM.equalsIgnoreCase(configuration.getKeystoreType())) {
-                options.setKeyCertOptions(
-                    new PemKeyCertOptions()
-                        .setCertPaths(configuration.getKeystorePemCerts())
-                        .setKeyPaths(configuration.getKeystorePemKeys())
-                );
+            OTelSslOptionsFactory sslOptionsFactory = new OTelSslOptionsFactory(configuration);
+
+            KeyCertOptions keyCertOptions = sslOptionsFactory.buildKeyCertOptions();
+            if (keyCertOptions != null) {
+                options.setKeyCertOptions(keyCertOptions);
             }
 
-            if (KEYSTORE_FORMAT_JKS.equalsIgnoreCase(configuration.getTruststoreType())) {
-                options.setTrustOptions(
-                    new JksOptions().setPath(configuration.getTruststorePath()).setPassword(configuration.getTruststorePassword())
-                );
-            } else if (KEYSTORE_FORMAT_PKCS12.equalsIgnoreCase(configuration.getTruststoreType())) {
-                options.setTrustOptions(
-                    new PfxOptions().setPath(configuration.getTruststorePath()).setPassword(configuration.getTruststorePassword())
-                );
-            } else if (KEYSTORE_FORMAT_PEM.equalsIgnoreCase(configuration.getTruststoreType())) {
-                options.setTrustOptions(new PemTrustOptions().addCertPath(configuration.getTruststorePath()));
+            TrustOptions trustOptions = sslOptionsFactory.buildTrustOptions();
+            if (trustOptions != null) {
+                options.setTrustOptions(trustOptions);
             }
         }
 

--- a/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/OpenTelemetryTracerIntegrationTest.java
+++ b/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/OpenTelemetryTracerIntegrationTest.java
@@ -37,6 +37,11 @@ import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxExtension;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -374,15 +379,17 @@ public class OpenTelemetryTracerIntegrationTest {
             .keystoreType(keyStore.getString("type"))
             .keystorePath(keyStore.getString("path"))
             .keystorePassword(keyStore.getString("password"))
+            .keystoreContent(keyStore.getString("content"))
             .truststoreType(trustStore.getString("type"))
             .truststorePath(trustStore.getString("path"))
             .truststorePassword(trustStore.getString("password"))
+            .truststoreContent(trustStore.getString("content"))
             .endpoint("https://localhost:" + containerTLS.getCollectorGrpcPort())
             .tracesEnabled(true)
             .protocol(Protocol.GRPC.value())
             .build();
 
-        final var serviceName = "otel_grpc_" + keyStore.getString("type");
+        final var serviceName = "otel_grpc_" + name.replace(' ', '_');
         OpenTelemetryFactory openTelemetryFactory = openTelemetryFactory(vertx, openTelemetryConfiguration);
 
         var tracer = openTelemetryFactory.createTracer(
@@ -485,15 +492,17 @@ public class OpenTelemetryTracerIntegrationTest {
             .keystoreType(keyStore.getString("type"))
             .keystorePath(keyStore.getString("path"))
             .keystorePassword(keyStore.getString("password"))
+            .keystoreContent(keyStore.getString("content"))
             .truststoreType(trustStore.getString("type"))
             .truststorePath(trustStore.getString("path"))
             .truststorePassword(trustStore.getString("password"))
+            .truststoreContent(trustStore.getString("content"))
             .endpoint("https://localhost:" + containerTLS.getCollectorHttpPort())
             .tracesEnabled(true)
             .protocol(Protocol.HTTP_PROTOBUF.value())
             .build();
 
-        final var serviceName = "otel_http_" + keyStore.getString("type");
+        final var serviceName = "otel_http_" + name.replace(' ', '_');
         OpenTelemetryFactory openTelemetryFactory = openTelemetryFactory(vertx, openTelemetryConfiguration);
         var tracer = openTelemetryFactory.createTracer(
             "serviceInstanceId",
@@ -614,8 +623,72 @@ public class OpenTelemetryTracerIntegrationTest {
                         )
                     )
                 )
+            ),
+            Arguments.of(
+                "using a jks base64 content",
+                new JsonObject(
+                    Map.ofEntries(
+                        Map.entry(
+                            "keyStore",
+                            new JsonObject(
+                                Map.ofEntries(
+                                    Map.entry("type", "JKS"),
+                                    Map.entry("content", base64Of("src/test/resources/ssl/client-keystore.jks")),
+                                    Map.entry("password", "gravitee"),
+                                    Map.entry("alias", "jaeger-client")
+                                )
+                            )
+                        ),
+                        Map.entry(
+                            "trustStore",
+                            new JsonObject(
+                                Map.ofEntries(
+                                    Map.entry("type", "JKS"),
+                                    Map.entry("content", base64Of("src/test/resources/ssl/client-truststore.jks")),
+                                    Map.entry("password", "gravitee")
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            Arguments.of(
+                "using a PKCS12 base64 content",
+                new JsonObject(
+                    Map.ofEntries(
+                        Map.entry(
+                            "keyStore",
+                            new JsonObject(
+                                Map.ofEntries(
+                                    Map.entry("type", "PKCS12"),
+                                    Map.entry("content", base64Of("src/test/resources/ssl/client-keystore.p12")),
+                                    Map.entry("password", "gravitee"),
+                                    Map.entry("alias", "jaeger-client")
+                                )
+                            )
+                        ),
+                        Map.entry(
+                            "trustStore",
+                            new JsonObject(
+                                Map.ofEntries(
+                                    Map.entry("type", "PKCS12"),
+                                    Map.entry("content", base64Of("src/test/resources/ssl/client-truststore.p12")),
+                                    Map.entry("password", "gravitee")
+                                )
+                            )
+                        )
+                    )
+                )
             )
         );
+    }
+
+    private static String base64Of(final String path) {
+        try {
+            return Base64.getEncoder().encodeToString(Files.readAllBytes(Path.of(path)));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     private void assertData(JsonObject json, boolean withAdditionalAttributes, boolean withError, boolean withEvents) {

--- a/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/exporter/OTelSslOptionsFactoryTest.java
+++ b/gravitee-node-opentelemetry/src/test/java/io/gravitee/node/opentelemetry/exporter/OTelSslOptionsFactoryTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.node.opentelemetry.exporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.node.opentelemetry.configuration.OpenTelemetryConfiguration;
+import io.vertx.core.net.JksOptions;
+import io.vertx.core.net.PemKeyCertOptions;
+import io.vertx.core.net.PemTrustOptions;
+import io.vertx.core.net.PfxOptions;
+import java.util.Base64;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class OTelSslOptionsFactoryTest {
+
+    private static final String STORE_BYTES = "binary-data";
+    private static final String STORE_CONTENT = Base64.getEncoder().encodeToString(STORE_BYTES.getBytes());
+
+    MockEnvironment environment = new MockEnvironment();
+
+    @Test
+    void should_build_jks_keystore_from_content_when_path_is_not_set() {
+        var result = factory(configuration().keystoreType("JKS").keystoreContent(STORE_CONTENT).keystorePassword("secret").build())
+            .buildKeyCertOptions();
+
+        assertThat(result).isInstanceOf(JksOptions.class);
+        var jks = (JksOptions) result;
+        assertThat(jks.getPath()).isNull();
+        assertThat(jks.getValue().getBytes()).isEqualTo(STORE_BYTES.getBytes());
+        assertThat(jks.getPassword()).isEqualTo("secret");
+    }
+
+    @Test
+    void should_build_pkcs12_keystore_from_content_when_path_is_not_set() {
+        var result = factory(configuration().keystoreType("PKCS12").keystoreContent(STORE_CONTENT).keystorePassword("secret").build())
+            .buildKeyCertOptions();
+
+        assertThat(result).isInstanceOf(PfxOptions.class);
+        var pfx = (PfxOptions) result;
+        assertThat(pfx.getPath()).isNull();
+        assertThat(pfx.getValue().getBytes()).isEqualTo(STORE_BYTES.getBytes());
+    }
+
+    @Test
+    void should_prefer_keystore_path_over_content() {
+        var result = factory(
+            configuration().keystoreType("JKS").keystorePath("/path/to/keystore.jks").keystoreContent(STORE_CONTENT).build()
+        )
+            .buildKeyCertOptions();
+
+        var jks = (JksOptions) result;
+        assertThat(jks.getPath()).isEqualTo("/path/to/keystore.jks");
+        assertThat(jks.getValue()).isNull();
+    }
+
+    @Test
+    void should_leave_keystore_empty_when_neither_path_nor_content_is_set() {
+        var result = (JksOptions) factory(configuration().keystoreType("JKS").keystorePassword("secret").build()).buildKeyCertOptions();
+
+        assertThat(result).isNotNull();
+        assertThat(result.getPath()).isNull();
+        assertThat(result.getValue()).isNull();
+    }
+
+    @Test
+    void should_not_build_keystore_for_an_unknown_type() {
+        assertThat(factory(configuration().keystoreType("BOGUS").keystoreContent(STORE_CONTENT).build()).buildKeyCertOptions()).isNull();
+    }
+
+    @Test
+    void should_not_build_keystore_when_no_type_is_set() {
+        assertThat(factory(configuration().build()).buildKeyCertOptions()).isNull();
+    }
+
+    @Test
+    void should_leave_keystore_empty_when_content_is_not_valid_base64() {
+        var result = (JksOptions) factory(configuration().keystoreType("JKS").keystoreContent("not base64!").build()).buildKeyCertOptions();
+
+        assertThat(result).isNotNull();
+        assertThat(result.getValue()).isNull();
+    }
+
+    @Test
+    void should_build_pem_keystore_from_cert_and_key_paths() {
+        environment.withProperty("services.opentelemetry.exporter.ssl.keystore.certs[0]", "/path/to/client.cer");
+        environment.withProperty("services.opentelemetry.exporter.ssl.keystore.keys[0]", "/path/to/client.key");
+
+        var result = factory(configuration().keystoreType("PEM").build()).buildKeyCertOptions();
+
+        assertThat(result).isInstanceOf(PemKeyCertOptions.class);
+        var pem = (PemKeyCertOptions) result;
+        assertThat(pem.getCertPaths()).containsExactly("/path/to/client.cer");
+        assertThat(pem.getKeyPaths()).containsExactly("/path/to/client.key");
+    }
+
+    @Test
+    void should_build_jks_truststore_from_content_when_path_is_not_set() {
+        var result = factory(configuration().truststoreType("JKS").truststoreContent(STORE_CONTENT).truststorePassword("secret").build())
+            .buildTrustOptions();
+
+        assertThat(result).isInstanceOf(JksOptions.class);
+        var jks = (JksOptions) result;
+        assertThat(jks.getPath()).isNull();
+        assertThat(jks.getValue().getBytes()).isEqualTo(STORE_BYTES.getBytes());
+        assertThat(jks.getPassword()).isEqualTo("secret");
+    }
+
+    @Test
+    void should_build_pkcs12_truststore_from_content_when_path_is_not_set() {
+        var result = factory(configuration().truststoreType("PKCS12").truststoreContent(STORE_CONTENT).build()).buildTrustOptions();
+
+        assertThat(result).isInstanceOf(PfxOptions.class);
+        assertThat(((PfxOptions) result).getValue().getBytes()).isEqualTo(STORE_BYTES.getBytes());
+    }
+
+    @Test
+    void should_prefer_truststore_path_over_content() {
+        var result = factory(
+            configuration().truststoreType("JKS").truststorePath("/path/to/truststore.jks").truststoreContent(STORE_CONTENT).build()
+        )
+            .buildTrustOptions();
+
+        var jks = (JksOptions) result;
+        assertThat(jks.getPath()).isEqualTo("/path/to/truststore.jks");
+        assertThat(jks.getValue()).isNull();
+    }
+
+    @Test
+    void should_leave_truststore_empty_when_neither_path_nor_content_is_set() {
+        var result = (PfxOptions) factory(configuration().truststoreType("PKCS12").build()).buildTrustOptions();
+
+        assertThat(result).isNotNull();
+        assertThat(result.getPath()).isNull();
+        assertThat(result.getValue()).isNull();
+    }
+
+    @Test
+    void should_not_build_truststore_for_an_unknown_type() {
+        assertThat(factory(configuration().truststoreType("BOGUS").truststoreContent(STORE_CONTENT).build()).buildTrustOptions()).isNull();
+    }
+
+    @Test
+    void should_leave_truststore_empty_when_content_is_not_valid_base64() {
+        var result = (PfxOptions) factory(configuration().truststoreType("PKCS12").truststoreContent("not base64!").build())
+            .buildTrustOptions();
+
+        assertThat(result).isNotNull();
+        assertThat(result.getValue()).isNull();
+    }
+
+    @Test
+    void should_leave_pem_truststore_empty_when_no_path_is_set() {
+        var result = (PemTrustOptions) factory(configuration().truststoreType("PEM").build()).buildTrustOptions();
+
+        assertThat(result).isNotNull();
+        assertThat(result.getCertPaths()).isEmpty();
+    }
+
+    @Test
+    void should_build_pem_truststore_from_path() {
+        var result = factory(configuration().truststoreType("PEM").truststorePath("/path/to/ca.pem").build()).buildTrustOptions();
+
+        assertThat(result).isInstanceOf(PemTrustOptions.class);
+        assertThat(((PemTrustOptions) result).getCertPaths()).containsExactly("/path/to/ca.pem");
+    }
+
+    private OpenTelemetryConfiguration.OpenTelemetryConfigurationBuilder configuration() {
+        return OpenTelemetryConfiguration.builder().environment(environment);
+    }
+
+    private OTelSslOptionsFactory factory(final OpenTelemetryConfiguration configuration) {
+        return new OTelSslOptionsFactory(configuration);
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/CJ-4304

**Description**

Cockpit is adding an OpenTelemetry reporter form where customers can upload client certificates for mTLS to their own collector. Cockpit already pushes reporter config down to the gateways, so the certificate wants to travel the same way, but the OTLP exporter only reads keystores and truststores from a file path.

This adds `services.opentelemetry.exporter.ssl.{keystore,truststore}.content`, taking a base64-encoded jks or pkcs12 store. PEM is untouched and stays path only. Traces only, since the log record exporter uses the OTel SDK's own sender rather than this one. Same idea as gravitee-io/gravitee-reporter-tcp#131 for the TCP reporter.

A store whose type is set but has no usable path or content is left empty rather than unset. That preserves the current behaviour, since the old code always set the options and so trusted nothing. Returning null would instead let Vert.x fall back to the JVM default trust store and silently trust public CAs.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `9.7.0-feat-CJ-4304-otel-exporter-base64-keystore-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/node/gravitee-node/9.7.0-feat-CJ-4304-otel-exporter-base64-keystore-SNAPSHOT/gravitee-node-9.7.0-feat-CJ-4304-otel-exporter-base64-keystore-SNAPSHOT.zip)
  <!-- Version placeholder end -->
